### PR TITLE
Fix sidecar crashing when check is deleted

### DIFF
--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -338,9 +338,10 @@ func (c *Updater) handleCheckUpdate(ctx context.Context, check worldping.Check) 
 	// down, start it again.
 
 	scraper.Stop()
+	checkType := scraper.CheckType()
 	delete(c.scrapers, check.Id)
 
-	c.runningScrapers.WithLabelValues(getCheckType(&check)).Dec()
+	c.runningScrapers.WithLabelValues(checkType).Dec()
 
 	return c.addAndStartScraper(ctx, check)
 }
@@ -356,10 +357,11 @@ func (c *Updater) handleCheckDelete(ctx context.Context, check worldping.Check) 
 	}
 
 	scraper.Stop()
+	checkType := scraper.CheckType()
 
 	delete(c.scrapers, check.Id)
 
-	c.runningScrapers.WithLabelValues(getCheckType(&check)).Dec()
+	c.runningScrapers.WithLabelValues(checkType).Dec()
 
 	return nil
 }
@@ -403,7 +405,7 @@ func (c *Updater) addAndStartScraper(ctx context.Context, check worldping.Check)
 
 	go scraper.Run(ctx)
 
-	c.runningScrapers.WithLabelValues(getCheckType(&check)).Inc()
+	c.runningScrapers.WithLabelValues(scraper.CheckType()).Inc()
 
 	return nil
 }
@@ -457,19 +459,4 @@ func (bbe *bbeInfo) updateConfig(scrapers map[int64]*scraper.Scraper) error {
 	}
 
 	return nil
-}
-
-func getCheckType(check *worldping.Check) string {
-	switch {
-	case check.Settings.Dns != nil:
-		return "dns"
-
-	case check.Settings.Http != nil:
-		return "http"
-
-	case check.Settings.Ping != nil:
-		return "ping"
-	}
-
-	panic("unknown check type")
 }


### PR DESCRIPTION
When adding instrumentation, I missed the fact that deleted checks are
mostly empty, so the "type" of the incoming check is invalid. We could
fix this on the worldping-api side, by retrieving the existing check and
sending that instead of the shell that the app sends to worldping-api.

Ask the scraper what kind of test it was running, and use that for the
metrics.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>