### PR TITLE
Implement handling of CacheBustingQueryParamName

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -335,6 +335,12 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, erro
 	// but this is special-casing HTTP because we need to modify the
 	// target to append a cache-busting parameter that includes the
 	// current timestamp.
+	//
+	// This parameter IS NOT part of the target specified by the
+	// user because it needs to change every time the check runs,
+	// and it IS NOT part of s.check.Target because that would cause
+	// it to end up in the instance label that is added to every
+	// metric (see below).
 	if s.CheckType() == ScraperTypeHTTP && s.check.Settings.Http.CacheBustingQueryParamName != "" {
 		q.Set("target", addCacheBustParam(s.check.Target, s.check.Settings.Http.CacheBustingQueryParamName, s.probe.Name))
 	}


### PR DESCRIPTION
If CacheBustingQueryParamName is not empty, it is used as the query
parameter name passed to blackbox-exporter. The value of this parameter
is the current timestamp salted with the probe's name, hashed and
represented as hex.

This is optional, the name of the parameter must be specified by the
user to activate this functionality.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>