### PR TITLE
If the probe gets disconnected, clean up scrapers

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -211,6 +211,8 @@ func (s *Scraper) Run(ctx context.Context) {
 			return
 		}
 
+		s.logger.Debug().Msg("marking metrics as stale")
+
 		staleSample := prompb.Sample{
 			Timestamp: t.UnixNano()/1e6 + 1, // ms
 			Value:     staleMarker,
@@ -239,7 +241,10 @@ func (s *Scraper) Run(ctx context.Context) {
 
 func (s *Scraper) Stop() {
 	s.logger.Info().Msg("stopping scraper")
-	close(s.stop)
+	if s.stop != nil {
+		close(s.stop)
+		s.stop = nil
+	}
 }
 
 func (s Scraper) CheckType() string {


### PR DESCRIPTION
If the probe gets disconnected in a way that it's still possible to
restart, it's necessary to stop and clean up the running scrapers to
avoid a situation where we end up with multiple copies of the same
scraper posting metrics and logs.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>