### PR TITLE
push docker image to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,11 +29,11 @@ jobs:
       - deploy:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              docker login -u $DOCKER_USER -p "$DOCKER_PASS" https://us.gcr.io
-              docker push us.gcr.io/kubernetes-dev/synthetic-monitoring-agent:latest
+              docker login -u $DOCKER_USER -p "$DOCKER_PASS"
+              make docker-push
               export GCS_KEY_DIR=$(pwd)/keys
               mkdir -p $GCS_KEY_DIR
-              echo "$DOCKER_PASS" > $GCS_KEY_DIR/gcs-key.json
+              echo "$GCS_KEY" > $GCS_KEY_DIR/gcs-key.json
               make publish-packages
             fi
 

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,12 @@ help: ## Display this help.
 docker: build
 	$(S) docker build -t $(DOCKER_TAG) ./
 
+.PHONY: docker-push
+docker-push:  docker
+	$(S) docker push $(DOCKER_TAG)
+	$(S) docker tag $(DOCKER_TAG) $(DOCKER_TAG):$(BUILD_VERSION)
+	$(S) docker push $(DOCKER_TAG):$(BUILD_VERSION)
+
 define build_go_command
 	$(S) echo 'Building $(1)'
 	$(S) mkdir -p dist

--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,4 @@
 # This file is included from the main makefile. Anything that is
 # specific to this module should go in this file.
 
-DOCKER_TAG = us.gcr.io/kubernetes-dev/synthetic-monitoring-agent:latest
+DOCKER_TAG = grafana/synthetic-monitoring-agent


### PR DESCRIPTION
push docker images to dockerhub instead of our private Google Container
Repo.
Additionally, when pushing images push with :latest tag and a tag for
the current build version