### PR TITLE
Use a random offset for scrapers

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -8,6 +8,7 @@ import (
 	"hash/fnv"
 	"io/ioutil"
 	"math"
+	"math/rand"
 	"net/url"
 	"os"
 	"strconv"
@@ -226,7 +227,12 @@ func (s *Scraper) Run(ctx context.Context) {
 		payload = nil
 	}
 
-	tickWithOffset(ctx, s.stop, scrape, cleanup, s.check.Offset, s.check.Frequency)
+	offset := s.check.Offset
+	if offset == 0 {
+		offset = rand.Int63n(s.check.Frequency)
+	}
+
+	tickWithOffset(ctx, s.stop, scrape, cleanup, offset, s.check.Frequency)
 
 	s.cancel()
 


### PR DESCRIPTION
Currently the offset parameter is not being set anywhere (other than
adding a check directly thru the API), so all the scrapers have an
offset of 0.

Compute a random offset with a maximum value equal to the frenquency of
the check. In this way, the check will not fire at the same time,
specially when a probe reconnects.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>