### PR TITLE
Update blackbox_exporter to current master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/mmcloughlin/geohash v0.9.0
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/blackbox_exporter v0.17.1-0.20200713103052-55c667ab4ce5
+	github.com/prometheus/blackbox_exporter v0.17.1-0.20200829081835-daa62bf75457
 	github.com/prometheus/client_golang v1.6.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -638,8 +638,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/prometheus/alertmanager v0.18.0/go.mod h1:WcxHBl40VSPuOaqWae6l6HpnEOVRIycEJ7i9iYkadEE=
 github.com/prometheus/alertmanager v0.19.0/go.mod h1:Eyp94Yi/T+kdeb2qvq66E3RGuph5T/jm/RBVh4yz1xo=
 github.com/prometheus/alertmanager v0.20.0/go.mod h1:9g2i48FAyZW6BtbsnvHtMHQXl2aVtrORKwKVCQ+nbrg=
-github.com/prometheus/blackbox_exporter v0.17.1-0.20200713103052-55c667ab4ce5 h1:CV9Uil9IfwPlyj6upRAPzMWE6xXfFswuw+VggO3grn4=
-github.com/prometheus/blackbox_exporter v0.17.1-0.20200713103052-55c667ab4ce5/go.mod h1:cwo6pb60ghYWFCGtAdq/cavlA4WSQiDCPygeLja+RyY=
+github.com/prometheus/blackbox_exporter v0.17.1-0.20200829081835-daa62bf75457 h1:nspCS0D4C7eX5fra7naBcXBuBFH2ad4gfEEndz/MMcA=
+github.com/prometheus/blackbox_exporter v0.17.1-0.20200829081835-daa62bf75457/go.mod h1:cwo6pb60ghYWFCGtAdq/cavlA4WSQiDCPygeLja+RyY=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -771,13 +771,7 @@ func pingSettingsToBBEModule(settings *sm.PingSettings) bbeconfig.Module {
 
 	m.ICMP.PayloadSize = int(settings.PayloadSize)
 
-	// TODO(mem): uncomment this.
-	//
-	// DontFragment is causing a panic inside BBE. Disable this
-	// temporarely until we can find a fix.
-	//
-	// m.ICMP.DontFragment = settings.DontFragment
-	m.ICMP.DontFragment = false
+	m.ICMP.DontFragment = settings.DontFragment
 
 	return m
 }


### PR DESCRIPTION
Fixes crashing of probe becuase of don't fragment option and the
incorrect reporting of content length when using regular expression
validations.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>