### PR TITLE
Move build from circleCI to drone

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -66,8 +66,9 @@ local vault_secret(name, vault_path, key) = {
       + {environment: {
           GCS_KEY:{from_secret: 'gcs_key'},
           GPG_PRIV_KEY:{from_secret: 'gpg_priv_key'},
+          PUBLISH_PROD_PKGS: "1",
         }}
-      ,
+      + masterOnly,
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -15,6 +15,10 @@ local masterOnly = {
   when: {branch:['master']},
 };
 
+local prOnly = {
+  when: {event: ['pull_request']},
+},
+
 local repo = 'grafana/synthetic-monitoring-agent';
 
 local vault_secret(name, vault_path, key) = {
@@ -53,7 +57,7 @@ local vault_secret(name, vault_path, key) = {
         }
     }
     + masterOnly,
-    step('package', ['make package']),
+    step('package', ['make package']) + prOnly,
     step('publish packages', ['make publish-packages']),
   ]),
 

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -20,7 +20,7 @@ local repo = 'grafana/synthetic-monitoring-agent';
 
 [
   pipeline('build', [
-    step('lint', ['make lint']),
+    step('lint', ['echo $GOCACHE', 'ls $GOCACHE', 'make lint']),
     step('test', ['make test']),
     step('build', [
       'git fetch origin --tags',

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -67,7 +67,7 @@ local vault_secret(name, vault_path, key) = {
           GCS_KEY:{from_secret: 'gcs_key'},
           GPG_PRIV_KEY:{from_secret: 'gpg_priv_key'},
         }}
-      + masterOnly,
+      ,
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -9,6 +9,10 @@ local pipeline(name, steps=[]) = {
   type: 'docker',
   name: name,
   steps: [step('runner identification', ['echo $DRONE_RUNNER_NAME'], 'alpine')] + steps,
+  trigger+: {
+    branch+: ['master'],
+    event+: ['push','pull_request'],
+  },
 };
 
 local masterOnly = {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -17,7 +17,7 @@ local masterOnly = {
 
 local prOnly = {
   when: {event: ['pull_request']},
-},
+};
 
 local repo = 'grafana/synthetic-monitoring-agent';
 

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -67,12 +67,11 @@ local vault_secret(name, vault_path, key) = {
           GCS_KEY:{from_secret: 'gcs_key'},
           GPG_PRIV_KEY:{from_secret: 'gpg_priv_key'},
           PUBLISH_PROD_PKGS: "1",
-        }}
-      + masterOnly,
+        }},
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),
   vault_secret('docker_password','infra/data/ci/docker_hub', 'password'),
   vault_secret('gcs_key','infra/data/ci/gcp/synthetic-mon-publish-pkgs', 'key'),
-  vault_secret('gpg_priv_key','infra/data/ci/gcp/synthetic-mon-publish-pkgs', 'key'),
+  vault_secret('gpg_priv_key','infra/data/ci/gcp/synthetic-mon-publish-pkgs', 'gpg_priv_key'),
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -68,6 +68,7 @@ local vault_secret(name, vault_path, key) = {
           GPG_PRIV_KEY:{from_secret: 'gpg_priv_key'},
           PUBLISH_PROD_PKGS: "1",
         }}
+      + masterOnly,
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -23,6 +23,7 @@ local masterOnly = {
     step('build', [
       'git fetch origin --tags',
       './scripts/version',
+      './scripts/version > .tags', // save version in special file for docker plugin
       'make build',
     ]),
     step('docker',[],'plugins/docker')+{

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -61,14 +61,14 @@ local vault_secret(name, vault_path, key) = {
       'export GCS_KEY_DIR=$(pwd)/keys',
       'mkdir -p $GCS_KEY_DIR',
       'echo "$GCS_KEY" > $GCS_KEY_DIR/gcs-key.json',
-      'make publish-packages',
+      'cat $GCS_KEY_DIR/gcs-key.json | base64',
+      //'make publish-packages',
       ])
       + {environment: {
           GCS_KEY:{from_secret: 'gcs_key'},
           GPG_PRIV_KEY:{from_secret: 'gpg_priv_key'},
           PUBLISH_PROD_PKGS: "1",
         }}
-      + masterOnly,
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -49,7 +49,7 @@ local vault_secret(name, vault_path, key) = {
     step('docker build',[],'plugins/docker')+{
       settings:{
         repo: repo,
-        dry_run: 'false',
+        dry_run: 'true',
       }
     },
     step('docker push',[],'plugins/docker')

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,0 +1,20 @@
+local step(name, commands, image) = {
+  name: name,
+  commands: commands,
+  image: image,
+};
+
+
+local pipeline(name, steps=[]) = {
+  kind: 'pipeline',
+  type: 'docker',
+  name: name,
+  steps: [step('runner identification', ['echo $DRONE_RUNNER_NAME'], 'alpine')] + steps,
+};
+
+
+[
+  pipeline('build', [
+    step('lint', ['make lint'], 'golang:1.15'),
+  ])
+]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,4 +1,4 @@
-local step(name, commands, image) = {
+local step(name, commands, image='golang:1.13.10') = {
   name: name,
   commands: commands,
   image: image,
@@ -15,6 +15,12 @@ local pipeline(name, steps=[]) = {
 
 [
   pipeline('build', [
-    step('lint', ['make lint'], 'golang:1.15'),
+    step('lint', ['make lint']),
+    step('test', ['make test']),
+    step('build', [
+      'git fetch origin --tags',
+      './scripts/version',
+      'make build',
+    ]),
   ])
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -29,7 +29,7 @@ local vault_secret(name, vault_path, key) = {
 
 [
   pipeline('build', [
-    step('lint', ['echo $GOCACHE', 'ls $GOCACHE', 'make lint']),
+    step('lint', ['make lint']),
     step('test', ['make test']),
     step('build', [
       'git fetch origin --tags',
@@ -54,6 +54,7 @@ local vault_secret(name, vault_path, key) = {
         }
     }
     + masterOnly,
+    step('package', ['make package']),
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -16,7 +16,7 @@ local pipeline(name, steps=[]) = {
 };
 
 local masterOnly = {
-  when: {branch:['master']},
+  when: {branch:['master'], event: ['push']},
 };
 
 local prOnly = {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -18,18 +18,19 @@ local masterOnly = {
 
 [
   pipeline('build', [
-    //step('lint', ['make lint']),
-    // step('test', ['make test']),
-    // step('build', [
-    //   'git fetch origin --tags',
-    //   './scripts/version',
-    //   'make build',
-    // ]),
-    step('package',[
+    step('lint', ['make lint']),
+    step('test', ['make test']),
+    step('build', [
       'git fetch origin --tags',
       './scripts/version',
-      'make docker',
-      'make package'
-    ],'circleci/golang:1.13.10')
+      'make build',
+    ]),
+    step('docker',[],'plugins/docker')+{
+      settings:{
+        repo: 'grafana/synthetic-monitoring-agent',
+        tags: 'dronetest',
+        dry_run: 'true',
+      }
+    },
   ])
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -60,7 +60,7 @@ local vault_secret(name, vault_path, key) = {
     step('publish packages', [
       'export GCS_KEY_DIR=$(pwd)/keys',
       'mkdir -p $GCS_KEY_DIR',
-      'echo "$GCS_KEY" > $GCS_KEY_DIR/gcs-key.json',
+      'echo "$GCS_KEY" | base64 -d > $GCS_KEY_DIR/gcs-key.json',
       'make publish-packages',
       ])
       + {environment: {

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -12,6 +12,9 @@ local pipeline(name, steps=[]) = {
   steps: [step('runner identification', ['echo $DRONE_RUNNER_NAME'], 'alpine')] + steps,
 };
 
+local masterOnly = {
+  when: {branch:['master']},
+};
 
 [
   pipeline('build', [
@@ -22,5 +25,9 @@ local pipeline(name, steps=[]) = {
       './scripts/version',
       'make build',
     ]),
+    step('deploy',[
+      'git fetch origin --tags',
+      './scripts/version',
+    ]) + masterOnly,
   ])
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -18,18 +18,18 @@ local masterOnly = {
 
 [
   pipeline('build', [
-    step('lint', ['make lint']),
-    step('test', ['make test']),
-    step('build', [
-      'git fetch origin --tags',
-      './scripts/version',
-      'make build',
-    ]),
+    //step('lint', ['make lint']),
+    // step('test', ['make test']),
+    // step('build', [
+    //   'git fetch origin --tags',
+    //   './scripts/version',
+    //   'make build',
+    // ]),
     step('package',[
       'git fetch origin --tags',
       './scripts/version',
       'make docker',
       'make package'
-    ])
+    ],'circleci/golang:1.13.10')
   ])
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,4 +1,4 @@
-local step(name, commands, image='circleci/golang:1.13.10') = {
+local step(name, commands, image='golang:1.13.10') = {
   name: name,
   commands: commands,
   image: image,
@@ -54,6 +54,7 @@ local vault_secret(name, vault_path, key) = {
     }
     + masterOnly,
     step('package', ['make package']),
+    step('publish packages', ['make publish-packages']),
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -67,7 +67,7 @@ local vault_secret(name, vault_path, key) = {
           GCS_KEY:{from_secret: 'gcs_key'},
           GPG_PRIV_KEY:{from_secret: 'gpg_priv_key'},
           PUBLISH_PROD_PKGS: "1",
-        }},
+        }} + masterOnly,
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -16,6 +16,8 @@ local masterOnly = {
   when: {branch:['drone']},
 };
 
+local repo = 'grafana/synthetic-monitoring-agent'
+
 [
   pipeline('build', [
     step('lint', ['make lint']),
@@ -28,11 +30,18 @@ local masterOnly = {
     ]),
     // We can't use 'make docker' without making this repo priveleged in drone
     // so we will use the native docker plugin instead for security.
-    step('docker',[],'plugins/docker')+{
+    step('docker build',[],'plugins/docker')+{
       settings:{
-        repo: 'grafana/synthetic-monitoring-agent',
+        repo: repo,
         dry_run: 'true',
       }
     },
+    step('docker push',[],'plugins/docker')
+    + {
+        settings:{
+          repo: repo,
+        }
+    }
+    + masterOnly,
   ])
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -55,8 +55,7 @@ local vault_secret(name, vault_path, key) = {
           username: {from_secret: 'docker_username'},
           password: {from_secret: 'docker_password'},
         }
-    }
-    + masterOnly,
+    } + masterOnly,
     step('package', ['make package']) + prOnly,
     step('publish packages', [
       'export GCS_KEY_DIR=$(pwd)/keys',
@@ -64,11 +63,15 @@ local vault_secret(name, vault_path, key) = {
       'echo "$GCS_KEY" > $GCS_KEY_DIR/gcs-key.json',
       'make publish-packages',
       ])
-    + {environment: {GCS_KEY:{from_secret: 'gcs_key'}},
-    }
+      + {environment: {
+          GCS_KEY:{from_secret: 'gcs_key'}
+          GPG_PRIV_KEY:{from_secret: 'gpg_priv_key'}
+        }}
+      + masterOnly,
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),
   vault_secret('docker_password','infra/data/ci/docker_hub', 'password'),
   vault_secret('gcs_key','infra/data/ci/gcp/synthetic-mon-publish-pkgs', 'key'),
+  vault_secret('gpg_priv_key','infra/data/ci/gcp/synthetic-mon-publish-pkgs', 'key'),
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -16,7 +16,7 @@ local masterOnly = {
   when: {branch:['drone']},
 };
 
-local repo = 'grafana/synthetic-monitoring-agent'
+local repo = 'grafana/synthetic-monitoring-agent';
 
 [
   pipeline('build', [

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -67,8 +67,7 @@ local vault_secret(name, vault_path, key) = {
           GCS_KEY:{from_secret: 'gcs_key'},
           GPG_PRIV_KEY:{from_secret: 'gpg_priv_key'},
           PUBLISH_PROD_PKGS: "1",
-        }}
-      + masterOnly,
+        }},
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -63,10 +63,12 @@ local vault_secret(name, vault_path, key) = {
       'mkdir -p $GCS_KEY_DIR',
       'echo "$GCS_KEY" > $GCS_KEY_DIR/gcs-key.json',
       'make publish-packages',
-      ]),
+      ])
+    + {environment: {GCS_KEY:{from_secret: 'gcs_key'}},
+    }
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),
   vault_secret('docker_password','infra/data/ci/docker_hub', 'password'),
-
+  vault_secret('gcs_key','infra/data/ci/gcp/synthetic-mon-publish-pkgs', 'key'),
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -13,7 +13,7 @@ local pipeline(name, steps=[]) = {
 };
 
 local masterOnly = {
-  when: {branch:['master']},
+  when: {branch:['drone']},
 };
 
 [
@@ -25,9 +25,11 @@ local masterOnly = {
       './scripts/version',
       'make build',
     ]),
-    step('deploy',[
+    step('package',[
       'git fetch origin --tags',
       './scripts/version',
-    ]) + masterOnly,
+      'make docker',
+      'make package'
+    ])
   ])
 ]

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -58,7 +58,12 @@ local vault_secret(name, vault_path, key) = {
     }
     + masterOnly,
     step('package', ['make package']) + prOnly,
-    step('publish packages', ['make publish-packages']),
+    step('publish packages', [
+      'export GCS_KEY_DIR=$(pwd)/keys',
+      'mkdir -p $GCS_KEY_DIR',
+      'echo "$GCS_KEY" > $GCS_KEY_DIR/gcs-key.json',
+      'make publish-packages',
+      ]),
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -64,8 +64,8 @@ local vault_secret(name, vault_path, key) = {
       'make publish-packages',
       ])
       + {environment: {
-          GCS_KEY:{from_secret: 'gcs_key'}
-          GPG_PRIV_KEY:{from_secret: 'gpg_priv_key'}
+          GCS_KEY:{from_secret: 'gcs_key'},
+          GPG_PRIV_KEY:{from_secret: 'gpg_priv_key'},
         }}
       + masterOnly,
   ]),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -1,9 +1,8 @@
-local step(name, commands, image='golang:1.13.10') = {
+local step(name, commands, image='circleci/golang:1.13.10') = {
   name: name,
   commands: commands,
   image: image,
 };
-
 
 local pipeline(name, steps=[]) = {
   kind: 'pipeline',

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -61,8 +61,7 @@ local vault_secret(name, vault_path, key) = {
       'export GCS_KEY_DIR=$(pwd)/keys',
       'mkdir -p $GCS_KEY_DIR',
       'echo "$GCS_KEY" > $GCS_KEY_DIR/gcs-key.json',
-      'cat $GCS_KEY_DIR/gcs-key.json | base64',
-      //'make publish-packages',
+      'make publish-packages',
       ])
       + {environment: {
           GCS_KEY:{from_secret: 'gcs_key'},

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -26,10 +26,11 @@ local masterOnly = {
       './scripts/version > .tags', // save version in special file for docker plugin
       'make build',
     ]),
+    // We can't use 'make docker' without making this repo priveleged in drone
+    // so we will use the native docker plugin instead for security.
     step('docker',[],'plugins/docker')+{
       settings:{
         repo: 'grafana/synthetic-monitoring-agent',
-        tags: 'dronetest',
         dry_run: 'true',
       }
     },

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -49,7 +49,7 @@ local vault_secret(name, vault_path, key) = {
     step('docker build',[],'plugins/docker')+{
       settings:{
         repo: repo,
-        dry_run: 'true',
+        dry_run: 'false',
       }
     },
     step('docker push',[],'plugins/docker')

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -67,7 +67,8 @@ local vault_secret(name, vault_path, key) = {
           GCS_KEY:{from_secret: 'gcs_key'},
           GPG_PRIV_KEY:{from_secret: 'gpg_priv_key'},
           PUBLISH_PROD_PKGS: "1",
-        }},
+        }}
+      + masterOnly,
   ]),
 
   vault_secret('docker_username','infra/data/ci/docker_hub', 'username'),

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -13,7 +13,7 @@ local pipeline(name, steps=[]) = {
 };
 
 local masterOnly = {
-  when: {branch:['drone']},
+  when: {branch:['master']},
 };
 
 local repo = 'grafana/synthetic-monitoring-agent';
@@ -34,8 +34,7 @@ local vault_secret(name, vault_path, key) = {
     step('build', [
       'git fetch origin --tags',
       './scripts/version',
-      //'./scripts/version > .tags', // save version in special file for docker plugin
-      'echo test > .tags',
+      './scripts/version > .tags', // save version in special file for docker plugin
       'make build',
     ]),
     // We can't use 'make docker' without making this repo priveleged in drone


### PR DESCRIPTION
This moves all builds from circleCI to drone. On pull request does all lint and build steps.

On push to master it will do all that, as well as publishing docker image and packages.