### PR TITLE
Fix: be more flexible with what we accept for a FQHN

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -148,16 +148,20 @@ func TestCheckFQHN(t *testing.T) {
 			input:       "x",
 			expectError: true,
 		},
-		"label must start with letter 1": {
+		"label must start with letter or digit 1": {
 			input:       "0.x",
-			expectError: true,
+			expectError: false,
 		},
-		"label must start with letter 2": {
+		"label must start with letter or digit 2": {
 			input:       "-.x",
 			expectError: true,
 		},
-		"label must start with letter 3": {
+		"label must start with letter or digit 3": {
 			input:       "x.y",
+			expectError: false,
+		},
+		"label must start with letter or digit 4": {
+			input:       "1x.y",
 			expectError: false,
 		},
 		"label must end with a letter or digit 1": {


### PR DESCRIPTION
RFC 1123 indicates that it's OK for host names to start with digits, and
there are plently of examples of this out there. Relax the FQHN
validation to accept that.

Modify the tests to accept this change.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>