### PR TITLE
Fix: keep registering summaries and histograms

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -1051,11 +1051,11 @@ func updateSummaryFromMetric(mName, help string, m *dto.Metric, summaries map[ui
 			ConstLabels: getLabels(m),
 		})
 
-		if err := registry.Register(summary); err != nil {
-			return nil, err
-		}
-
 		summaries[mHash] = summary
+	}
+
+	if err := registry.Register(summary); err != nil {
+		return nil, err
 	}
 
 	summary.Observe(value)
@@ -1088,11 +1088,11 @@ func updateHistogramFromMetric(mName, help string, m *dto.Metric, histograms map
 			Buckets:     prometheus.DefBuckets,
 		})
 
-		if err := registry.Register(histogram); err != nil {
-			return nil, err
-		}
-
 		histograms[mHash] = histogram
+	}
+
+	if err := registry.Register(histogram); err != nil {
+		return nil, err
 	}
 
 	histogram.Observe(value)


### PR DESCRIPTION
updateSummaryFromMetric and updateHistogramFromMetric receive a registry
and maps holding the existing histograms for the scraper. The registry
is created fresh every time this function is called, but the maps are
reused. This means the entries in the maps have to be created once, but
the histograms / summaries have to be registered everytime this runs.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>