### PR TITLE
Use stringData instead of data

### DIFF
--- a/examples/kubernetes/secret.yaml
+++ b/examples/kubernetes/secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-data:
+stringData:
   api-token: YOUR_TOKEN_HERE
 kind: Secret
 metadata:


### PR DESCRIPTION
data requires users to encode data in base64, use stringData to let k8s do base64 encoding

k8s docs: https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-config-file/#create-the-config-file