### PR TITLE
Feature: Add version, commit and buildstamp to Probe

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks.proto
+++ b/pkg/pb/synthetic_monitoring/checks.proto
@@ -42,9 +42,9 @@ message Void {
 }
 
 message ProbeInfo {
-	string Version    = 1;
-	string Commit     = 2;
-	string Buildstamp = 3;
+	string Version    = 1 [(gogoproto.jsontag) = "version"];     // version of the probe
+	string Commit     = 2 [(gogoproto.jsontag) = "commit"];      // commit hash used to build the probe
+	string Buildstamp = 3 [(gogoproto.jsontag) = "buildstamp"];  // timestamp when the probe was built
 }
 
 // StatusCode represents the result of registering a probe with the API.
@@ -85,6 +85,9 @@ message Probe {
 	bool           public       = 8 [(gogoproto.jsontag) = "public"];                               // whether the probe is private or shared with all users
 	bool           online       = 9 [(gogoproto.jsontag) = "online"];                               // whether the probe is currently online
 	double         onlineChange = 10 [(gogoproto.jsontag) = "onlineChange"];                        // time probe started or stopped being online
+	string         version      = 11 [(gogoproto.jsontag) = "version"];                             // version of the probe
+	string         commit       = 12 [(gogoproto.jsontag) = "commit"];                              // commit hash used to build the probe
+	string         buildstamp   = 13 [(gogoproto.jsontag) = "buildstamp"];                          // timestamp when the probe was built
 	double         created      = 100 [(gogoproto.jsontag) = "created"];                            // time the probe was created
 	double         modified     = 101 [(gogoproto.jsontag) = "modified"];                           // last time modified
 }


### PR DESCRIPTION
In order to be able to report this information as part of probe listing,
add them to the "Probe" message. This should not be sent when adding
probes, only when listing them.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>