### PR TITLE
Fix: typo in client certificate and key

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -983,7 +983,7 @@ func smTLSConfigToBBE(ctx context.Context, logger zerolog.Logger, tlsConfig *sm.
 	}
 
 	if len(tlsConfig.ClientCert) > 0 {
-		fn, err := newDataProvider(ctx, logger, "client_cert", tlsConfig.CACert)
+		fn, err := newDataProvider(ctx, logger, "client_cert", tlsConfig.ClientCert)
 		if err != nil {
 			return promconfig.TLSConfig{}, err
 		}
@@ -991,7 +991,7 @@ func smTLSConfigToBBE(ctx context.Context, logger zerolog.Logger, tlsConfig *sm.
 	}
 
 	if len(tlsConfig.ClientKey) > 0 {
-		fn, err := newDataProvider(ctx, logger, "client_key", tlsConfig.CACert)
+		fn, err := newDataProvider(ctx, logger, "client_key", tlsConfig.ClientKey)
 		if err != nil {
 			return promconfig.TLSConfig{}, err
 		}


### PR DESCRIPTION
It seems this has been present for ages. Instead of using the client
certificate and key, this code is trying to use the CA certificate for
that purpose.

Fix that.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>