### PR TITLE
Cache and queue tenant requests in the agent

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -131,7 +131,9 @@ func run(args []string, stdout io.Writer) error {
 		return checksUpdater.Run(ctx)
 	})
 
-	publisher := pusher.NewPublisher(conn, publishCh, tenantCh, zl.With().Str("subsystem", "publisher").Logger(), promRegisterer)
+	tm := pusher.NewTenantManager(ctx, synthetic_monitoring.NewTenantsClient(conn), tenantCh, 15*time.Minute)
+
+	publisher := pusher.NewPublisher(tm, publishCh, zl.With().Str("subsystem", "publisher").Logger(), promRegisterer)
 
 	g.Go(func() error {
 		return publisher.Run(ctx)

--- a/internal/pusher/tenant_manager.go
+++ b/internal/pusher/tenant_manager.go
@@ -1,0 +1,120 @@
+package pusher
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+type TenantManager struct {
+	tenantCh      <-chan sm.Tenant
+	tenantsClient sm.TenantsClient
+	timeout       time.Duration
+	tenantsMutex  sync.Mutex
+	tenants       map[int64]*tenantInfo
+}
+
+type tenantInfo struct {
+	mutex      sync.Mutex // protects the entire structure
+	validUntil time.Time
+	tenant     *sm.Tenant
+}
+
+// NewTenantManager creates a new tenant manager that is able to
+// retrieve tenants from the remote API using the specified
+// tenantsClient or receive them over the provided tenantCh channel. It
+// will keep them for a duration no longer than `timeout`.
+//
+// A new goroutine is started which stops when the provided context is
+// cancelled.
+func NewTenantManager(ctx context.Context, tenantsClient sm.TenantsClient, tenantCh <-chan sm.Tenant, timeout time.Duration) *TenantManager {
+	tm := &TenantManager{
+		tenantCh:      tenantCh,
+		tenantsClient: tenantsClient,
+		timeout:       timeout,
+		tenants:       make(map[int64]*tenantInfo),
+	}
+
+	go tm.run(ctx)
+
+	return tm
+}
+
+func (tm *TenantManager) run(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case tenant := <-tm.tenantCh:
+			tm.updateTenant(tenant)
+		}
+	}
+}
+
+func (tm *TenantManager) updateTenant(tenant sm.Tenant) {
+	tm.tenantsMutex.Lock()
+
+	info, found := tm.tenants[tenant.Id]
+	if !found {
+		info = new(tenantInfo)
+		tm.tenants[tenant.Id] = info
+	}
+
+	tm.tenantsMutex.Unlock()
+
+	// There's a window here where GetTenant got the lock before
+	// this function, didn't find the tenant, created a new one and
+	// added it. In that case `found` above would be true and this
+	// function would not create a new one. Now we are racing to
+	// acquire info.mutex.
+	//
+	// 1. updateTenant acquires it first: it simply inserts the new
+	// tenant and GetTenant sees it and uses it;
+	//
+	// 2. GetTenant acquires it first: That's why we need to release
+	// the lock _before_ operating on info, so that we don't end up
+	// waiting for GetTenant to fetch the information from the API
+	// and blocking other goroutines from retrieving a different
+	// tenant. In that case, when updateTenant acquires the lock
+	// below, make sure the tenant we have is in fact newer than the
+	// one that is already there, if there's one.
+
+	info.mutex.Lock()
+	if info.tenant == nil || info.tenant.Modified < tenant.Modified {
+		info.validUntil = time.Now().Add(tm.timeout)
+		info.tenant = &tenant
+	}
+	info.mutex.Unlock()
+}
+
+// GetTenant retrieves the tenant specified by `req`, either from a
+// local cache or by making a request to the API.
+func (tm *TenantManager) GetTenant(ctx context.Context, req *sm.TenantInfo) (*sm.Tenant, error) {
+	tm.tenantsMutex.Lock()
+	now := time.Now()
+	info, found := tm.tenants[req.Id]
+	if !found {
+		info = new(tenantInfo)
+		tm.tenants[req.Id] = info
+	}
+	tm.tenantsMutex.Unlock()
+
+	info.mutex.Lock()
+	defer info.mutex.Unlock()
+
+	if info.validUntil.After(now) {
+		return info.tenant, nil
+	}
+
+	tenant, err := tm.tenantsClient.GetTenant(ctx, req)
+
+	if err == nil {
+		info.validUntil = time.Now().Add(tm.timeout)
+		info.tenant = tenant
+	}
+
+	return tenant, err
+}

--- a/internal/pusher/tenant_manager_test.go
+++ b/internal/pusher/tenant_manager_test.go
@@ -1,0 +1,145 @@
+package pusher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+type testTenantsClient struct {
+	tenants      map[int64]sm.Tenant
+	requestCount map[int64]int
+}
+
+var errTenantNotFound = errors.New("tenant not found")
+
+func (c *testTenantsClient) GetTenant(ctx context.Context, in *sm.TenantInfo, opts ...grpc.CallOption) (*sm.Tenant, error) {
+	c.requestCount[in.Id]++
+
+	tenant, found := c.tenants[in.Id]
+	if !found {
+		return nil, errTenantNotFound
+	}
+
+	return &tenant, nil
+}
+
+func makeTenant(idx int) sm.Tenant {
+	return sm.Tenant{
+		Id:    int64(idx),
+		OrgId: int64(idx * 1000),
+		MetricsRemote: &sm.RemoteInfo{
+			Name:     fmt.Sprintf("test-%d", idx),
+			Url:      fmt.Sprintf("http://127.0.0.1/%d", idx),
+			Username: fmt.Sprintf("user-%d", idx),
+			Password: fmt.Sprintf("pw-%d", idx),
+		},
+	}
+}
+
+func TestTenantManagerGetTenant(t *testing.T) {
+	tc := testTenantsClient{
+		tenants: map[int64]sm.Tenant{
+			1: makeTenant(1),
+		},
+		requestCount: make(map[int64]int),
+	}
+
+	deadline, hasTimeout := t.Deadline()
+	if !hasTimeout {
+		deadline = time.Now().Add(5 * time.Second)
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	tenantCh := make(chan sm.Tenant)
+
+	tm := NewTenantManager(ctx, &tc, tenantCh, 500*time.Millisecond)
+
+	t1 := tc.tenants[1]
+
+	// requesting an existent tenant should return it
+	tenant, err := tm.GetTenant(ctx, &sm.TenantInfo{Id: t1.Id})
+	require.NoError(t, err)
+	require.NotNil(t, tenant)
+	require.Equal(t, 1, tc.requestCount[t1.Id])
+	require.Equal(t, t1, *tenant)
+
+	// requesting the same tenant within a short period of time
+	// should not cause a new request to the server, so the count
+	// should remain at 1.
+	tenant, err = tm.GetTenant(ctx, &sm.TenantInfo{Id: t1.Id})
+	require.NoError(t, err)
+	require.NotNil(t, tenant)
+	require.Equal(t, 1, tc.requestCount[t1.Id])
+	require.Equal(t, t1, *tenant)
+
+	// requesting the same tenant after a longer time should evict
+	// the existing tenant and make a new request; make sure we are
+	// not getting a cached copy.
+	time.Sleep(500 * time.Millisecond)
+
+	t1.MetricsRemote.Password += "-new"
+
+	tenant, err = tm.GetTenant(ctx, &sm.TenantInfo{Id: t1.Id})
+	require.NoError(t, err)
+	require.NotNil(t, tenant)
+	require.Equal(t, 2, tc.requestCount[t1.Id])
+	require.Equal(t, t1, *tenant)
+
+	// create a new tenant but don't insert it in the cache
+	t2 := makeTenant(2)
+
+	// requesting a non-existent tenant should return an error
+	tenant, err = tm.GetTenant(ctx, &sm.TenantInfo{Id: t2.Id})
+	require.Error(t, err)
+	require.Equal(t, errTenantNotFound, err)
+	require.Nil(t, tenant)
+	require.Equal(t, 1, tc.requestCount[t2.Id])
+
+	// negative responses should not be cached
+	tenant, err = tm.GetTenant(ctx, &sm.TenantInfo{Id: t2.Id})
+	require.Error(t, err)
+	require.Equal(t, errTenantNotFound, err)
+	require.Nil(t, tenant)
+	require.Equal(t, 2, tc.requestCount[t2.Id])
+
+	// after adding the tenant, a new request for that tenant should
+	// return the correct information
+	tc.tenants[2] = t2
+	tenant, err = tm.GetTenant(ctx, &sm.TenantInfo{Id: t2.Id})
+	require.NoError(t, err)
+	require.NotNil(t, tenant)
+	require.Equal(t, 3, tc.requestCount[t2.Id])
+	require.Equal(t, t2, *tenant)
+
+	// create a new tenant and send it over the channel to the
+	// tenant manager
+	t3 := makeTenant(3)
+
+	tenantCh <- t3
+	// here we don't know if the tenant has been added to the list
+	// of known tenants or not; busy-loop waiting for the tenant to
+	// show up in the internal list kept by the tenant manager
+	for i := 0; i < 100; i++ {
+		tm.tenantsMutex.Lock()
+		_, found := tm.tenants[t3.Id]
+		tm.tenantsMutex.Unlock()
+		if found {
+			break
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+	tenant, err = tm.GetTenant(ctx, &sm.TenantInfo{Id: t3.Id})
+	require.NoError(t, err)
+	require.NotNil(t, tenant)
+	require.Equal(t, 0, tc.requestCount[t3.Id])
+	require.Equal(t, t3, *tenant)
+}


### PR DESCRIPTION
To avoid spamming the API server with requests for tenant information,
cache it in the agent for a short time. This is also causing the
requests to be queued, since GetTenant is issued with the lock held.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>