### PR TITLE
Feature: add method to report check type

### DIFF
--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -355,7 +355,7 @@ func (c *Updater) handleCheckUpdateWithLock(ctx context.Context, check sm.Check)
 	// down, start it again.
 
 	scraper.Stop()
-	checkType := scraper.CheckType()
+	checkType := scraper.CheckType().String()
 	delete(c.scrapers, check.Id)
 
 	c.metrics.runningScrapers.WithLabelValues(checkType).Dec()
@@ -376,7 +376,7 @@ func (c *Updater) handleCheckDelete(ctx context.Context, check sm.Check) error {
 	}
 
 	scraper.Stop()
-	checkType := scraper.CheckType()
+	checkType := scraper.CheckType().String()
 
 	delete(c.scrapers, check.Id)
 
@@ -442,7 +442,7 @@ func (c *Updater) handleFirstBatch(ctx context.Context, changes *sm.Changes) {
 			continue
 		}
 
-		checkType := scraper.CheckType()
+		checkType := scraper.CheckType().String()
 		scraper.Stop()
 
 		delete(c.scrapers, id)
@@ -550,7 +550,7 @@ func (c *Updater) addAndStartScraperWithLock(ctx context.Context, check sm.Check
 
 	go scraper.Run(ctx)
 
-	c.metrics.runningScrapers.WithLabelValues(scraper.CheckType()).Inc()
+	c.metrics.runningScrapers.WithLabelValues(scraper.CheckType().String()).Inc()
 
 	return nil
 }

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -119,6 +119,116 @@ func TestCheckValidate(t *testing.T) {
 	}
 }
 
+func TestCheckType(t *testing.T) {
+	testcases := map[string]struct {
+		input    Check
+		expected CheckType
+	}{
+		"dns": {
+			input: Check{
+				Target:    "www.example.org",
+				Job:       "job",
+				Frequency: 1000,
+				Timeout:   1000,
+				Probes:    []int64{1},
+				Settings: CheckSettings{
+					Dns: &DnsSettings{
+						Server: "127.0.0.1",
+					},
+				},
+			},
+			expected: CheckTypeDns,
+		},
+		"http": {
+			input: Check{
+				Target:    "http://www.example.org",
+				Job:       "job",
+				Frequency: 1000,
+				Timeout:   1000,
+				Probes:    []int64{1},
+				Settings: CheckSettings{
+					Http: &HttpSettings{},
+				},
+			},
+			expected: CheckTypeHttp,
+		},
+		"ping": {
+			input: Check{
+				Target:    "127.0.0.1",
+				Job:       "job",
+				Frequency: 1000,
+				Timeout:   1000,
+				Probes:    []int64{1},
+				Settings: CheckSettings{
+					Ping: &PingSettings{},
+				},
+			},
+			expected: CheckTypePing,
+		},
+		"tcp": {
+			input: Check{
+				Target:    "127.0.0.1:9000",
+				Job:       "job",
+				Frequency: 1000,
+				Timeout:   1000,
+				Probes:    []int64{1},
+				Settings: CheckSettings{
+					Tcp: &TcpSettings{},
+				},
+			},
+			expected: CheckTypeTcp,
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			err := testcase.input.Validate()
+			checkError(t, false, err, testcase.input)
+			if err != nil {
+				return
+			}
+
+			actual := testcase.input.Type()
+			if testcase.expected != actual {
+				t.Errorf(`expecting %[1]d (%[1]s) for input %[3]q, but got %[2]d (%[2]s)`, testcase.expected, actual, &testcase.input)
+			}
+		})
+	}
+}
+
+func TestCheckTypeString(t *testing.T) {
+	testcases := map[string]struct {
+		input    CheckType
+		expected string
+	}{
+		"dns": {
+			input:    CheckTypeDns,
+			expected: "dns",
+		},
+		"http": {
+			input:    CheckTypeHttp,
+			expected: "http",
+		},
+		"ping": {
+			input:    CheckTypePing,
+			expected: "ping",
+		},
+		"tcp": {
+			input:    CheckTypeTcp,
+			expected: "tcp",
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := testcase.input.String()
+			if testcase.expected != actual {
+				t.Errorf(`expecting %s for input %q, but got %s`, testcase.expected, &testcase.input, actual)
+			}
+		})
+	}
+}
+
 func TestValidateHost(t *testing.T) {
 	testcases := map[string]struct {
 		input       string


### PR DESCRIPTION
The checktype is determined by the settings field, as exactly one field
can be set. Even so, it's useful to be able to ask for the check type
without reimplementing logic that knows about this quirk.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>