### PR TITLE
Feature: provide number of active series per check type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,14 @@ docker-push:  docker
 	$(S) docker tag $(DOCKER_TAG) $(DOCKER_TAG):$(BUILD_VERSION)
 	$(S) docker push $(DOCKER_TAG):$(BUILD_VERSION)
 
+.PHONY: generate
+generate: $(ROOTDIR)/pkg/accounting/data.go
+	$(S) true
+
+$(ROOTDIR)/pkg/accounting/data.go : $(ROOTDIR)/pkg/accounting/data.go.tmpl $(wildcard $(ROOTDIR)/internal/scraper/testdata/*.txt)
+	$(S) echo "Generating $@ ..."
+	$(GO) generate -v "$(@D)"
+
 define build_go_command
 	$(S) echo 'Building $(1)'
 	$(S) mkdir -p dist

--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -1,0 +1,56 @@
+// Package accounting provides information about the number of active
+// series produed by checks and other related metrics.
+package accounting
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+//go:generate ./generate-active-series-counts
+
+var ErrUnhandledCheck = errors.New("cannot compute the number of active series for check")
+
+// GetActiveSeriesForCheck returns the number of active series that the
+// provided check produces. The data is embedded in the program at build
+// time and it's obtained from the test data used to keep the generated
+// series in sync with the rest of the program.
+//
+// This is of course dependent on the running agent being the same
+// version as the code embedded in the program using this information.
+func GetActiveSeriesForCheck(check synthetic_monitoring.Check) (int, error) {
+	checkType := check.Type()
+	key := checkType.String()
+
+	switch checkType {
+	case synthetic_monitoring.CheckTypeDns:
+
+	case synthetic_monitoring.CheckTypeHttp:
+		if strings.HasPrefix(check.Target, "https://") {
+			key += "_ssl"
+		}
+
+	case synthetic_monitoring.CheckTypePing:
+
+	case synthetic_monitoring.CheckTypeTcp:
+		if check.Settings.Tcp.Tls {
+			key += "_ssl"
+		}
+
+	default:
+		return 0, ErrUnhandledCheck
+	}
+
+	if check.BasicMetricsOnly {
+		key += "_basic"
+	}
+
+	as, found := activeSeriesByCheckType[key]
+	if !found {
+		return 0, ErrUnhandledCheck
+	}
+
+	return as, nil
+}

--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -1,0 +1,184 @@
+package accounting
+
+import (
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetActiveSeriesForCheck verifies that GetActiveSeriesForCheck
+// returns the data in activeSeriesByCheckType. This makes sure that the
+// function is applying the correct criteria to select the entry from
+// the map. It also verifies that all the entries in that map are
+// covered.
+func TestGetActiveSeriesForCheck(t *testing.T) {
+	testcases := map[string]struct {
+		input                synthetic_monitoring.Check
+		expectedActiveSeries int
+	}{
+		"dns": {
+			input: synthetic_monitoring.Check{
+				Target: "127.0.0.1",
+				Settings: synthetic_monitoring.CheckSettings{
+					Dns: &synthetic_monitoring.DnsSettings{},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["dns"],
+		},
+		"dns_basic": {
+			input: synthetic_monitoring.Check{
+				Target:           "127.0.0.1",
+				BasicMetricsOnly: true,
+				Settings: synthetic_monitoring.CheckSettings{
+					Dns: &synthetic_monitoring.DnsSettings{},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["dns_basic"],
+		},
+
+		"http": {
+			input: synthetic_monitoring.Check{
+				Target: "http://127.0.0.1/",
+				Settings: synthetic_monitoring.CheckSettings{
+					Http: &synthetic_monitoring.HttpSettings{},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["http"],
+		},
+		"http_ssl": {
+			input: synthetic_monitoring.Check{
+				Target: "https://127.0.0.1/",
+				Settings: synthetic_monitoring.CheckSettings{
+					Http: &synthetic_monitoring.HttpSettings{},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["http_ssl"],
+		},
+		"http_basic": {
+			input: synthetic_monitoring.Check{
+				Target:           "http://127.0.0.1/",
+				BasicMetricsOnly: true,
+				Settings: synthetic_monitoring.CheckSettings{
+					Http: &synthetic_monitoring.HttpSettings{},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["http_basic"],
+		},
+		"http_ssl_basic": {
+			input: synthetic_monitoring.Check{
+				Target:           "https://127.0.0.1/",
+				BasicMetricsOnly: true,
+				Settings: synthetic_monitoring.CheckSettings{
+					Http: &synthetic_monitoring.HttpSettings{},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["http_ssl_basic"],
+		},
+
+		"ping": {
+			input: synthetic_monitoring.Check{
+				Target: "127.0.0.1",
+				Settings: synthetic_monitoring.CheckSettings{
+					Ping: &synthetic_monitoring.PingSettings{},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["ping"],
+		},
+		"ping_basic": {
+			input: synthetic_monitoring.Check{
+				Target:           "127.0.0.1",
+				BasicMetricsOnly: true,
+				Settings: synthetic_monitoring.CheckSettings{
+					Ping: &synthetic_monitoring.PingSettings{},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["ping_basic"],
+		},
+
+		"tcp": {
+			input: synthetic_monitoring.Check{
+				Target: "127.0.0.1:8080",
+				Settings: synthetic_monitoring.CheckSettings{
+					Tcp: &synthetic_monitoring.TcpSettings{},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["tcp"],
+		},
+		"tcp_ssl": {
+			input: synthetic_monitoring.Check{
+				Target: "127.0.0.1:8080",
+				Settings: synthetic_monitoring.CheckSettings{
+					Tcp: &synthetic_monitoring.TcpSettings{
+						Tls: true,
+					},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["tcp_ssl"],
+		},
+		"tcp_basic": {
+			input: synthetic_monitoring.Check{
+				Target:           "127.0.0.1:8080",
+				BasicMetricsOnly: true,
+				Settings: synthetic_monitoring.CheckSettings{
+					Tcp: &synthetic_monitoring.TcpSettings{},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["tcp_basic"],
+		},
+		"tcp_ssl_basic": {
+			input: synthetic_monitoring.Check{
+				Target:           "127.0.0.1:8080",
+				BasicMetricsOnly: true,
+				Settings: synthetic_monitoring.CheckSettings{
+					Tcp: &synthetic_monitoring.TcpSettings{
+						Tls: true,
+					},
+				},
+			},
+			expectedActiveSeries: activeSeriesByCheckType["tcp_ssl_basic"],
+		},
+	}
+
+	// For know simply expect that every element in
+	// activeSeriesByCheckType has a corresponding test case of the
+	// same name. This ensures that if additional checks are added,
+	// or new variants are introduced, they don't go unnoticed here.
+	//
+	// If more test cases are added, they can use names other than
+	// the keys in activeSeriesByCheckType.
+	for checkType := range activeSeriesByCheckType {
+		_, found := testcases[checkType]
+		require.True(t, found, "every element in activeSeriesByCheckType must be tested")
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			as, err := GetActiveSeriesForCheck(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, activeSeriesByCheckType[name], as)
+		})
+	}
+}
+
+// TestActiveSeriesByCheckTypeInSyncWithData checks that all the entries
+// in the file system have a corresponding entry in
+// activeSeriesByCheckType, to make sure that code generation runs
+// whenever new check types or check variants are added.
+//
+// FIXME(mem): the coupling between this function and the package
+// layout is a little annoying.
+func TestActiveSeriesByCheckTypeInSyncWithData(t *testing.T) {
+	entries, err := filepath.Glob("../../internal/scraper/testdata/*.txt")
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+
+	for _, fn := range entries {
+		casename := strings.TrimSuffix(path.Base(fn), ".txt")
+		_, found := activeSeriesByCheckType[casename]
+		require.Truef(t, found, "case %s (%s) not found in activeSeriesByCheckType", casename, fn)
+	}
+}

--- a/pkg/accounting/data.go
+++ b/pkg/accounting/data.go
@@ -1,0 +1,17 @@
+// Code generated automatically. DO NOT EDIT.
+package accounting
+
+var activeSeriesByCheckType = map[string]int{
+	"dns":            84,
+	"dns_basic":      28,
+	"http":           118,
+	"http_basic":     34,
+	"http_ssl":       122,
+	"http_ssl_basic": 38,
+	"ping":           81,
+	"ping_basic":     25,
+	"tcp":            37,
+	"tcp_basic":      23,
+	"tcp_ssl":        41,
+	"tcp_ssl_basic":  27,
+}

--- a/pkg/accounting/data.go.tmpl
+++ b/pkg/accounting/data.go.tmpl
@@ -1,0 +1,8 @@
+// Code generated automatically. DO NOT EDIT.
+package accounting
+
+var activeSeriesByCheckType = map[string]int{
+{{range $name, $count := . -}}
+	"{{$name}}": {{$count}},
+{{end -}}
+}

--- a/pkg/accounting/generate-active-series-counts
+++ b/pkg/accounting/generate-active-series-counts
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+GOMOD=$(go env GOMOD)
+GOMOD_DIR=$(dirname "${GOMOD}")
+
+go run \
+	"./generate-active-series-counts.go" \
+	"./data.go.tmpl" \
+	"${GOMOD_DIR}"/internal/scraper/testdata/*.txt > "./data.go"
+
+gofmt -w -s "./data.go"

--- a/pkg/accounting/generate-active-series-counts.go
+++ b/pkg/accounting/generate-active-series-counts.go
@@ -1,0 +1,68 @@
+// +build ignore
+
+package main
+
+import (
+	"bufio"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"strings"
+	"text/template"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		log.Fatalf("Syntax:\n\t%s {template} {files...}\n", os.Args[0])
+	}
+
+	contents, err := ioutil.ReadFile(os.Args[1])
+	if err != nil {
+		log.Fatalf("E: cannot load template %s: %s", os.Args[1], err)
+	}
+
+	tmpl, err := template.New("program").Parse(string(contents))
+	if err != nil {
+		log.Fatalf("E: cannot parse template %s: %s", os.Args[1], err)
+	}
+
+	data := make(map[string]int)
+
+	for _, fn := range os.Args[2:] {
+		name, count, err := countActiveSeries(fn)
+		if err != nil {
+			log.Fatalf("E: cannot count active series in %s: %s", fn, err)
+		}
+
+		data[name] = count
+	}
+
+	if err := tmpl.Execute(os.Stdout, data); err != nil {
+		log.Fatalf("E: cannot process template: %s", err)
+	}
+}
+
+func countActiveSeries(fn string) (string, int, error) {
+	fh, err := os.Open(fn)
+	if err != nil {
+		return "", 0, err
+	}
+
+	defer fh.Close()
+
+	scanner := bufio.NewScanner(fh)
+
+	activeSeries := 0
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		activeSeries++
+	}
+
+	return strings.TrimSuffix(path.Base(fn), ".txt"), activeSeries, nil
+}


### PR DESCRIPTION
Add a function to obtain the number of active series generated by a
check based on its configuration. The number is obtained from the
actual metrics emitted by each check type.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>