### PR TITLE
Fix: provide check type along with class info

### DIFF
--- a/pkg/accounting/accounting_test.go
+++ b/pkg/accounting/accounting_test.go
@@ -192,10 +192,23 @@ func TestGetCheckAccountingClass(t *testing.T) {
 func TestGetAccountingClassInfo(t *testing.T) {
 	info := GetAccountingClassInfo()
 
-	for checkType, expected := range activeSeriesByCheckType {
-		actual, found := info[checkType]
+	for accountingClass, expectedSeries := range activeSeriesByCheckType {
+		actual, found := info[accountingClass]
 		require.True(t, found, "every element in activeSeriesByCheckType must be tested")
-		require.Equal(t, expected, actual)
+		require.Equal(t, expectedSeries, actual.Series)
+		require.Equal(t, getTypeFromClass(accountingClass), actual.CheckType)
+	}
+}
+
+// TestGetTypeFromClass verifies that the helper returns the correct
+// type for the corresponding check.
+func TestGetTypeFromClass(t *testing.T) {
+	for name, tc := range getTestCases() {
+		t.Run(name, func(t *testing.T) {
+			expected := tc.input.Type()
+			actual := getTypeFromClass(tc.class)
+			require.Equal(t, expected, actual)
+		})
 	}
 }
 

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -80,29 +80,53 @@ const (
 )
 
 // CheckType represents the type of the associated check
-type CheckType int
+type CheckType int32
 
 const (
-	CheckTypeDns CheckType = iota
-	CheckTypeHttp
-	CheckTypePing
-	CheckTypeTcp
+	CheckTypeDns  CheckType = 0
+	CheckTypeHttp CheckType = 1
+	CheckTypePing CheckType = 2
+	CheckTypeTcp  CheckType = 3
 )
 
-var checkTypeToString = map[CheckType]string{
-	CheckTypeDns:  "dns",
-	CheckTypeHttp: "http",
-	CheckTypePing: "ping",
-	CheckTypeTcp:  "tcp",
-}
+var (
+	checkType_name = map[CheckType]string{
+		CheckTypeDns:  "dns",
+		CheckTypeHttp: "http",
+		CheckTypePing: "ping",
+		CheckTypeTcp:  "tcp",
+	}
+
+	checkType_value = map[string]CheckType{
+		"dns":  CheckTypeDns,
+		"http": CheckTypeHttp,
+		"ping": CheckTypePing,
+		"tcp":  CheckTypeTcp,
+	}
+)
 
 func (t CheckType) String() string {
-	str, found := checkTypeToString[t]
+	str, found := checkType_name[t]
 	if !found {
 		panic("unhandled check type")
 	}
 
 	return str
+}
+
+func CheckTypeFromString(in string) (CheckType, bool) {
+	if checkType, found := checkType_value[in]; found {
+		return checkType, true
+	}
+
+	// lowercase input, try again
+	in = strings.ToLower(in)
+
+	if checkType, found := checkType_value[in]; found {
+		return checkType, true
+	}
+
+	return 0, false
 }
 
 func (c *Check) Validate() error {


### PR DESCRIPTION
In order to make it possible to associate accounting classes with check
types, extend the information returned by GetAccountingClassInfo to
include that detail.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>