### PR TITLE
Add target to Makefile to update golden files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,11 @@ $(ROOTDIR)/pkg/pb/synthetic_monitoring/%.pb.go : $(ROOTDIR)/pkg/pb/synthetic_mon
 	$(S) echo "Generating $@ ..."
 	$(V) $(ROOTDIR)/scripts/genproto.sh
 
+.PHONY: testdata
+testdata: ## Update golden files for tests.
+	# update scraper golden files
+	$(V) $(GO) go -v -run TestValidateMetrics ./internal/scraper -args -update-golden
+
 define build_go_command
 	$(S) echo 'Building $(1)'
 	$(S) mkdir -p dist


### PR DESCRIPTION
Use:

	$ make testdata

to update the golden files in internal/scraper/testdata/.

Other future golden files should be generated from the same target.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>