### PR TITLE
Change: Increase the maximum label length to 128

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -75,8 +75,9 @@ var (
 )
 
 const (
-	MaxCheckLabels = 5
-	MaxProbeLabels = 3
+	MaxCheckLabels      = 5   // Loki allows a maximum of 15 labels, we reserve 7 for internal use
+	MaxProbeLabels      = 3   // and split the other 8 in 3 for the probes and 5 for the checks.
+	MaxLabelValueLength = 128 // Keep this number low so that the UI remains usable.
 )
 
 // CheckType represents the type of the associated check
@@ -307,7 +308,7 @@ func (p *Probe) Validate() error {
 }
 
 func (l Label) Validate() error {
-	if len(l.Name) == 0 {
+	if len(l.Name) == 0 || len(l.Name) > MaxLabelValueLength {
 		return ErrInvalidLabelName
 	}
 
@@ -321,7 +322,7 @@ func (l Label) Validate() error {
 		}
 	}
 
-	if len(l.Value) == 0 || len(l.Value) > 32 {
+	if len(l.Value) == 0 || len(l.Value) > MaxLabelValueLength {
 		return ErrInvalidLabelValue
 	}
 	return nil

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -635,6 +635,15 @@ func TestValidateHttpUrl(t *testing.T) {
 }
 
 func TestValidateLabel(t *testing.T) {
+	genString := func(n int) string {
+		var s strings.Builder
+		s.Grow(n)
+		for i := 0; i < n; i++ {
+			_ = s.WriteByte('x')
+		}
+		return s.String()
+	}
+
 	testcases := map[string]struct {
 		input       Label
 		expectError bool
@@ -668,11 +677,11 @@ func TestValidateLabel(t *testing.T) {
 			expectError: true,
 		},
 		"long value": {
-			input:       Label{Name: "name", Value: "12345678901234567890123456789012"},
+			input:       Label{Name: "name", Value: genString(MaxLabelValueLength)},
 			expectError: false,
 		},
 		"value too long": {
-			input:       Label{Name: "name", Value: "123456789012345678901234567890123"},
+			input:       Label{Name: "name", Value: genString(MaxLabelValueLength + 1)},
 			expectError: true,
 		},
 	}


### PR DESCRIPTION
Currently we allow label names and label values to have a maximum length
of 32 bytes. Increase this to 128. The number is still lower than the
maximum of 2048 allowed by Cortex because the UI becomes harder to use
with really long values.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>