### PR TITLE
Fix: check that there are no duplicate label names

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -54,6 +54,40 @@ func TestCheckValidate(t *testing.T) {
 			},
 			expectError: true,
 		},
+		"duplicate label names": {
+			input: Check{
+				Target:    "127.0.0.1",
+				Job:       "job",
+				Frequency: 1000,
+				Timeout:   1000,
+				Probes:    []int64{1},
+				Settings: CheckSettings{
+					Ping: &PingSettings{},
+				},
+				Labels: []Label{
+					{Name: "name", Value: "1"},
+					{Name: "name", Value: "2"},
+				},
+			},
+			expectError: true,
+		},
+		"duplicate label values": {
+			input: Check{
+				Target:    "127.0.0.1",
+				Job:       "job",
+				Frequency: 1000,
+				Timeout:   1000,
+				Probes:    []int64{1},
+				Settings: CheckSettings{
+					Ping: &PingSettings{},
+				},
+				Labels: []Label{
+					{Name: "name_1", Value: "1"},
+					{Name: "name_2", Value: "1"},
+				},
+			},
+			expectError: false,
+		},
 		"multiple settings": {
 			input: Check{
 				Target:    "127.0.0.1",


### PR DESCRIPTION
Validate that user-defined labels are not using duplicated names, e.g.
label_a = 1 and label_a = 2.

Fixes #139

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>