### PR TITLE
Set user agent in outgoing HTTP requests

### DIFF
--- a/internal/pusher/pusher.go
+++ b/internal/pusher/pusher.go
@@ -11,16 +11,14 @@ import (
 	"github.com/grafana/loki/pkg/logproto"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/loki"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/prom"
+	"github.com/grafana/synthetic-monitoring-agent/internal/version"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/rs/zerolog"
 )
 
-const (
-	defaultBufferCapacity = 10 * 1024
-	userAgent             = "synthetic-monitoring-agent/0.0.1"
-)
+const defaultBufferCapacity = 10 * 1024
 
 var bufPool = sync.Pool{
 	New: func() interface{} {
@@ -270,7 +268,7 @@ func clientFromRemoteInfo(tenantId int64, remote *sm.RemoteInfo) (*prom.ClientCo
 	clientCfg := prom.ClientConfig{
 		URL:       u,
 		Timeout:   5 * time.Second,
-		UserAgent: userAgent,
+		UserAgent: version.UserAgent(),
 	}
 
 	if remote.Username != "" {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,9 +1,19 @@
 package version
 
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+)
+
+const smHomepage = "https://github.com/grafana/synthetic-monitoring-agent"
+
 var (
 	version    = "unknown"
-	commit     = "NA"
-	buildstamp string
+	commit     = "0000000000000000000000000000000000000000"
+	buildstamp = "1970-01-01 00:00:00+00:00"
+	userAgent  = buildUserAgentStr()
 )
 
 func Short() string {
@@ -16,4 +26,18 @@ func Commit() string {
 
 func Buildstamp() string {
 	return buildstamp
+}
+
+func UserAgent() string {
+	return userAgent
+}
+
+func buildUserAgentStr() string {
+	program := "unknown"
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		program = filepath.Base(info.Path)
+	}
+
+	return fmt.Sprintf("%s/%s (%s %s; %s; %s; +%s)", program, version, runtime.GOOS, runtime.GOARCH, commit, buildstamp, smHomepage)
 }


### PR DESCRIPTION
The user agent identifies the synthetic monitoring agent version, OS,
architecture, buildstamp and commit hash, and it points to the synthetic
monitoring product page on grafana.com so that people can more easily
identify requests as coming from Synthetic Monitoring.

The more explicit user agent version is also passed to Prometheus so
that it's easier to identify issues.

Closes #142 #117

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>