### PR TITLE
Add feature package to implement feature flags

### DIFF
--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -1,0 +1,72 @@
+// The feature package provides types and methods for working with
+// feature flags.
+package feature
+
+import (
+	"errors"
+	"sort"
+	"strings"
+)
+
+// ErrInvalidCollection is returned when you try to set a flag in an
+// invalid collection.
+var ErrInvalidCollection = errors.New("invalid feature collection")
+
+// Collection represents a set of feature flags.
+type Collection map[string]struct{}
+
+// NewCollection returns a correctly initialized Collection.
+func NewCollection() Collection {
+	return make(Collection)
+}
+
+// Set adds the value specified by s to the collection.
+//
+// The input s can be a single feature flag or multiple feature flags
+// separated by commas.
+func (c Collection) Set(s string) error {
+	if c == nil {
+		return ErrInvalidCollection
+	}
+
+	for _, elem := range strings.Split(s, ",") {
+		feature := strings.TrimSpace(elem)
+		if feature == "" {
+			continue
+		}
+		c[feature] = struct{}{}
+	}
+
+	return nil
+}
+
+// String returns an string representation of the collection.
+//
+// The returned value can be passed to Set to recreate an identical
+// collection.
+func (c Collection) String() string {
+	if c == nil {
+		return ""
+	}
+
+	values := make([]string, 0, len(c))
+	for elem := range c {
+		values = append(values, elem)
+	}
+
+	sort.Strings(values)
+
+	return strings.Join(values, ",")
+}
+
+// IsSet returns true if the provided name is part of the collection,
+// false otherwise.
+func (c Collection) IsSet(name string) bool {
+	if c == nil {
+		return false
+	}
+
+	_, found := c[name]
+
+	return found
+}

--- a/internal/feature/feature_test.go
+++ b/internal/feature/feature_test.go
@@ -1,0 +1,111 @@
+package feature
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidCollection(t *testing.T) {
+	var c Collection
+	err := c.Set("flag")
+	require.Error(t, err)
+}
+
+func TestCollection(t *testing.T) {
+	testcases := map[string]struct {
+		input              string
+		shouldError        bool
+		expectedString     string
+		expectedCollection Collection
+	}{
+		"empty": {
+			input:              "",
+			shouldError:        false,
+			expectedString:     "",
+			expectedCollection: Collection{},
+		},
+		"single": {
+			input:              "flag",
+			shouldError:        false,
+			expectedString:     "flag",
+			expectedCollection: Collection{"flag": struct{}{}},
+		},
+		"multiple": {
+			input:              "flag1,flag2",
+			shouldError:        false,
+			expectedString:     "flag1,flag2",
+			expectedCollection: Collection{"flag1": struct{}{}, "flag2": struct{}{}},
+		},
+		"blanks": {
+			input:              " flag1 , flag2 ",
+			shouldError:        false,
+			expectedString:     "flag1,flag2",
+			expectedCollection: Collection{"flag1": struct{}{}, "flag2": struct{}{}},
+		},
+		"empty element": {
+			input:              "flag1,,flag2",
+			shouldError:        false,
+			expectedString:     "flag1,flag2",
+			expectedCollection: Collection{"flag1": struct{}{}, "flag2": struct{}{}},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			c := NewCollection()
+			err := c.Set(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedCollection, c)
+			require.Equal(t, tc.expectedString, c.String())
+
+			for flag := range tc.expectedCollection {
+				require.True(t, c.IsSet(flag))
+			}
+		})
+	}
+}
+
+func TestCollectionFromFlag(t *testing.T) {
+	testcases := map[string]struct {
+		input            []string
+		expectedFeatures []string
+	}{
+		"single flag single value": {
+			input:            []string{"--flag", "foo"},
+			expectedFeatures: []string{"foo"},
+		},
+		"single flag multiple values": {
+			input:            []string{"--flag", "foo,bar"},
+			expectedFeatures: []string{"foo", "bar"},
+		},
+		"multiple flags": {
+			input:            []string{"--flag", "foo", "--flag", "bar"},
+			expectedFeatures: []string{"foo", "bar"},
+		},
+		"multiple flags multiple values": {
+			input:            []string{"--flag", "foo,bar", "--flag", "baz"},
+			expectedFeatures: []string{"foo", "bar", "baz"},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			c := NewCollection()
+			require.NotNil(t, c)
+
+			fs := flag.NewFlagSet("test flag set", flag.ContinueOnError)
+			require.NotNil(t, fs)
+
+			fs.Var(&c, "flag", "test flag")
+
+			err := fs.Parse(tc.input)
+			require.NoError(t, err)
+
+			for _, feature := range tc.expectedFeatures {
+				require.True(t, c.IsSet(feature))
+			}
+		})
+	}
+}


### PR DESCRIPTION
You can create a feature.Collection, pass that to flagset.Var, and get a
set of features from the command line. On the command line it
understands a flag passed multiple times with different values or a flag
passed one time with multiple values (separated by commas). E.g.:

	my_progam --features foo --features bar
	my_progam --features foo,bar

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>