### PR TITLE
Feature: report overall test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,7 @@ test-go: $(GOTESTSUM) ## Run Go tests.
 		-coverprofile=$(TEST_OUTPUT).cov \
 		-race \
 		$(GO_TEST_ARGS)
+	$(S) $(ROOTDIR)/scripts/report-test-coverage $(TEST_OUTPUT).cov
 
 .PHONY: test
 test: test-go ## Run all tests.

--- a/scripts/report-test-coverage
+++ b/scripts/report-test-coverage
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+echo -n 'Overall test coverage: '
+go tool cover -func "$1" |
+grep ^total: |
+expand |
+tr -s ' ' |
+cut -d ' ' -f3


### PR DESCRIPTION
Add a script to report the overall test coverage. Call it at the end of
a test run.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>