### PR TITLE
Rework logic around running probers

### DIFF
--- a/internal/prober/dns/dns.go
+++ b/internal/prober/dns/dns.go
@@ -1,0 +1,79 @@
+package dns
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/prometheus/blackbox_exporter/config"
+	bbeprober "github.com/prometheus/blackbox_exporter/prober"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var errUnsupportedCheck = errors.New("unsupported check")
+
+type Prober struct {
+	config config.Module
+}
+
+func NewProber(check sm.Check) (Prober, error) {
+	if check.Settings.Dns == nil {
+		return Prober{}, errUnsupportedCheck
+	}
+
+	cfg := settingsToModule(check.Settings.Dns, check.Target)
+	cfg.Timeout = time.Duration(check.Timeout) * time.Millisecond
+
+	return Prober{
+		config: cfg,
+	}, nil
+}
+
+func (p Prober) Name() string {
+	return "dns"
+}
+
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+	return bbeprober.ProbeDNS(ctx, target, p.config, registry, logger)
+}
+
+func settingsToModule(settings *sm.DnsSettings, target string) config.Module {
+	var m config.Module
+
+	m.Prober = sm.CheckTypeDns.String()
+	m.DNS.IPProtocol, m.DNS.IPProtocolFallback = settings.IpVersion.ToIpProtocol()
+
+	// BBE dns_probe actually tests the DNS server, so we
+	// need to pass the query (e.g. www.grafana.com) as part
+	// of the configuration and the server as the target
+	// parameter.
+	m.DNS.QueryName = target
+	m.DNS.QueryType = settings.RecordType.String()
+	m.DNS.SourceIPAddress = settings.SourceIpAddress
+	// In the protobuffer definition the protocol is either
+	// "TCP" or "UDP", but blackbox-exporter wants "tcp" or
+	// "udp".
+	m.DNS.TransportProtocol = strings.ToLower(settings.Protocol.String())
+
+	m.DNS.ValidRcodes = settings.ValidRCodes
+
+	if settings.ValidateAnswer != nil {
+		m.DNS.ValidateAnswer.FailIfMatchesRegexp = settings.ValidateAnswer.FailIfMatchesRegexp
+		m.DNS.ValidateAnswer.FailIfNotMatchesRegexp = settings.ValidateAnswer.FailIfNotMatchesRegexp
+	}
+
+	if settings.ValidateAuthority != nil {
+		m.DNS.ValidateAuthority.FailIfMatchesRegexp = settings.ValidateAuthority.FailIfMatchesRegexp
+		m.DNS.ValidateAuthority.FailIfNotMatchesRegexp = settings.ValidateAuthority.FailIfNotMatchesRegexp
+	}
+
+	if settings.ValidateAdditional != nil {
+		m.DNS.ValidateAdditional.FailIfMatchesRegexp = settings.ValidateAdditional.FailIfMatchesRegexp
+		m.DNS.ValidateAdditional.FailIfNotMatchesRegexp = settings.ValidateAdditional.FailIfNotMatchesRegexp
+	}
+
+	return m
+}

--- a/internal/prober/http/http.go
+++ b/internal/prober/http/http.go
@@ -1,0 +1,214 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
+	"github.com/grafana/synthetic-monitoring-agent/internal/tls"
+	"github.com/grafana/synthetic-monitoring-agent/internal/version"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/prometheus/blackbox_exporter/config"
+	bbeprober "github.com/prometheus/blackbox_exporter/prober"
+	"github.com/prometheus/client_golang/prometheus"
+	promconfig "github.com/prometheus/common/config"
+	"github.com/rs/zerolog"
+)
+
+var errUnsupportedCheck = errors.New("unsupported check")
+
+type Prober struct {
+	config                     config.Module
+	cacheBustingQueryParamName string
+}
+
+func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger) (Prober, error) {
+	if check.Settings.Http == nil {
+		return Prober{}, errUnsupportedCheck
+	}
+
+	cfg, err := settingsToModule(ctx, check.Settings.Http, logger)
+	if err != nil {
+		return Prober{}, err
+	}
+
+	cfg.Timeout = time.Duration(check.Timeout) * time.Millisecond
+
+	return Prober{
+		config:                     cfg,
+		cacheBustingQueryParamName: check.Settings.Http.CacheBustingQueryParamName,
+	}, nil
+}
+
+func (p Prober) Name() string {
+	return "http"
+}
+
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+	if p.cacheBustingQueryParamName != "" {
+		// FIXME(mem): the second target argument should be the probe's name
+		target = addCacheBustParam(target, p.cacheBustingQueryParamName, target)
+	}
+
+	return bbeprober.ProbeHTTP(ctx, target, p.config, registry, logger)
+}
+
+func settingsToModule(ctx context.Context, settings *sm.HttpSettings, logger zerolog.Logger) (config.Module, error) {
+	var m config.Module
+
+	m.Prober = sm.CheckTypeHttp.String()
+
+	m.HTTP.IPProtocol, m.HTTP.IPProtocolFallback = settings.IpVersion.ToIpProtocol()
+
+	m.HTTP.Body = settings.Body
+
+	m.HTTP.Method = settings.Method.String()
+
+	m.HTTP.FailIfSSL = settings.FailIfSSL
+
+	m.HTTP.FailIfNotSSL = settings.FailIfNotSSL
+
+	m.HTTP.Headers = buildHttpHeaders(settings.Headers)
+
+	if settings.Compression != sm.CompressionAlgorithm_none {
+		m.HTTP.Compression = settings.Compression.String()
+	}
+
+	m.HTTP.ValidStatusCodes = make([]int, 0, len(settings.ValidStatusCodes))
+	for _, code := range settings.ValidStatusCodes {
+		m.HTTP.ValidStatusCodes = append(m.HTTP.ValidStatusCodes, int(code))
+	}
+
+	m.HTTP.ValidHTTPVersions = make([]string, len(settings.ValidHTTPVersions))
+	copy(m.HTTP.ValidHTTPVersions, settings.ValidHTTPVersions)
+
+	m.HTTP.FailIfBodyMatchesRegexp = make([]config.Regexp, 0, len(settings.FailIfBodyMatchesRegexp))
+	for _, str := range settings.FailIfBodyMatchesRegexp {
+		re, err := config.NewRegexp(str)
+		if err != nil {
+			return m, err
+		}
+
+		m.HTTP.FailIfBodyMatchesRegexp = append(m.HTTP.FailIfBodyMatchesRegexp, re)
+	}
+
+	m.HTTP.FailIfBodyNotMatchesRegexp = make([]config.Regexp, 0, len(settings.FailIfBodyNotMatchesRegexp))
+	for _, str := range settings.FailIfBodyNotMatchesRegexp {
+		re, err := config.NewRegexp(str)
+		if err != nil {
+			return m, err
+		}
+
+		m.HTTP.FailIfBodyNotMatchesRegexp = append(m.HTTP.FailIfBodyNotMatchesRegexp, re)
+	}
+
+	m.HTTP.FailIfHeaderMatchesRegexp = make([]config.HeaderMatch, 0, len(settings.FailIfHeaderMatchesRegexp))
+	for _, match := range settings.FailIfHeaderMatchesRegexp {
+		re, err := config.NewRegexp(match.Regexp)
+		if err != nil {
+			return m, err
+		}
+
+		m.HTTP.FailIfHeaderMatchesRegexp = append(m.HTTP.FailIfHeaderMatchesRegexp, config.HeaderMatch{
+			Header:       match.Header,
+			Regexp:       re,
+			AllowMissing: match.AllowMissing,
+		})
+	}
+
+	m.HTTP.FailIfHeaderNotMatchesRegexp = make([]config.HeaderMatch, 0, len(settings.FailIfHeaderNotMatchesRegexp))
+	for _, match := range settings.FailIfHeaderNotMatchesRegexp {
+		re, err := config.NewRegexp(match.Regexp)
+		if err != nil {
+			return m, err
+		}
+
+		m.HTTP.FailIfHeaderNotMatchesRegexp = append(m.HTTP.FailIfHeaderNotMatchesRegexp, config.HeaderMatch{
+			Header:       match.Header,
+			Regexp:       re,
+			AllowMissing: match.AllowMissing,
+		})
+	}
+
+	m.HTTP.HTTPClientConfig.FollowRedirects = !settings.NoFollowRedirects
+
+	if settings.TlsConfig != nil {
+		var err error
+		m.HTTP.HTTPClientConfig.TLSConfig, err = tls.SMtoProm(ctx, logger.With().Str("prober", m.Prober).Logger(), settings.TlsConfig)
+		if err != nil {
+			return m, err
+		}
+	}
+
+	m.HTTP.HTTPClientConfig.BearerToken = promconfig.Secret(settings.BearerToken)
+
+	if settings.BasicAuth != nil {
+		m.HTTP.HTTPClientConfig.BasicAuth = &promconfig.BasicAuth{
+			Username: settings.BasicAuth.Username,
+			Password: promconfig.Secret(settings.BasicAuth.Password),
+		}
+	}
+
+	if settings.ProxyURL != "" {
+		var err error
+		m.HTTP.HTTPClientConfig.ProxyURL.URL, err = url.Parse(settings.ProxyURL)
+		if err != nil {
+			return m, fmt.Errorf("parsing proxy URL: %w", err)
+		}
+	}
+
+	return m, nil
+}
+
+func buildHttpHeaders(headers []string) map[string]string {
+	userAgentHeader := "user-agent"
+
+	h := map[string]string{
+		userAgentHeader: version.UserAgent(), // default user-agent header
+	}
+
+	for _, header := range headers {
+		parts := strings.SplitN(header, ":", 2)
+
+		var value string
+		if len(parts) == 2 {
+			value = strings.TrimLeft(parts[1], " ")
+		}
+
+		if strings.ToLower(parts[0]) == userAgentHeader {
+			// Remove the default user-agent header and
+			// replace it with the one the user is
+			// specifying, so that we respect whatever case
+			// they chose (e.g. "user-agent" vs
+			// "User-Agent").
+			delete(h, userAgentHeader)
+		}
+
+		h[parts[0]] = value
+	}
+
+	return h
+}
+
+func addCacheBustParam(target, paramName, salt string) string {
+	// we already know this URL is valid
+	u, _ := url.Parse(target)
+	q := u.Query()
+	value := hashString(salt, strconv.FormatInt(time.Now().UnixNano(), 10))
+	q.Set(paramName, value)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+func hashString(salt, str string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(salt))
+	_, _ = h.Write([]byte(str))
+	return strconv.FormatUint(h.Sum64(), 16)
+}

--- a/internal/prober/http/http_test.go
+++ b/internal/prober/http/http_test.go
@@ -1,0 +1,124 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildHeaders(t *testing.T) {
+	testcases := map[string]struct {
+		input    []string
+		expected map[string]string
+	}{
+		"nil": {
+			input: nil,
+			expected: map[string]string{
+				"user-agent": version.UserAgent(),
+			},
+		},
+
+		"empty": {
+			input: []string{},
+			expected: map[string]string{
+				"user-agent": version.UserAgent(),
+			},
+		},
+
+		"trivial": {
+			input: []string{
+				"foo: bar",
+			},
+			expected: map[string]string{
+				"foo":        "bar",
+				"user-agent": version.UserAgent(),
+			},
+		},
+
+		"multiple headers": {
+			input: []string{
+				"h1: v1",
+				"h2: v2",
+			},
+			expected: map[string]string{
+				"h1":         "v1",
+				"h2":         "v2",
+				"user-agent": version.UserAgent(),
+			},
+		},
+
+		"compact": {
+			input: []string{
+				"h1:v1",
+				"h2:v2",
+			},
+			expected: map[string]string{
+				"h1":         "v1",
+				"h2":         "v2",
+				"user-agent": version.UserAgent(),
+			},
+		},
+
+		"trim leading whitespace": {
+			input: []string{
+				"h1:   v1",
+				"h2:      v2",
+			},
+			expected: map[string]string{
+				"h1":         "v1",
+				"h2":         "v2",
+				"user-agent": version.UserAgent(),
+			},
+		},
+
+		"keep trailing whitespace": {
+			input: []string{
+				"h1: v1   ",
+				"h2: v2 ",
+			},
+			expected: map[string]string{
+				"h1":         "v1   ",
+				"h2":         "v2 ",
+				"user-agent": version.UserAgent(),
+			},
+		},
+
+		"empty values": {
+			input: []string{
+				"h1: ",
+				"h2:",
+			},
+			expected: map[string]string{
+				"h1":         "",
+				"h2":         "",
+				"user-agent": version.UserAgent(),
+			},
+		},
+
+		"custom user agent": {
+			input: []string{
+				"User-Agent: test agent",
+			},
+			expected: map[string]string{
+				"User-Agent": "test agent",
+			},
+		},
+
+		"custom user agent, weird header capitalization": {
+			input: []string{
+				"uSEr-AGenT: test agent",
+			},
+			expected: map[string]string{
+				"uSEr-AGenT": "test agent",
+			},
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := buildHttpHeaders(testcase.input)
+			require.Equal(t, testcase.expected, actual)
+		})
+	}
+}

--- a/internal/prober/icmp/icmp.go
+++ b/internal/prober/icmp/icmp.go
@@ -1,0 +1,56 @@
+package icmp
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/prometheus/blackbox_exporter/config"
+	bbeprober "github.com/prometheus/blackbox_exporter/prober"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var errUnsupportedCheck = errors.New("unsupported check")
+
+type Prober struct {
+	config config.Module
+}
+
+func NewProber(check sm.Check) (Prober, error) {
+	if check.Settings.Ping == nil {
+		return Prober{}, errUnsupportedCheck
+	}
+
+	cfg := settingsToModule(check.Settings.Ping)
+	cfg.Timeout = time.Duration(check.Timeout) * time.Millisecond
+
+	return Prober{
+		config: cfg,
+	}, nil
+}
+
+func (p Prober) Name() string {
+	return "ping"
+}
+
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+	return bbeprober.ProbeICMP(ctx, target, p.config, registry, logger)
+}
+
+func settingsToModule(settings *sm.PingSettings) config.Module {
+	var m config.Module
+
+	m.Prober = sm.CheckTypePing.String()
+
+	m.ICMP.IPProtocol, m.ICMP.IPProtocolFallback = settings.IpVersion.ToIpProtocol()
+
+	m.ICMP.SourceIPAddress = settings.SourceIpAddress
+
+	m.ICMP.PayloadSize = int(settings.PayloadSize)
+
+	m.ICMP.DontFragment = settings.DontFragment
+
+	return m
+}

--- a/internal/prober/logger/logger.go
+++ b/internal/prober/logger/logger.go
@@ -1,0 +1,5 @@
+package logger
+
+type Logger interface {
+	Log(keyvals ...interface{}) error
+}

--- a/internal/prober/prober.go
+++ b/internal/prober/prober.go
@@ -1,0 +1,55 @@
+package prober
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/prober/dns"
+	"github.com/grafana/synthetic-monitoring-agent/internal/prober/http"
+	"github.com/grafana/synthetic-monitoring-agent/internal/prober/icmp"
+	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
+	"github.com/grafana/synthetic-monitoring-agent/internal/prober/tcp"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+)
+
+type Prober interface {
+	Name() string
+	Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool
+}
+
+func Run(ctx context.Context, p Prober, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+	return p.Probe(ctx, target, registry, logger)
+}
+
+func NewFromCheck(ctx context.Context, logger zerolog.Logger, check sm.Check) (Prober, string, error) {
+	var (
+		p      Prober
+		target string
+		err    error
+	)
+
+	switch checkType := check.Type(); checkType {
+	case sm.CheckTypePing:
+		p, err = icmp.NewProber(check)
+		target = check.Target
+
+	case sm.CheckTypeHttp:
+		p, err = http.NewProber(ctx, check, logger)
+		target = check.Target
+
+	case sm.CheckTypeDns:
+		p, err = dns.NewProber(check)
+		target = check.Settings.Dns.Server
+
+	case sm.CheckTypeTcp:
+		p, err = tcp.NewProber(ctx, check, logger)
+		target = check.Target
+
+	default:
+		return nil, "", fmt.Errorf("unsupported change")
+	}
+
+	return p, target, err
+}

--- a/internal/prober/tcp/tcp.go
+++ b/internal/prober/tcp/tcp.go
@@ -1,0 +1,82 @@
+package tcp
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
+	"github.com/grafana/synthetic-monitoring-agent/internal/tls"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/prometheus/blackbox_exporter/config"
+	bbeprober "github.com/prometheus/blackbox_exporter/prober"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+)
+
+var errUnsupportedCheck = errors.New("unsupported check")
+
+type Prober struct {
+	config config.Module
+}
+
+func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger) (Prober, error) {
+	if check.Settings.Tcp == nil {
+		return Prober{}, errUnsupportedCheck
+	}
+
+	cfg, err := settingsToModule(ctx, check.Settings.Tcp, logger)
+	if err != nil {
+		return Prober{}, err
+	}
+
+	cfg.Timeout = time.Duration(check.Timeout) * time.Millisecond
+
+	return Prober{
+		config: cfg,
+	}, nil
+}
+
+func (p Prober) Name() string {
+	return "tcp"
+}
+
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+	return bbeprober.ProbeTCP(ctx, target, p.config, registry, logger)
+}
+
+func settingsToModule(ctx context.Context, settings *sm.TcpSettings, logger zerolog.Logger) (config.Module, error) {
+	var m config.Module
+
+	m.Prober = sm.CheckTypeTcp.String()
+
+	m.TCP.IPProtocol, m.TCP.IPProtocolFallback = settings.IpVersion.ToIpProtocol()
+
+	m.TCP.SourceIPAddress = settings.SourceIpAddress
+
+	m.TCP.TLS = settings.Tls
+
+	m.TCP.QueryResponse = make([]config.QueryResponse, len(settings.QueryResponse))
+
+	for _, qr := range settings.QueryResponse {
+		re, err := config.NewRegexp(string(qr.Expect))
+		if err != nil {
+			return m, err
+		}
+
+		m.TCP.QueryResponse = append(m.TCP.QueryResponse, config.QueryResponse{
+			Expect: re,
+			Send:   string(qr.Send),
+		})
+	}
+
+	if settings.TlsConfig != nil {
+		var err error
+		m.TCP.TLSConfig, err = tls.SMtoProm(ctx, logger.With().Str("prober", m.Prober).Logger(), settings.TlsConfig)
+		if err != nil {
+			return m, err
+		}
+	}
+
+	return m, nil
+}

--- a/internal/tls/tls.go
+++ b/internal/tls/tls.go
@@ -1,0 +1,88 @@
+package tls
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	promconfig "github.com/prometheus/common/config"
+	"github.com/rs/zerolog"
+)
+
+func SMtoProm(ctx context.Context, logger zerolog.Logger, tlsConfig *sm.TLSConfig) (promconfig.TLSConfig, error) {
+	c := promconfig.TLSConfig{
+		InsecureSkipVerify: tlsConfig.InsecureSkipVerify,
+		ServerName:         tlsConfig.ServerName,
+	}
+
+	if len(tlsConfig.CACert) > 0 {
+		fn, err := newDataProvider(ctx, logger, "ca_cert", tlsConfig.CACert)
+		if err != nil {
+			return promconfig.TLSConfig{}, err
+		}
+		c.CAFile = fn
+	}
+
+	if len(tlsConfig.ClientCert) > 0 {
+		fn, err := newDataProvider(ctx, logger, "client_cert", tlsConfig.ClientCert)
+		if err != nil {
+			return promconfig.TLSConfig{}, err
+		}
+		c.CertFile = fn
+	}
+
+	if len(tlsConfig.ClientKey) > 0 {
+		fn, err := newDataProvider(ctx, logger, "client_key", tlsConfig.ClientKey)
+		if err != nil {
+			return promconfig.TLSConfig{}, err
+		}
+		c.KeyFile = fn
+	}
+
+	return c, nil
+}
+
+// newDataProvider creates a filesystem object that provides the
+// specified data as often as needed. It returns the name under which
+// the data can be accessed.
+//
+// It does NOT try to make guarantees about partial reads. If the reader
+// goes away before reaching the end of the data, the next time the
+// reader shows up, the writer might continue from the previous
+// prosition.
+func newDataProvider(ctx context.Context, logger zerolog.Logger, basename string, data []byte) (string, error) {
+	fh, err := ioutil.TempFile("", basename+".")
+	if err != nil {
+		logger.Error().Err(err).Str("basename", basename).Msg("creating temporary file")
+		return "", fmt.Errorf("creating temporary file: %w", err)
+	}
+	defer func() {
+		if err := fh.Close(); err != nil {
+			// close errors should never happen, but if they
+			// do, the most we can do is log them to be able
+			// to debug the issue.
+			logger.Error().Err(err).Str("filename", fh.Name()).Msg("closing temporary file")
+		}
+	}()
+
+	fn := fh.Name()
+
+	if n, err := fh.Write(data); err != nil {
+		logger.Error().Err(err).Str("filename", fn).Int("bytes", n).Int("data", len(data)).Msg("writing temporary file")
+		return "", fmt.Errorf("writing temporary file for %s: %w", basename, err)
+	}
+
+	// play nice and make sure this file gets deleted once the
+	// context is cancelled, which could be when the program is
+	// shutting down or when the scraper stops.
+	go func() {
+		<-ctx.Done()
+		if err := os.Remove(fn); err != nil {
+			logger.Error().Err(err).Str("filename", fn).Msg("removing temporary file")
+		}
+	}()
+
+	return fn, nil
+}

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -430,6 +430,23 @@ func (out *IpVersion) UnmarshalJSON(b []byte) error {
 	return ErrInvalidIpVersionString
 }
 
+// ToIpProtocol converts the IpVersion setting into a pair of IP
+// protocol and fallback option.
+func (v IpVersion) ToIpProtocol() (string, bool) {
+	switch v {
+	case IpVersion_V4:
+		return "ip4", false
+
+	case IpVersion_V6:
+		return "ip6", false
+
+	case IpVersion_Any:
+		return "ip6", true
+	}
+
+	return "", false
+}
+
 func (v CompressionAlgorithm) MarshalJSON() ([]byte, error) {
 	if b := lookupValue(int32(v), CompressionAlgorithm_name); b != nil {
 		return b, nil


### PR DESCRIPTION
This part of the code has always been very messy. Move the logic around
creating a probe out of the scraper package into its own packages and
add a Prober interface that the different probers have to implement in
order to be able to run them.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>