### PR TITLE
Remove quotes from ExecStart in .service file

### DIFF
--- a/scripts/package/config/systemd/synthetic-monitoring-agent.service
+++ b/scripts/package/config/systemd/synthetic-monitoring-agent.service
@@ -6,7 +6,7 @@ Type=simple
 User=root
 Group=root
 EnvironmentFile=/etc/synthetic-monitoring/synthetic-monitoring-agent.conf
-ExecStart=/usr/bin/synthetic-monitoring-agent --api-token="${API_TOKEN}" --api-server-address="${API_SERVER}" --api-insecure="${API_INSECURE}" --listen-address="${LISTEN_ADDRESS}" --verbose="${VERBOSE}" --debug="${DEBUG}"
+ExecStart=/usr/bin/synthetic-monitoring-agent --api-token=${API_TOKEN} --api-server-address=${API_SERVER} --api-insecure=${API_INSECURE} --listen-address=${LISTEN_ADDRESS} --verbose=${VERBOSE} --debug=${DEBUG}
 Restart=always
 
 [Install]


### PR DESCRIPTION
Older versions of systemd handle quotes in ExecStart. At some point,
probably because people were doing it, systemd started handling quotes
differently. In particular, what's handling the word-splitting in the
arguments is systemd, not a shell, so it started looking at quotes to
prevent splits from ocurring within them. We don't have that case
because all the arguments should be single words without blanks in them.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>