### PR TITLE
Fix: add +Inf bucket to histograms

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -686,6 +686,13 @@ func appendDtoToTimeseries(ts []prompb.TimeSeries, t time.Time, mName string, sh
 					}
 					ts = append(ts, makeTimeseries(t, float64(v.GetCumulativeCount()), hLabels...))
 				}
+
+				// Add the +Inf bucket, which corresponds to the sample count.
+				hLabels[len(hLabels)-1] = prompb.Label{
+					Name:  "le",
+					Value: "+Inf",
+				}
+				ts = append(ts, makeTimeseries(t, float64(h.GetSampleCount()), hLabels...))
 			}
 		}
 	}


### PR DESCRIPTION
At some point the implementation changed and dropped the +Inf bucket and
nobody noticed (expect me, because I clearly remember fixing this a
while ago).

Fixes: #196

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>