### PR TITLE
Only build/publish when tagging a release

### DIFF
--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -49,7 +49,6 @@ steps:
       from_secret: docker_username
   when:
     ref:
-    - refs/heads/main
     - refs/tags/v*.*.*
 
 - name: package
@@ -75,7 +74,6 @@ steps:
     PUBLISH_PROD_PKGS: 1
   when:
     ref:
-    - refs/heads/main
     - refs/tags/v*.*.*
 
 trigger:


### PR DESCRIPTION
and not when merging to master. As far as I'm aware this has two
benefits:
1. We only publish packages/docker images for other people to use when
   we are also using them, so we won't be the last to know when we break
   something.
2. We avoid a race condition, where two build/publish processes are
   happening concurrently when we tag a new release.
