### PR TITLE
Fix: check if the incoming check is a traceroute one

### DIFF
--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -545,13 +545,14 @@ func (c *Updater) addAndStartScraperWithLock(ctx context.Context, check sm.Check
 	// If we need to accept checks based on whether a feature flag
 	// is enabled or not, we can "accept" the check from the point
 	// of view of the API, and skip running it here, e.g.
-	//
-	// if !c.features.IsSet(features.NEW_CHECK_TYPE) {
-	// 	return nil
-	// }
 
-	if !c.features.IsSet(feature.Traceroute) {
-		return nil
+	switch check.Type() {
+	case sm.CheckTypeTraceroute:
+		if !c.features.IsSet(feature.Traceroute) {
+			return nil
+		}
+
+	default:
 	}
 
 	scrapeCounter := c.metrics.scrapesCounter.With(prometheus.Labels{


### PR DESCRIPTION
It's necessary to check whether or not the incoming check is a
traceroute one in order to decide to skip it based on the feature flag.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>