### PR TITLE
Fix: update fpm to 1.13.1

### DIFF
--- a/scripts/package/package.sh
+++ b/scripts/package/package.sh
@@ -17,7 +17,7 @@ $SUDO apt-get update
 # Install fpm if needed
 if [ ! -x "$(which fpm)" ]; then
 	$SUDO apt-get install -y ruby ruby-dev rubygems build-essential
-	$SUDO gem install --no-document fpm -v 1.11.0
+	$SUDO gem install --no-document fpm -v 1.13.1
 fi
 
 BUILD_OUTPUT="${CODE_DIR}/dist"


### PR DESCRIPTION
They fixed the bug that caused us to pin to version 1.11.0 (empty if
branch causing a shell syntax error). Pin it to a newer version that
works with whatever changed in ffi.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>