### PR TITLE
add features to startup command

### DIFF
--- a/scripts/package/config/systemd/synthetic-monitoring-agent.conf
+++ b/scripts/package/config/systemd/synthetic-monitoring-agent.conf
@@ -15,3 +15,6 @@ VERBOSE="false"
 
 # debug output (enables verbose)
 DEBUG="false"
+
+# feature flags
+FEATURES=""

--- a/scripts/package/config/systemd/synthetic-monitoring-agent.service
+++ b/scripts/package/config/systemd/synthetic-monitoring-agent.service
@@ -6,7 +6,7 @@ Type=simple
 User=root
 Group=root
 EnvironmentFile=/etc/synthetic-monitoring/synthetic-monitoring-agent.conf
-ExecStart=/usr/bin/synthetic-monitoring-agent --api-token=${API_TOKEN} --api-server-address=${API_SERVER} --api-insecure=${API_INSECURE} --listen-address=${LISTEN_ADDRESS} --verbose=${VERBOSE} --debug=${DEBUG}
+ExecStart=/usr/bin/synthetic-monitoring-agent --api-token=${API_TOKEN} --api-server-address=${API_SERVER} --api-insecure=${API_INSECURE} --listen-address=${LISTEN_ADDRESS} --verbose=${VERBOSE} --debug=${DEBUG} --features=${FEATURES}
 Restart=always
 
 [Install]


### PR DESCRIPTION
We should have the ability to pass feature flags into agents running in VMs. I _think_ this is all that requires. 