### PR TITLE
Feature: disconnect agent from API on signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,18 @@ Now you should have the agent reporting as private probe, and running checks (if
 
 #### Deploy it using Kubernetes
 See [examples/kubernetes](./examples/kubernetes) for the documentation and example yaml files
+
+Signals
+-------
+
+The agent traps the following signals:
+
+* SIGTERM: The agent tries to clean up and shut down in an orderly
+  manner.
+* SIGUSR1: The agent disconnects from the API but keeps running checks.
+  After 1 minute elapses, the agent will try to reconnect to the API and
+  keep trying until it succeeds or it's killed. One possible use case is
+  upgrading a running agent with a newer version: after SIGUSR1 is sent,
+  the agent disconnects, allowing another agent to connect in its place.
+  If the new agent fails to connect, the old agent will reconnect and
+  take it from there.

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -1,7 +1,11 @@
 package checks
 
 import (
+	"context"
+	"sync/atomic"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/grafana/synthetic-monitoring-agent/internal/feature"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
@@ -52,4 +56,88 @@ func TestNewUpdater(t *testing.T) {
 			require.NotNil(t, u.metrics.probeInfo)
 		})
 	}
+}
+
+func TestInstallSignalHandler(t *testing.T) {
+	testcases := map[string]func(t *testing.T){
+		"signal": func(t *testing.T) {
+			// verify that the signal context is done after
+			// receiving the signal, and that the signal is
+			// correctly reported as having fired.
+
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			sigCtx, signalFired := installSignalHandler(ctx)
+			require.NotNil(t, sigCtx)
+			require.NotNil(t, signalFired)
+			require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGUSR1))
+
+			select {
+			case <-ctx.Done():
+				t.Fatal("context timeout expired")
+			case <-sigCtx.Done():
+				require.Equal(t, int32(1), atomic.LoadInt32(signalFired))
+			}
+		},
+
+		"no signal": func(t *testing.T) {
+			// verify that the signal context is done after
+			// the parrent context is done, and that the
+			// signal is correctly reported as not having
+			// fired.
+
+			ctx, cancel := context.WithCancel(context.Background())
+			sigCtx, signalFired := installSignalHandler(ctx)
+			require.NotNil(t, sigCtx)
+			require.NotNil(t, signalFired)
+
+			cancel()
+
+			timeout := 100 * time.Millisecond
+			timer := time.NewTimer(timeout)
+			defer timer.Stop()
+
+			select {
+			case <-timer.C:
+				t.Fatalf("signal context not cancelled after %s", timeout)
+			case <-sigCtx.Done():
+				require.Equal(t, int32(0), atomic.LoadInt32(signalFired))
+			}
+		},
+	}
+
+	for name, f := range testcases {
+		t.Run(name, f)
+	}
+}
+
+func TestSleepCtx(t *testing.T) {
+	var (
+		veryShort = 1 * time.Microsecond
+		long      = 10 * time.Second
+	)
+
+	// make sure errors are reported correctly
+
+	ctx := context.Background()
+	err := sleepCtx(ctx, veryShort)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = sleepCtx(ctx, long)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+
+	ctx, cancel = context.WithTimeout(context.Background(), veryShort)
+	err = sleepCtx(ctx, long)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	cancel()
+
+	ctx, cancel = context.WithTimeout(context.Background(), long)
+	cancel()
+	err = sleepCtx(ctx, long)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
 }


### PR DESCRIPTION
If the agent receives a SIGUSR1 signal, it will disconnect from the API,
but it will continue running checks. This makes it possible for a new
version of the agent to connect to the API. When that happens, it's
possible to kill the running agent (SIGTERM or otherwise).

This should provide for a smoother upgrade process.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>