### PR TITLE
Feature: add /ready endpoint for readiness probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,16 @@ The agent traps the following signals:
   the agent disconnects, allowing another agent to connect in its place.
   If the new agent fails to connect, the old agent will reconnect and
   take it from there.
+
+Readiness
+---------
+
+You can use the `/ready` endpoint to check if probe has been able to
+connect to the API and is ready to start processing checks. A status
+code of 200 signals that the agent is ready. If the agent is not yet
+ready, the response has a status code of 503.
+
+Used in conjunction with the USR1 signal, you can use this mechanism to
+ask a running agent to disconnect from the API, and poll the `/ready`
+entrypoint in order to determine if the new agent has been able to
+connect already.

--- a/cmd/synthetic-monitoring-agent/http_test.go
+++ b/cmd/synthetic-monitoring-agent/http_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadynessHandler(t *testing.T) {
+	h := NewReadynessHandler()
+
+	// Test that the handler returns a 503 when the agent is not ready.
+	var (
+		w *httptest.ResponseRecorder
+		r *http.Request
+	)
+
+	// A new readynessHandler should report not ready before the
+	// first call to Set(true).
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/ready", nil)
+	h.ServeHTTP(w, r)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	// Calling Set(false) should NOT change the readyness state.
+	h.Set(false)
+
+	// Still not ready, report not ready.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/ready", nil)
+	h.ServeHTTP(w, r)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+	// Set as ready.
+	h.Set(true)
+
+	// Now the handler should return a 200.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/ready", nil)
+	h.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "ready", w.Body.String())
+
+	// Setting it as ready again.
+	h.Set(true)
+
+	// Response should not change.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/ready", nil)
+	h.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "ready", w.Body.String())
+
+	// Setting it back to not ready.
+	h.Set(false)
+
+	// The handler should still return a 200 because the agent was
+	// marked as ready once.
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/ready", nil)
+	h.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "ready", w.Body.String())
+}

--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -99,9 +99,13 @@ func run(args []string, stdout io.Writer) error {
 		return err
 	}
 
+	// to know if probe is connected to API
+	readynessHandler := NewReadynessHandler()
+
 	router := NewMux(MuxOpts{
 		Logger:         zl.With().Str("subsystem", "mux").Logger(),
 		PromRegisterer: promRegisterer,
+		isReady:        readynessHandler,
 	})
 
 	httpConfig := http.Config{
@@ -147,6 +151,7 @@ func run(args []string, stdout io.Writer) error {
 		Logger:         zl.With().Str("subsystem", "updater").Logger(),
 		PublishCh:      publishCh,
 		TenantCh:       tenantCh,
+		IsConnected:    readynessHandler.Set,
 		PromRegisterer: promRegisterer,
 		Features:       features,
 	})

--- a/examples/kubernetes/deployment.yaml
+++ b/examples/kubernetes/deployment.yaml
@@ -41,6 +41,10 @@ spec:
               name: http-metrics
           readinessProbe:
             httpGet:
+              path: /ready
+              port: 4050
+          livenessProbe:
+            httpGet:
               path: /
               port: 4050
           resources:


### PR DESCRIPTION
When deplying probes in kubernetes like envirements, we need a way to know if agent process is ready.

probe is considered ready when it is to able connect to SM API. 

You can use `/ready` endpoint to check if probe is ready (was able to connect to SM API).  `/ready` endpoint will return HTTP OK (200) with `ready`  when probe is ready.


**demo:**

https://user-images.githubusercontent.com/9503187/143260060-f49a1def-2884-41da-949f-f1eea1780c11.mp4


