### PR TITLE
Add pre-stop.sh script to send signal USR1 to agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ RUN apt-get update && apt-get -y install ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 COPY dist/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
+COPY scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]

--- a/scripts/pre-stop.sh
+++ b/scripts/pre-stop.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# This scripts sends the USR1 signal to the synthetic monitoring agent
+# (PID 1) running in the container to ask it to disconnect from the API.
+
+kill -USR1 1


### PR DESCRIPTION
Add a script to the docker image that sends the USR1 signal to the
running agent. This is meant to be used as the preStop hook in a
kubernetes container.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>