### PR TITLE
Fix: correctly propagate check failure

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -357,6 +357,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, erro
 
 	successValue := "1"
 	if !success {
+		err = errCheckFailed
 		successValue = "0"
 	}
 
@@ -366,7 +367,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, erro
 	// loki does not support joins
 	streams := s.extractLogs(t, logs.Bytes(), logLabels)
 
-	return &probeData{ts: ts, streams: streams, tenantId: s.check.TenantId}, nil
+	return &probeData{ts: ts, streams: streams, tenantId: s.check.TenantId}, err
 }
 
 func getProbeMetrics(


### PR DESCRIPTION
The error metric is not getting updated because the scraper runner is
not reporting the failure as an error as expected. The failure is
correctly reported and recorded in user-visible metrics and logs, but
it's not accounted for in the agent's metrics, so it's possible to see
log entries for the checks entering the PASS state but no logs are
recorded for the FAIL state.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>