### PR TITLE
Feature: add `/disconnect` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ The agent traps the following signals:
   upgrading a running agent with a newer version: after SIGUSR1 is sent,
   the agent disconnects, allowing another agent to connect in its place.
   If the new agent fails to connect, the old agent will reconnect and
-  take it from there.
+  take it from there. 
+  You can also use `/disconnect` endpoint to send SIGUSR1 to process.
 
 Readiness
 ---------
@@ -55,7 +56,7 @@ connect to the API and is ready to start processing checks. A status
 code of 200 signals that the agent is ready. If the agent is not yet
 ready, the response has a status code of 503.
 
-Used in conjunction with the USR1 signal, you can use this mechanism to
-ask a running agent to disconnect from the API, and poll the `/ready`
-entrypoint in order to determine if the new agent has been able to
-connect already.
+Used in conjunction with the USR1 signal or `/disconnect` endpoint,
+you can use this mechanism to ask a running agent to disconnect from the API,
+and poll the `/ready` entrypoint in order to determine if the
+new agent has been able to connect already.

--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -37,6 +37,7 @@ func run(args []string, stdout io.Writer) error {
 		grpcInsecure      = flags.Bool("api-insecure", false, "Don't use TLS with connections to GRPC API")
 		httpListenAddr    = flags.String("listen-address", ":4050", "listen address")
 		apiToken          = flags.String("api-token", "", "synthetic monitoring probe authentication token")
+		enableDisconnect  = flags.Bool("enable-disconnect", false, "enable HTTP /disconnect endpoint")
 	)
 
 	flags.Var(&features, "features", "optional feature flags")
@@ -103,9 +104,10 @@ func run(args []string, stdout io.Writer) error {
 	readynessHandler := NewReadynessHandler()
 
 	router := NewMux(MuxOpts{
-		Logger:         zl.With().Str("subsystem", "mux").Logger(),
-		PromRegisterer: promRegisterer,
-		isReady:        readynessHandler,
+		Logger:            zl.With().Str("subsystem", "mux").Logger(),
+		PromRegisterer:    promRegisterer,
+		isReady:           readynessHandler,
+		disconnectEnabled: *enableDisconnect,
 	})
 
 	httpConfig := http.Config{


### PR DESCRIPTION
Add `/disconnect` endpoint to send `SIGUSR1` to process.

This endpoint is useful when you want to instruct agent to disconnect but can't send signals directly.