### PR TITLE
Fix: fix http status code parsing for publish

### DIFF
--- a/internal/pkg/prom/prom.go
+++ b/internal/pkg/prom/prom.go
@@ -53,10 +53,11 @@ func IsHttpUnauthorized(err error) bool {
 }
 
 func GetHttpStatusCode(err error) (int, bool) {
-	var httpErr httpError
-
-	if errors.As(err, &httpErr) {
-		return httpErr.StatusCode, true
+	for ; err != nil; err = errors.Unwrap(err) {
+		err2, ok := err.(*httpError)
+		if ok {
+			return err2.StatusCode, true
+		}
 	}
 
 	return 0, false


### PR DESCRIPTION
We had a temporary fix where we were looking at error string to check if we were getting 401 from server. 

`sm_agent_publisher_push_errors_total` metric is still broken after the temporary fix, and it was reporting `0` as status for all errors.

In this change, I am fixing the status code parsing code, and getting rid of temporary fix.