### PR TITLE
feat: Add a metric for failure to publish data

### DIFF
--- a/internal/pusher/pusher.go
+++ b/internal/pusher/pusher.go
@@ -48,6 +48,7 @@ type Publisher struct {
 	clients       map[int64]*remoteTarget
 	pushCounter   *prometheus.CounterVec
 	errorCounter  *prometheus.CounterVec
+	failedCounter *prometheus.CounterVec
 	bytesOut      *prometheus.CounterVec
 }
 
@@ -74,6 +75,17 @@ func NewPublisher(tm *TenantManager, publishCh <-chan Payload, logger zerolog.Lo
 
 	promRegisterer.MustRegister(errorCounter)
 
+	failedCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "sm_agent",
+			Subsystem: "publisher",
+			Name:      "push_failed_total",
+			Help:      "Total number of push failed.",
+		},
+		[]string{"type", "tenantID"})
+
+	promRegisterer.MustRegister(failedCounter)
+
 	bytesOut := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "sm_agent",
@@ -92,6 +104,7 @@ func NewPublisher(tm *TenantManager, publishCh <-chan Payload, logger zerolog.Lo
 		logger:        logger,
 		pushCounter:   pushCounter,
 		errorCounter:  errorCounter,
+		failedCounter: failedCounter,
 		bytesOut:      bytesOut,
 	}
 }
@@ -118,8 +131,8 @@ func (p *Publisher) publish(ctx context.Context, payload Payload) {
 	for retry := 2; retry > 0; retry-- {
 		client, err := p.getClient(ctx, tenantID, newClient)
 		if err != nil {
-			logger.Error().Err(err).Msg("get client")
-			p.errorCounter.WithLabelValues("client", tenantStr, "N/A").Inc()
+			logger.Error().Err(err).Msg("get client failed")
+			p.failedCounter.WithLabelValues("client", tenantStr).Inc()
 			return
 		}
 
@@ -168,6 +181,7 @@ func (p *Publisher) publish(ctx context.Context, payload Payload) {
 	}
 
 	// if we are here, we retried and failed
+	p.failedCounter.WithLabelValues("retry_exhausted", tenantStr).Inc()
 	logger.Warn().Msg("failed to push payload")
 }
 


### PR DESCRIPTION
Add a new metric to track total failure to push data, this will help us narrow down cases when we are dropping data for a tenant