### PR TITLE
Add metric to track prometheus client retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,4 +76,7 @@ tags
 # Coc configuration directory
 .vim
 
+# IntelliJ
+.idea/
+
 # End of https://www.gitignore.io/api/vim,code,linux,macos

--- a/internal/pkg/loki/loki.go
+++ b/internal/pkg/loki/loki.go
@@ -6,12 +6,10 @@ import (
 	"github.com/golang/snappy"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/logproto"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/prom"
-	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
 )
 
 // sendSamples to the remote storage with backoff for recoverable errors.
-// TODO: Inject here the counter with the "tenantID" tag already filled
-func SendStreamsWithBackoff(ctx context.Context, client *prom.Client, streams []logproto.Stream, buf *[]byte, retriesCtr pusher.RetriesCounter) error {
+func SendStreamsWithBackoff(ctx context.Context, client *prom.Client, streams []logproto.Stream, buf *[]byte) error {
 	req, err := buildStreamsPushRequest(streams, *buf)
 	*buf = req
 	if err != nil {
@@ -20,7 +18,7 @@ func SendStreamsWithBackoff(ctx context.Context, client *prom.Client, streams []
 		return err
 	}
 
-	return prom.SendBytesWithBackoff(ctx, client, req, retriesCtr)
+	return prom.SendBytesWithBackoff(ctx, client, req)
 }
 
 func buildStreamsPushRequest(streams []logproto.Stream, buf []byte) ([]byte, error) {

--- a/internal/pkg/loki/loki.go
+++ b/internal/pkg/loki/loki.go
@@ -2,6 +2,7 @@ package loki
 
 import (
 	"context"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/logproto"

--- a/internal/pkg/prom/prom.go
+++ b/internal/pkg/prom/prom.go
@@ -351,6 +351,8 @@ func (rt *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	return rt.rt.RoundTrip(req)
 }
 
+// CountRetries registers the number of retries the client did internally, in a generic metric. The main purpose is to
+// wrap in a simple way the underlying Prometheus metric.
 func (c *Client) CountRetries(retries float64) {
 	c.countRetriesFunc(retries)
 }

--- a/internal/pkg/prom/prom_test.go
+++ b/internal/pkg/prom/prom_test.go
@@ -1,0 +1,97 @@
+package prom_test
+
+import (
+	"context"
+	"errors"
+	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/prom"
+	"testing"
+)
+
+type FailNTimesPrometheusClient struct {
+	CountedRetries float64
+	FailuresLeft   int64
+}
+
+func (f *FailNTimesPrometheusClient) Store(ctx context.Context, req []byte) error {
+	if f.FailuresLeft == 0 {
+		return nil
+	}
+	f.FailuresLeft--
+	return prom.NewRecoverableError(errors.New("client failed"))
+
+}
+
+func (f *FailNTimesPrometheusClient) CountRetries(retries float64) {
+	f.CountedRetries = retries
+}
+
+type FakePrometheusClient struct {
+	storeFunc        func(ctx context.Context, req []byte) error
+	countRetriesFunc func(float642 float64)
+}
+
+func (f *FakePrometheusClient) Store(ctx context.Context, req []byte) error {
+	return f.storeFunc(ctx, req)
+}
+
+func (f *FakePrometheusClient) CountRetries(retries float64) {
+	f.countRetriesFunc(retries)
+}
+
+func TestSendBytesWithBackoffRetriesCounter(t *testing.T) {
+	type args struct {
+		ctx         context.Context
+		timesToFail int64
+		req         []byte
+	}
+	tests := []struct {
+		name                 string
+		args                 args
+		wantErr              bool
+		expectedRetriesCount float64
+	}{
+		{
+			name: "should count 0 retries when successful at first",
+			args: args{
+				ctx:         context.Background(),
+				timesToFail: 0,
+				req:         []byte{},
+			},
+			expectedRetriesCount: 0,
+		},
+		{
+			name: "should count 2 retries when failed 2 times",
+			args: args{
+				ctx:         context.Background(),
+				timesToFail: 2,
+				req:         []byte{},
+			},
+			expectedRetriesCount: 2,
+		},
+		{
+			name: "should count 10 retries when retries exceeded",
+			args: args{
+				ctx:         context.Background(),
+				timesToFail: 10,
+				req:         []byte{},
+			},
+			wantErr:              true,
+			expectedRetriesCount: 10,
+		},
+	}
+	for _, tt := range tests {
+		client := &FailNTimesPrometheusClient{
+			CountedRetries: -1,
+			FailuresLeft:   tt.args.timesToFail,
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			if err := prom.SendBytesWithBackoff(tt.args.ctx, client, tt.args.req); (err != nil) != tt.wantErr {
+				t.Errorf("SendBytesWithBackoff() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if client.CountedRetries != tt.expectedRetriesCount {
+				t.Errorf("Not expected retries count registered. Expected: %f, Got: %f", tt.expectedRetriesCount, client.CountedRetries)
+			}
+		})
+	}
+}

--- a/internal/pkg/prom/prom_test.go
+++ b/internal/pkg/prom/prom_test.go
@@ -3,8 +3,9 @@ package prom_test
 import (
 	"context"
 	"errors"
-	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/prom"
 	"testing"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/prom"
 )
 
 type FailNTimesPrometheusClient struct {
@@ -18,7 +19,6 @@ func (f *FailNTimesPrometheusClient) Store(ctx context.Context, req []byte) erro
 	}
 	f.FailuresLeft--
 	return prom.NewRecoverableError(errors.New("client failed"))
-
 }
 
 func (f *FailNTimesPrometheusClient) CountRetries(retries float64) {


### PR DESCRIPTION
### What this PR introduces?
This PR adds a new metrics to track the number of retries performed when sending metrics to the remote Prometheus instance. 
Because the clients themselves aren't aware of the `TenantID` or if they are sending either metrics or log streams, injected in each client a function to emit the metrics value with the labels already pre-filled. Tried doing it some other way but it wasn't as clean.

### Related
Related to: https://github.com/grafana/synthetic-monitoring-agent/issues/192

### Pending
- [x] Test in a local setup