### PR TITLE
Add tooling to configure agent in local k3d cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ tags
 .vim
 
 # End of https://www.gitignore.io/api/vim,code,linux,macos
+
+# Local dev environment configuration files
+*.env

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,14 +1,15 @@
 ### Local environment tools
-Follow the steps below to work with the local Synthetic Monitoring cluster, and add a development version of the SM agent in there.
+Follow the steps below to work with a local Synthetic Monitoring kubernetes cluster, and add a development version of the SM agent in there.
 
-First, setup a local cluster with [sm-dev](https://github.com/grafana/synthetic-monitoring-api/tree/main/scripts#sm-dev).
-Once configured, go into the local Grafana instance and configure the SM Plugin. Then:
+First, install the `Synthetic Monitoring plugin` in a `Grafana` instance, and follow these instructions on how to add a `Probe`.
 1. Go into the SM Plugin.
-2. Click `Probes`. Then `New`.
-3. Configure a `Probe Name`, and a `Region` name (`amer` for example). Click `Save`.
-4. Copy the `Probe Authentication Token` in a config file with the following format:
+2. First go to `Config`. You will notice under `Backend Address` a URL. This is the Synthetic Monitoring API URL. Save that for later, we will call it `<sm api url>`.
+4. After that, click`Probes`. Then `New`.
+5. Configure a `Probe Name`, and a `Region` name (`amer` for example). Click `Save`.
+6. Copy the `Probe Authentication Token`, and the `<sm api url>` (which if not present will default to `sm-api:4031`) in a config file with the following format:
 ```
 API_TOKEN=<probe authentication code>
+SM_API_URL=<sm api url> 
 ```
 5. Save the file and let's call its path `<config file path>`.
 6. Deploy and build the agent into the local cluster by running:
@@ -22,5 +23,31 @@ In the case you just want to deploy a k8s configuration change to the local clus
 ```
 This will avoid re-building the SM agent Docker image.
 
-Once depoyed, the agent will be reachable in the following host endpoint: `http://sm-agent.k3d.localhost:9999`. If you find
-a `Could not resolve host` error, follow the steps [here](https://github.com/grafana/cloud-onboarding/tree/main/ops#curling-cluster-ingress-urls-gives-you-curl-6-could-not-resolve-host).
+Once , the agent will be reachable in the following host endpoint: `http://sm-agent.k3d.localhost:9999`. If you find
+a `Could not resolve host` error, follow the steps in the [troubleshooting](#troubleshooting) section.
+
+### Troubleshooting
+
+#### Curling cluster ingress URLS gives you `curl: (6) Could not resolve host`
+
+There appears to be a DNS issue introduced by Big Sur where `*.localhost` top level domains do not resolve by default. Browsers will likely still resolve the URLs but curl and other CLI apps will not. Known fixes for this issue are below,
+
+1. Add all services to your /etc/hosts file (really annoying because there are quite a few services if you install apps)
+2. Setup a local DNS server to route `*.localhost` -> `127.0.0.1`
+    - The commands below will setup the rule using dnsmasq (Adopted from this gist https://gist.github.com/ogrrd/5831371)
+   ```shell
+   brew install dnsmasq
+
+   mkdir -pv $(brew --prefix)/etc/
+
+   echo 'address=/.localhost/127.0.0.1' >> $(brew --prefix)/etc/dnsmasq.conf
+
+   sudo brew services start dnsmasq
+
+   sudo mkdir -v /etc/resolver
+
+   sudo bash -c 'echo "nameserver 127.0.0.1" > /etc/resolver/localhost'
+
+   scutil --dns #should now show the localhost resolver
+   ```
+    - Retry the curl commands for integrations-api/hosted-exporters and you should hopefully get results now

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,26 @@
+### Local environment tools
+Follow the steps below to work with the local Synthetic Monitoring cluster, and add a development version of the SM agent in there.
+
+First, setup a local cluster with [sm-dev](https://github.com/grafana/synthetic-monitoring-api/tree/main/scripts#sm-dev).
+Once configured, go into the local Grafana instance and configure the SM Plugin. Then:
+1. Go into the SM Plugin.
+2. Click `Probes`. Then `New`.
+3. Configure a `Probe Name`, and a `Region` name (`amer` for example). Click `Save`.
+4. Copy the `Probe Authentication Token` in a config file with the following format:
+```
+API_TOKEN=<probe authentication code>
+```
+5. Save the file and let's call its path `<config file path>`.
+6. Deploy and build the agent into the local cluster by running:
+```bash
+./scripts/sm-dev <config file path>
+```
+
+In the case you just want to deploy a k8s configuration change to the local cluster, run:
+```bash
+./scripts/sm-dev -n <config file path>
+```
+This will avoid re-building the SM agent Docker image.
+
+Once depoyed, the agent will be reachable in the following host endpoint: `http://sm-agent.k3d.localhost:9999`. If you find
+a `Could not resolve host` error, follow the steps [here](https://github.com/grafana/cloud-onboarding/tree/main/ops#curling-cluster-ingress-urls-gives-you-curl-6-could-not-resolve-host).

--- a/scripts/agent.yaml.tmpl
+++ b/scripts/agent.yaml.tmpl
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sm-agent
+  labels:
+    app: sm-agent
+    env: development
+spec:
+  containers:
+    - image: grafana/synthetic-monitoring-agent:latest
+      name: agent
+      imagePullPolicy: Never
+      args:
+        - -api-server-address
+        - sm-api:4031
+        - -api-token
+        - {{ required "Missing API_TOKEN var" (ds "config").API_TOKEN }}
+        - -debug
+        - -api-insecure
+      ports:
+        - name: http
+          containerPort: 4050
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sm-agent
+spec:
+  ports:
+    - name: http
+      port: 4050
+      targetPort: http
+  selector:
+    app: sm-agent
+    env: development
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sm-agent-ingress
+  namespace: default
+spec:
+  rules:
+    - host: sm-agent.k3d.localhost
+      http:
+        paths:
+          - backend:
+              service:
+                name: sm-agent
+                port:
+                  number: 4050
+            path: /
+            pathType: Prefix

--- a/scripts/agent.yaml.tmpl
+++ b/scripts/agent.yaml.tmpl
@@ -12,7 +12,7 @@ spec:
       imagePullPolicy: Never
       args:
         - -api-server-address
-        - sm-api:4031
+        - {{ has (ds "config") SM_API_URL | ternary (ds "config").SM_API_URL "sm-api:4031" }}
         - -api-token
         - {{ required "Missing API_TOKEN var" (ds "config").API_TOKEN }}
         - -debug

--- a/scripts/docker_build
+++ b/scripts/docker_build
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+GOCACHE=$(go env GOCACHE)
+GOPKGCACHE=$(readlink -m "$(go env GOMODCACHE)"/..)
+
+docker container run \
+	-ti \
+	--rm \
+	--user "$(id -u)":"$(id -g)" \
+	--volume "${PWD}":/workdir \
+	--volume "${GOCACHE}":/.cache/go-build \
+	--volume "${GOPKGCACHE}":/go/pkg \
+	golang:1.18.1 \
+	make -C /workdir "$@"

--- a/scripts/sm-dev
+++ b/scripts/sm-dev
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+set -e
+
+usage() {
+	cat <<-EOT
+	Usage:
+
+	        $0 [-h] [-r] <filename.cfg>
+
+	Flags:
+
+	        -h: show this help
+	        -n: don't build api, already built
+	EOT
+}
+
+k3d_context=k3d-sm-test
+k3d_cluster=sm-test
+keep_current=true
+build_agent=true
+while getopts ":hn" arg ; do
+	case "$arg" in
+		n)
+			build_agent=false
+			shift
+			;;
+		h)
+			usage
+			exit 0
+			;;
+		*)
+			usage
+			exit 1
+			;;
+	esac
+done
+
+cfg_file=$1
+
+# check if k3d cluster is running or not
+# k3d image import fails if cluster is not running and script hangs
+cluster_running=$(k3d cluster get "${k3d_cluster}" -o json 2>/dev/null | jq '.[].serversRunning')
+if [ "${cluster_running}" != 1 ]; then
+  echo "E: k3d cluster '${k3d_cluster}' is not running!"
+  echo "INFO: start it with 'k3d cluster start ${k3d_cluster}'"
+  exit 1
+fi
+
+agent_yaml_tmpl=$(dirname "$0")/agent.yaml.tmpl
+
+if test ! -e "${agent_yaml_tmpl}" ; then
+	echo "E: agent.yaml.tmpl not found. Abort."
+	exit 1
+fi
+
+if test -z "${cfg_file}" -o ! -e "${cfg_file}" ; then
+	echo "E: configuration file '${cfg_file}' not found. Abort."
+	exit 1
+fi
+
+agent_yaml=$(mktemp)
+cat ${cfg_file} | gomplate -d config=stdin:///in.env --file "${agent_yaml_tmpl}" > "${agent_yaml}"
+
+if "${build_agent}" ; then
+  ./scripts/docker_build
+  docker build -t "grafana/synthetic-monitoring-agent" -f Dockerfile .
+  k3d image import grafana/synthetic-monitoring-agent:latest -c sm-test
+fi
+
+echo "Applying configuration..."
+
+kubectl --context="${k3d_context}" apply -f "${agent_yaml}"
+
+echo "Done."

--- a/scripts/sm-dev
+++ b/scripts/sm-dev
@@ -1,5 +1,4 @@
 #!/bin/sh
-# Inspired by https://github.com/grafana/synthetic-monitoring-api/tree/main/scripts#sm-dev
 
 set -e
 

--- a/scripts/sm-dev
+++ b/scripts/sm-dev
@@ -1,4 +1,5 @@
 #!/bin/sh
+# Inspired by https://github.com/grafana/synthetic-monitoring-api/tree/main/scripts#sm-dev
 
 set -e
 


### PR DESCRIPTION
This PR adds some tooling for deploying a newly built image of Synthetic Monitoring agent in a kubernetes cluster.
The configuration needed is minimal:
```
API_TOKEN=<probe authentication code>
SM_API_URL=<synthetic monitoring api url> 
```

Once deployed, the script will create 3 resources:
- Pod with grafana agent running
- Service, to encapsulate pods under a networking abstraction
- Ingress, to make the agent http server accessible from `http://sm-agent.k3d.localhost:9999`
