### PR TITLE
Enable blocking IPs (via bbe fork)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,3 +87,5 @@ replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.0+inc
 replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
 
 replace github.com/tonobo/mtr => github.com/grafana/mtr v0.1.1-0.20211103212629-0a455647759f
+
+replace github.com/prometheus/blackbox_exporter => github.com/captncraig/blackbox_exporter v0.20.1-0.20220505194755-e5a84035e259

--- a/go.sum
+++ b/go.sum
@@ -612,8 +612,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/alertmanager v0.21.0/go.mod h1:h7tJ81NA0VLWvWEayi1QltevFkLF3KxmC/malTcT8Go=
-github.com/prometheus/blackbox_exporter v0.20.0 h1:3880Ab2GJYgpnKciV6nVXDsd5F4cMsY8ecuZUPdmLs8=
-github.com/prometheus/blackbox_exporter v0.20.0/go.mod h1:NCyUMGWAeRaPFhLID6X/WAuChGMOc4wNvSQj7Qd31Bg=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx2
 github.com/buger/goterm v0.0.0-20181115115552-c206103e1f37 h1:uxxtrnACqI9zK4ENDMf0WpXfUsHP5V8liuq5QdgDISU=
 github.com/buger/goterm v0.0.0-20181115115552-c206103e1f37/go.mod h1:u9UyCz2eTrSGy6fbupqJ54eY5c4IC8gREQ1053dK12U=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
+github.com/captncraig/blackbox_exporter v0.20.1-0.20220505194755-e5a84035e259 h1:lxrKnFZypYAyJu6CuosTbLtm9JRq7rP2s6R31CNhwNg=
+github.com/captncraig/blackbox_exporter v0.20.1-0.20220505194755-e5a84035e259/go.mod h1:NCyUMGWAeRaPFhLID6X/WAuChGMOc4wNvSQj7Qd31Bg=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=


### PR DESCRIPTION
This implements blocked IP addresses inside the agent code itself. It does this by injecting a custom dialer into blackbox_exporter that checks the forbidden cidrs before dialing. This is not merged into bbe yet, but hopefully they will take it. 

https://github.com/prometheus/blackbox_exporter/compare/master...captncraig:cmp_dialer?expand=1