### PR TITLE
Allow for building docker images for other architectures

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -84,6 +84,9 @@ local vault_secret(name, vault_path, key) = {
     // so we will use the native docker plugin instead for security.
     step('docker build', [], 'plugins/docker')
     + {
+      environment: {
+        DOCKER_BUILDKIT: '1',
+      },
       settings: {
         repo: docker_repo,
         dry_run: 'true',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -52,6 +52,8 @@ steps:
   settings:
     dry_run: true
     repo: grafana/synthetic-monitoring-agent
+  environment:
+    DOCKER_BUILDKIT: 1
   depends_on:
   - build
 
@@ -213,6 +215,6 @@ get:
 
 ---
 kind: signature
-hmac: 717b7fce8402131bcbd3477d4a09d69ea70dddd81d819c4b5df056658f58c3a5
+hmac: 40798b1ad1a705e2f4026f29e7a752ecef29ba4b44acea2ef726608be090ce09
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
-FROM debian:stable-slim
+# First stage obtains the list of certificates.
+FROM --platform=$BUILDPLATFORM debian:stable-slim AS build
+RUN apt-get update && apt-get -y install ca-certificates
 
-RUN apt-get update && apt-get -y install ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
+# Second stage copies the binaries, configuration and also the
+# certificates from the first stage.
 
-COPY dist/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
+ARG TARGETPLATFORM
+
+FROM --platform=$TARGETPLATFORM debian:stable-slim
+ARG TARGETOS
+ARG TARGETARCH
+ARG HOST_DIST=$TARGETOS-$TARGETARCH
+
+COPY dist/${HOST_DIST}/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]


### PR DESCRIPTION
Split the Dockerfile in two stages: the first stage (native) install the
ca-certificates package; in the second stage copy the
target-architecture files to their final destination, as well the
certificate bundle.

For the --platform argument to FROM to work (to have access to the
BUILDPLATFORM variable) it's necessary to switch to BUILDKIT:

    FROM --platform=$BUILDPLATFORM debian:stable-slim AS build

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>