### PR TITLE
feat: Add password on /disconnect endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ The agent traps the following signals:
   If the new agent fails to connect, the old agent will reconnect and
   take it from there. 
   You can also use `/disconnect` endpoint to send SIGUSR1 to process.
+  * To make use of `/disconnect` endpoint, you need to enable it with
+   `--enable-disconnect=<secret password\>`.
+  * You will need to pass the same password when hitting disconnect endpoint.
+    e.g: `curl http://127.0.0.1:<listen-address>/disconnect?secret=<secret password\>`,
+    `listen-address` is `4050` by default.
 
 Readiness
 ---------

--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -41,7 +41,7 @@ func run(args []string, stdout io.Writer) error {
 		grpcInsecure      = flags.Bool("api-insecure", false, "Don't use TLS with connections to GRPC API")
 		httpListenAddr    = flags.String("listen-address", ":4050", "listen address")
 		apiToken          = flags.String("api-token", "", "synthetic monitoring probe authentication token")
-		enableDisconnect  = flags.Bool("enable-disconnect", false, "enable HTTP /disconnect endpoint")
+		enableDisconnect  = flags.String("enable-disconnect", "", "enable HTTP /disconnect endpoint with password")
 	)
 
 	flags.Var(&features, "features", "optional feature flags")

--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -110,10 +110,10 @@ func run(args []string, stdout io.Writer) error {
 	readynessHandler := NewReadynessHandler()
 
 	router := NewMux(MuxOpts{
-		Logger:            zl.With().Str("subsystem", "mux").Logger(),
-		PromRegisterer:    promRegisterer,
-		isReady:           readynessHandler,
-		disconnectEnabled: *enableDisconnect,
+		Logger:           zl.With().Str("subsystem", "mux").Logger(),
+		PromRegisterer:   promRegisterer,
+		isReady:          readynessHandler,
+		disconnectSecret: *enableDisconnect,
 	})
 
 	httpConfig := http.Config{


### PR DESCRIPTION
`/disconnect` is a control endpoint, and can be left open in environments where sm-agent is not secured properly.

Put a password on `/disconnect` endpoint to NOT make it insecure by default.