### PR TITLE
Temporarily use BBE fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,3 +89,5 @@ replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.0+inc
 replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
 
 replace github.com/tonobo/mtr => github.com/grafana/mtr v0.1.1-0.20211103212629-0a455647759f
+
+replace github.com/prometheus/blackbox_exporter v0.21.0 => github.com/grafana/blackbox_exporter v0.21.1-0.20220614164936-0cf374fec170

--- a/go.sum
+++ b/go.sum
@@ -389,6 +389,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/grafana/blackbox_exporter v0.21.1-0.20220614164936-0cf374fec170 h1:LO3TZhlQVL2Z6cvW55boAVj+leN5HEhXI4ClxXQqXZs=
+github.com/grafana/blackbox_exporter v0.21.1-0.20220614164936-0cf374fec170/go.mod h1:C2+yfkUsPkUbrw5hK1KfUrJ7D0XzkmRfpCMc++zsAfY=
 github.com/grafana/mtr v0.1.1-0.20211103212629-0a455647759f h1:p6vtqczeUvE5yVozBMjQtwt0wiSviWtsJEFNaJmFkMM=
 github.com/grafana/mtr v0.1.1-0.20211103212629-0a455647759f/go.mod h1:qDO1rp1hUZzunyD0f38VNbY0j6k+ZFRNZkHl3jbn/MU=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -612,8 +614,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/alertmanager v0.21.0/go.mod h1:h7tJ81NA0VLWvWEayi1QltevFkLF3KxmC/malTcT8Go=
-github.com/prometheus/blackbox_exporter v0.21.0 h1:KSgaeEsvL28MacRIg2aqjHm8KHoEe0hSjxmKzi3cnK0=
-github.com/prometheus/blackbox_exporter v0.21.0/go.mod h1:C2+yfkUsPkUbrw5hK1KfUrJ7D0XzkmRfpCMc++zsAfY=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=


### PR DESCRIPTION
There's an open PR in BBE to fix an issue with reusing a
golang.org/x/text/cases/Caser:

https://github.com/prometheus/blackbox_exporter/pull/927

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>