### PR TITLE
Fix: use buildkit when building docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,8 @@ help: ## Display this help.
 
 .PHONY: docker
 docker: build
-	$(S) docker build -t $(DOCKER_TAG) ./
+	$(S) echo "Building docker image..."
+	$(V) DOCKER_BUILDKIT=1 docker build -t $(DOCKER_TAG) ./
 
 .PHONY: docker-push
 docker-push:  docker


### PR DESCRIPTION
9315139aa048099a89b0f54a53c1187e6719f5e0 added the ability to build
images for other architectures, and as part of that the Dockerfile was
changed to use BUILDPLATFORM and TARGETPLATFORM. These values are
provided by buildkit, not by regular docker builds. Set the
DOCKER_BUILDKIT environment variable to 1 so that the `docker build`
command uses buildkit.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>