### PR TITLE
Fix: reject passwords in HTTP urls

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -65,6 +65,8 @@ var (
 	ErrInvalidHttpMethodString = errors.New("invalid HTTP method string")
 	ErrInvalidHttpMethodValue  = errors.New("invalid HTTP method value")
 	ErrInvalidHttpHeaders      = errors.New("invalid HTTP headers")
+	ErrHttpUrlContainsPassword = errors.New("HTTP URL contains username and password")
+	ErrHttpUrlContainsUsername = errors.New("HTTP URL contains username")
 
 	ErrInvalidTracerouteHostname = errors.New("invalid traceroute hostname")
 
@@ -726,6 +728,14 @@ func validateHttpUrl(target string) error {
 	u, err := url.Parse(target)
 	if err != nil {
 		return ErrInvalidHttpUrl
+	}
+
+	if _, isSet := u.User.Password(); isSet {
+		return ErrHttpUrlContainsPassword
+	}
+
+	if u.User.Username() != "" {
+		return ErrHttpUrlContainsUsername
 	}
 
 	if !(u.Scheme == "http" || u.Scheme == "https") {

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -660,6 +660,14 @@ func TestValidateHttpUrl(t *testing.T) {
 			input:       "ftp://example.org/",
 			expectError: true,
 		},
+		"with username": {
+			input:       "http://user@example.org/",
+			expectError: true,
+		},
+		"with username and password": {
+			input:       "http://user:password@example.org/",
+			expectError: true,
+		},
 
 		// these are covered by TestValidateHostPort
 		"bad host": {


### PR DESCRIPTION
We will reject URLs that contain passwords because there are dedicated
fields for configuring these. By including the password in the target,
this ends up being part of the metrics and logs labels.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>