### PR TITLE
build: prevent invalid os/arch combinations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ ROOTDIR       := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 DISTDIR       := $(abspath $(ROOTDIR)/dist)
 HOST_OS       := $(shell go env GOOS)
 HOST_ARCH     := $(shell go env GOARCH)
-WANTED_OSES   := $(sort $(HOST_OS) linux)
-WANTED_ARCHES := $(sort $(HOST_ARCH) amd64 arm arm64)
+PLATFORMS     := $(sort $(HOST_OS)/$(HOST_ARCH) linux/amd64 linux/arm linux/arm64)
 
 BUILD_VERSION := $(shell $(ROOTDIR)/scripts/version)
 BUILD_COMMIT  := $(shell git rev-parse HEAD^{commit})
@@ -84,10 +83,9 @@ build-go-$(1)-$(2)-$(3) : GOPKG := $(3)
 
 endef
 
-$(foreach BUILD_OS,$(WANTED_OSES), \
-	$(foreach BUILD_ARCH,$(WANTED_ARCHES), \
-		$(foreach CMD,$(COMMANDS), \
-			$(eval $(call build_go_template,$(BUILD_OS),$(BUILD_ARCH),$(CMD))))))
+$(foreach BUILD_PLATFORM,$(PLATFORMS), \
+	$(foreach CMD,$(COMMANDS), \
+		$(eval $(call build_go_template,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))),$(CMD)))))
 
 BUILD_GO_NATIVE_TARGETS := $(filter build-go-$(HOST_OS)-$(HOST_ARCH)-%, $(BUILD_GO_TARGETS))
 


### PR DESCRIPTION
This adjusts the Makefile to prevent crossbuilding for invalid OS/arch targets. After this, `make build` will create binaries for `linux/arm`, `linux/arm64`, `linux/amd64` and the local platform, if different.

Originally, it would build for all combinations of:
    GOOS={current, linux}
    GOARCH={current, amd64, arm, arm64}

This could cause the build to fail when run on an OS other than Linux. For example, when run under macOS, it will result in an attempt to build a `darwin/arm` binary, which is not a platform supported by Go:

> go: unsupported GOOS/GOARCH pair darwin/arm
> make: *** [build-go-darwin-arm-github.com/grafana/synthetic-monitoring-agent/cmd/synthetic-monitoring-agent] Error 2