### PR TITLE
Make agent more resilient to network failures

### DIFF
--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -98,12 +98,15 @@ func testNetworkFailure(t *testing.T, s sm.ChecksServer) {
 
 	// Serve requests.
 	go func() {
-		server.Serve(listener)
+		if err := server.Serve(listener); err != nil {
+			t.Logf("server: %v", err)
+		}
 	}()
 	t.Logf("running fake server at %s", listener.Addr())
 
 	// Create a grpc client and updater.
 	conn, err := grpc.Dial(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
 	u, err := NewUpdater(UpdaterOptions{
 		Backoff: &backoff.Backoff{
 			Min:    2 * time.Second,

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package synthetic_monitoring provides access to types and methods
+// Package synthetic_monitoring provides access to types and methods
 // that allow for the production and consumption of protocol buffer
 // messages used to communicate with synthetic-monitoring-api.
 package synthetic_monitoring
@@ -93,6 +93,7 @@ var (
 
 const (
 	HealthCheckInterval = 90 * time.Second
+	HealthCheckTimeout  = 30 * time.Second
 )
 
 const (


### PR DESCRIPTION
It's been observed that the agent can hang if the API server disappears from the network after the initial connect without closing the grpc connection. This is due to all code paths waiting indefinitely for a reply to a network message from the API server.

This PR adds a timeout to the ping sent within the checks updater, and extends the error handling so that the agent can terminate if no response is received after 30s.

Added a test to reproduce the problem.