### PR TITLE
Ignore the private key created during the release process

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -260,13 +260,13 @@ local docker_publish(repo, auth, tag, os, arch, version='') =
       step('write-key', ['printf "%s" "$NFPM_SIGNING_KEY" > $NFPM_SIGNING_KEY_FILE']) {
         environment: {
           NFPM_SIGNING_KEY: { from_secret: 'gpg_private_key' },
-          NFPM_SIGNING_KEY_FILE: '/drone/src/private-key.key',
+          NFPM_SIGNING_KEY_FILE: '/drone/src/release-private-key.key',
         },
       },
       step('test release', ['make release-snapshot']) {
         environment: {
           NFPM_DEFAULT_PASSPHRASE: { from_secret: 'gpg_passphrase' },
-          NFPM_SIGNING_KEY_FILE: '/drone/src/private-key.key',
+          NFPM_SIGNING_KEY_FILE: '/drone/src/release-private-key.key',
         },
       },
       step('test deb package', ['./scripts/package/verify-deb-install.sh'], image='docker') {
@@ -291,7 +291,7 @@ local docker_publish(repo, auth, tag, os, arch, version='') =
         environment: {
           GITHUB_TOKEN: { from_secret: 'gh_token' },
           NFPM_DEFAULT_PASSPHRASE: { from_secret: 'gpg_passphrase' },
-          NFPM_SIGNING_KEY_FILE: '/drone/src/private-key.key',
+          NFPM_SIGNING_KEY_FILE: '/drone/src/release-private-key.key',
         },
       },
     ],

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -217,7 +217,7 @@ steps:
   environment:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
-    NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
+    NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
   image: golang:1.18
   name: write-key
 - commands:
@@ -225,7 +225,7 @@ steps:
   environment:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
-    NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
+    NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
   image: golang:1.18
   name: test release
 - commands:
@@ -251,7 +251,7 @@ steps:
       from_secret: gh_token
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
-    NFPM_SIGNING_KEY_FILE: /drone/src/private-key.key
+    NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
   image: golang:1.18
   name: release
   when:
@@ -315,6 +315,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 6d62cc8065a8187b7224df260e631cfc5192654247747b9c9f4a0b6e88eaf6d0
+hmac: aefbf1c6a02e7bc3976ee73ad5a35538f50f55b0360f7726ef8bb5957daf040e
 
 ...

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 ### Release ###
 dist
-release-private-key.key
+./release-private-key.key
 
 ### Code ###
 .vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 # Created by https://www.gitignore.io/api/vim,code,linux,macos
 # Edit at https://www.gitignore.io/?templates=vim,code,linux,macos
 
+### Release ###
 dist
+release-private-key.key
 
 ### Code ###
 .vscode/*


### PR DESCRIPTION
It failed here: https://drone.grafana.net/grafana/synthetic-monitoring-agent/869