### PR TITLE
Fix: update MTR package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,4 +92,4 @@ replace github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.0+inc
 
 replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
 
-replace github.com/tonobo/mtr => github.com/grafana/mtr v0.1.1-0.20211103212629-0a455647759f
+replace github.com/tonobo/mtr => github.com/grafana/mtr v0.1.1-0.20221107202107-a9806fdda166

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/mtr v0.1.1-0.20211103212629-0a455647759f h1:p6vtqczeUvE5yVozBMjQtwt0wiSviWtsJEFNaJmFkMM=
-github.com/grafana/mtr v0.1.1-0.20211103212629-0a455647759f/go.mod h1:qDO1rp1hUZzunyD0f38VNbY0j6k+ZFRNZkHl3jbn/MU=
+github.com/grafana/mtr v0.1.1-0.20221107202107-a9806fdda166 h1:COSDtVDArtLKK9p+mkUlPXCfWFslQFVVuQos39vxQrU=
+github.com/grafana/mtr v0.1.1-0.20221107202107-a9806fdda166/go.mod h1:qDO1rp1hUZzunyD0f38VNbY0j6k+ZFRNZkHl3jbn/MU=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=


### PR DESCRIPTION
Pull in a new version of the MTR package to prevent a panic that is occuring inside it.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>