### PR TITLE
Fix: WANTED_OSES / WANTED_ARCHES was removed, use PLATFORMS

### DIFF
--- a/scripts/package/goreleaser-build
+++ b/scripts/package/goreleaser-build
@@ -5,7 +5,8 @@ log=false
 if "$log" ; then
 	exec 6>&1
 	exec 7>&2
-	exec > "goreleaser.$(date +%s).log" 2>&1
+	exec > "goreleaser.$(date +%s).$$.log" 2>&1
+	trap 'exec 1>&6 2>&7 6>&- 7>&-' EXIT
 fi
 
 # On macOS, use GNU's getopt: "brew install gnu-getopt"
@@ -39,12 +40,20 @@ while true ; do
 	esac
 done
 
-make build \
-	"WANTED_OSES=${GOOS}" \
-	"WANTED_ARCHES=${GOARCH}" \
-	"COMMANDS=github.com/grafana/synthetic-monitoring-agent/cmd/synthetic-monitoring-agent" \
-	"OUTPUT_FILE=${OUTPUT}"
+case "$1" in
+	version)
+		go "$@"
+		;;
 
-if "$log" ; then
-	exec 1>&6 2>&7 6>&- 7>&-
-fi
+	build)
+		make build \
+			"PLATFORMS=${GOOS}/${GOARCH}" \
+			"COMMANDS=github.com/grafana/synthetic-monitoring-agent/cmd/synthetic-monitoring-agent" \
+			"OUTPUT_FILE=${OUTPUT}"
+		;;
+
+	*)
+		echo "E: Unhandled arguments: '$@'. Stop."
+		exit 100
+		;;
+esac


### PR DESCRIPTION
A while back the use of the WANTED_OSES and WANTED_ARCHES variables was removed in favor of buidling a single list using PLATFORMS, which has a default value.

When this was fixed, the scripts/package/goreleaser-build wrapper was broken, and we didn't notice because we didn't do a release. Later we didn't notice because we ourselves use the docker images, which are unaffected by this.

Fix this by passing PLATFORMS in the wrapper.

Fixes: #367
Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>