### PR TITLE
Add flag to enable HTTP pprof endpoint

### DIFF
--- a/cmd/synthetic-monitoring-agent/http.go
+++ b/cmd/synthetic-monitoring-agent/http.go
@@ -28,6 +28,7 @@ type MuxOpts struct {
 	}
 	isReady           *readynessHandler
 	disconnectEnabled bool
+	pprofEnabled      bool
 }
 
 func NewMux(opts MuxOpts) *Mux {
@@ -54,11 +55,13 @@ func NewMux(opts MuxOpts) *Mux {
 	}
 
 	// Register pprof handlers
-	router.HandleFunc("/debug/pprof/", pprof.Index)
-	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	if opts.pprofEnabled {
+		router.HandleFunc("/debug/pprof/", pprof.Index)
+		router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		router.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
 
 	requestCounter := prometheus.NewSummaryVec(prometheus.SummaryOpts{
 		Namespace: "http",

--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -42,6 +42,7 @@ func run(args []string, stdout io.Writer) error {
 		httpListenAddr    = flags.String("listen-address", ":4050", "listen address")
 		apiToken          = flags.String("api-token", "", "synthetic monitoring probe authentication token")
 		enableDisconnect  = flags.Bool("enable-disconnect", false, "enable HTTP /disconnect endpoint")
+		enablePProf       = flags.Bool("enable-pprof", false, "exposes profiling data via HTTP /debug/pprof/ endpoint")
 	)
 
 	flags.Var(&features, "features", "optional feature flags")
@@ -114,6 +115,7 @@ func run(args []string, stdout io.Writer) error {
 		PromRegisterer:    promRegisterer,
 		isReady:           readynessHandler,
 		disconnectEnabled: *enableDisconnect,
+		pprofEnabled:      *enablePProf,
 	})
 
 	httpConfig := http.Config{


### PR DESCRIPTION
This adds a new flag, `-enable-pprof` to expose the HTTP pprof endpoint via the HTTP server, under the `/debug/pprof/` path.

Disabled by default.