### PR TITLE
Fix: allow getting API token from environment

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -62,6 +62,14 @@ func run(args []string, stdout io.Writer) error {
 		return nil
 	}
 
+	// If the token is provided on the command line, prefer that. Otherwise
+	// pull it from the environment variable SM_AGENT_API_TOKEN. If that's
+	// not available, fallback to API_TOKEN, which was the environment
+	// variable name previously used in the systemd unit files.
+	//
+	// Using API_TOKEN should be deprecated after March 1st, 2023.
+	*apiToken = stringFromEnv("API_TOKEN", stringFromEnv("SM_AGENT_API_TOKEN", *apiToken))
+
 	if *apiToken == "" {
 		return fmt.Errorf("invalid API token")
 	}
@@ -234,4 +242,12 @@ func newConnectionBackoff() *backoff.Backoff {
 		Factor: math.Pow(30./2., 1./8.), // reach the target in ~ 8 steps
 		Jitter: true,
 	}
+}
+
+func stringFromEnv(name string, override string) string {
+	if override != "" {
+		return override
+	}
+
+	return os.Getenv(name)
 }

--- a/scripts/package/config/systemd/synthetic-monitoring-agent.conf
+++ b/scripts/package/config/systemd/synthetic-monitoring-agent.conf
@@ -1,5 +1,5 @@
 # Enter API token retrieved from grafana.com here
-API_TOKEN='YOUR TOKEN HERE'
+SM_AGENT_API_TOKEN='YOUR TOKEN HERE'
 
 # Backend API server to connect to
 API_SERVER='synthetic-monitoring-grpc.grafana.net:443' 

--- a/scripts/package/config/systemd/synthetic-monitoring-agent.service
+++ b/scripts/package/config/systemd/synthetic-monitoring-agent.service
@@ -6,7 +6,7 @@ Type=simple
 User=root
 Group=root
 EnvironmentFile=/etc/synthetic-monitoring/synthetic-monitoring-agent.conf
-ExecStart=/usr/bin/synthetic-monitoring-agent --api-token=${API_TOKEN} --api-server-address=${API_SERVER} --api-insecure=${API_INSECURE} --listen-address=${LISTEN_ADDRESS} --verbose=${VERBOSE} --debug=${DEBUG} --features=${FEATURES}
+ExecStart=/usr/bin/synthetic-monitoring-agent --api-server-address=${API_SERVER} --api-insecure=${API_INSECURE} --listen-address=${LISTEN_ADDRESS} --verbose=${VERBOSE} --debug=${DEBUG} --features=${FEATURES}
 Restart=always
 
 [Install]


### PR DESCRIPTION
Allow the API token to be obtained from the environment. If it's passed on the command line, that value takes precedence.

Use this mechanism in the shipped systemd service file.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>