### PR TITLE
adhoc: Reorder validation of adhoc checks

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -363,11 +363,11 @@ func (c AdHocCheck) Validate() error {
 		return err
 	}
 
-	if err := c.validateTarget(); err != nil {
+	if err := c.Settings.Validate(); err != nil {
 		return err
 	}
 
-	if err := c.Settings.Validate(); err != nil {
+	if err := c.validateTarget(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is done to mimic the validation order of regular checks, so both fail in the same way.

