### PR TITLE
Feature: Support global IDs in checks and tenants

### DIFF
--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -624,7 +624,6 @@ func (c *Updater) handleCheckDelete(ctx context.Context, check sm.Check) error {
 
 	scraper, found := c.scrapers[check.Id]
 	if !found {
-
 		withCheckID(c.logger.Warn(), check.Id).Msg("delete request for an unknown check")
 		return errors.New("check not found")
 	}

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -183,6 +183,7 @@ func TestHandleCheckOp(t *testing.T) {
 
 	check := sm.Check{
 		Id:        5000,
+		TenantId:  1,
 		Frequency: 1000,
 		Timeout:   1000,
 		Target:    "127.0.0.1",

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -97,8 +97,7 @@ type ScraperOpts struct {
 func NewWithOpts(ctx context.Context, check sm.Check, opts ScraperOpts) (*Scraper, error) {
 	checkName := check.Type().String()
 
-	logger := opts.Logger.With().
-		Int64("check_id", check.Id).
+	logger := withCheckID(opts.Logger.With(), check.Id).
 		Str("probe", opts.Probe.Name).
 		Str("target", check.Target).
 		Str("job", check.Job).
@@ -887,4 +886,13 @@ func getLabels(m *dto.Metric) map[string]string {
 	}
 
 	return labels
+}
+
+// Helper to add a check ID and optionally a region ID to a log context.
+func withCheckID(ctx zerolog.Context, checkID int64) zerolog.Context {
+	if localID, regionID, err := sm.GlobalIDToLocalID(checkID); err == nil {
+		ctx = ctx.Int("region_id", regionID)
+		checkID = localID
+	}
+	return ctx.Int64("check_id", checkID)
 }

--- a/pkg/pb/pb.go
+++ b/pkg/pb/pb.go
@@ -1,4 +1,4 @@
-// package pb is empty and exists only to express build dependencies for
+// Package pb is empty and exists only to express build dependencies for
 // protocol buffers code generation and to provide a nice clean way to
 // obtain the location of the subpackages using "go list".
 package pb

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -190,7 +190,7 @@ func (c Check) Type() CheckType {
 }
 
 func (c Check) Validate() error {
-	if c.TenantId == 0 {
+	if c.TenantId == BadID {
 		return ErrInvalidTenantId
 	}
 	if len(c.Probes) == 0 {

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package synthetic_monitoring provides access to types and methods
+// Package synthetic_monitoring provides access to types and methods
 // that allow for the production and consumption of protocol buffer
 // messages used to communicate with synthetic-monitoring-api.
 package synthetic_monitoring
@@ -190,7 +190,7 @@ func (c Check) Type() CheckType {
 }
 
 func (c Check) Validate() error {
-	if c.TenantId < 0 {
+	if c.TenantId == 0 {
 		return ErrInvalidTenantId
 	}
 	if len(c.Probes) == 0 {

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -18,6 +18,8 @@ func TestCheckValidate(t *testing.T) {
 	}{
 		"trivial ping": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "127.0.0.1",
 				Job:       "job",
 				Frequency: 1000,
@@ -31,7 +33,8 @@ func TestCheckValidate(t *testing.T) {
 		},
 		"invalid tenant": {
 			input: Check{
-				TenantId:  -1,
+				Id:        1,
+				TenantId:  BadID,
 				Target:    "127.0.0.1",
 				Job:       "job",
 				Frequency: 1000,
@@ -45,6 +48,8 @@ func TestCheckValidate(t *testing.T) {
 		},
 		"invalid label": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "127.0.0.1",
 				Job:       "job",
 				Frequency: 1000,
@@ -59,6 +64,8 @@ func TestCheckValidate(t *testing.T) {
 		},
 		"duplicate label names": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "127.0.0.1",
 				Job:       "job",
 				Frequency: 1000,
@@ -76,6 +83,8 @@ func TestCheckValidate(t *testing.T) {
 		},
 		"duplicate label values": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "127.0.0.1",
 				Job:       "job",
 				Frequency: 1000,
@@ -93,6 +102,8 @@ func TestCheckValidate(t *testing.T) {
 		},
 		"multiple settings": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "127.0.0.1",
 				Job:       "job",
 				Frequency: 1000,
@@ -108,6 +119,8 @@ func TestCheckValidate(t *testing.T) {
 		},
 		"valid timeout & frequency": { // test for case when frequency > max timeout
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "127.0.0.1",
 				Job:       "job",
 				Frequency: 60000, // 60 seconds
@@ -121,6 +134,8 @@ func TestCheckValidate(t *testing.T) {
 		},
 		"invalid timeout": { // issue #101
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "127.0.0.1",
 				Job:       "job",
 				Frequency: 1000,
@@ -134,6 +149,8 @@ func TestCheckValidate(t *testing.T) {
 		},
 		"invalid HTTP target": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "ftp://example.org/",
 				Job:       "job",
 				Frequency: 1000,
@@ -148,6 +165,8 @@ func TestCheckValidate(t *testing.T) {
 		},
 		"valid proxy URL": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "http://example.org/",
 				Job:       "job",
 				Frequency: 1000,
@@ -163,6 +182,8 @@ func TestCheckValidate(t *testing.T) {
 		},
 		"valid proxy URL and headers": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "http://example.org/",
 				Job:       "job",
 				Frequency: 1000,
@@ -179,6 +200,8 @@ func TestCheckValidate(t *testing.T) {
 		},
 		"proxy headers without url": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "http://example.org/",
 				Job:       "job",
 				Frequency: 1000,
@@ -209,6 +232,8 @@ func TestCheckType(t *testing.T) {
 	}{
 		"dns": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "www.example.org",
 				Job:       "job",
 				Frequency: 1000,
@@ -224,6 +249,8 @@ func TestCheckType(t *testing.T) {
 		},
 		"http": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "http://www.example.org",
 				Job:       "job",
 				Frequency: 1000,
@@ -237,6 +264,8 @@ func TestCheckType(t *testing.T) {
 		},
 		"ping": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "127.0.0.1",
 				Job:       "job",
 				Frequency: 1000,
@@ -250,6 +279,8 @@ func TestCheckType(t *testing.T) {
 		},
 		"tcp": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "127.0.0.1:9000",
 				Job:       "job",
 				Frequency: 1000,
@@ -263,6 +294,8 @@ func TestCheckType(t *testing.T) {
 		},
 		"traceroute": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "127.0.0.1",
 				Job:       "job",
 				Frequency: 120000,
@@ -277,6 +310,8 @@ func TestCheckType(t *testing.T) {
 
 		"k6": {
 			input: Check{
+				Id:        1,
+				TenantId:  1,
 				Target:    "http://www.example.org",
 				Job:       "job",
 				Frequency: 10000,

--- a/pkg/pb/synthetic_monitoring/ids.go
+++ b/pkg/pb/synthetic_monitoring/ids.go
@@ -1,0 +1,157 @@
+// Copyright 2022 Grafana Labs
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetic_monitoring
+
+import (
+	"fmt"
+	"math"
+)
+
+// This file contains methods for converting IDs for Synthetic Monitoring
+// objects (checks, tenants) from single-region (local) to region-aware IDs
+// (global). This is needed for agents that run checks for multiple
+// regions.
+//
+// As IDs are only unique within their region, we create a new space
+// of IDs (global IDs) that avoids collisions when objects from
+// different regions are handled.
+//
+// At the same time, it is necessary to undo the process and obtain
+// the region and local ID from a global ID, so that results can be
+// associated with their respective regions.
+//
+// How this works:
+//
+// Local IDs are positive, non-zero integers, assigned sequentially.
+//
+// Global IDs are negative, non-zero integers. This allows to tell them
+// apart from Local IDs easily and for both to coexist with some safety.
+// They are constructed by multiplying the original ID by 1000 (MaxRegions)
+// and then adding a unique regionID (<1000).
+//
+// For example, check with ID 1234 in region 3 will have a global ID of:
+//  -1234003
+//
+// This reduces the space of IDs available by a factor of 1000, from 63 bits
+// to 53, which is still more than enough.
+const (
+	// MaxRegions is the maximum number of regions supported.
+	MaxRegions = 1000
+
+	// MinRegionID is the minimum valid region ID.
+	MinRegionID = 1
+
+	// MaxRegionID is the maximum valid region ID.
+	MaxRegionID = MaxRegions - 1
+
+	// BadID is the ID value that is not valid in any case
+	// (as global, local or region ID).
+	BadID = 0
+
+	// MinLocalID is the smallest local ID, as 0 is not valid.
+	MinLocalID = 1
+
+	// MaxLocalID is the maximum value allowed for a local ID.
+	// This is the largest positive integer that can be multiplied
+	// by 1000 and 999 added to it and still fit in an int64.
+	// MaxLocalID = 9_223_372_036_854_774
+	MaxLocalID = (math.MaxInt64 / MaxRegions) - 1
+
+	// MaxGlobalID is the maximum value a global ID can hold.
+	// It is the equivalent to (MinLocalID, MinRegionID)
+	// MaxGlobalID = -1001
+	MaxGlobalID = -(MinLocalID*MaxRegions + MinRegionID)
+
+	// MinGlobalID is the minimum value a GlobalID can hold.
+	// MinGlobalID = -9_223_372_036_854_774_999
+	MinGlobalID = -(MaxLocalID*MaxRegions + MaxRegionID)
+)
+
+// IsGlobalIDValid returns true if an ID is Global, false otherwise.
+func IsGlobalIDValid(id int64) bool {
+	return MinGlobalID <= id && id <= MaxGlobalID
+}
+
+// IsRegionIDValid checks that a region ID is within bounds.
+func IsRegionIDValid(id int) bool {
+	return MinRegionID <= id && id <= MaxRegionID
+}
+
+func IsLocalIDValid(id int64) bool {
+	return MinLocalID <= id && id <= MaxLocalID
+}
+
+// LocalIDToGlobalID converts the given localID to a global ID
+// using the given region ID.
+func LocalIDToGlobalID(localID int64, regionID int) (int64, error) {
+	if !IsLocalIDValid(localID) {
+		return BadID, BadLocalIDError(localID)
+	}
+	if !IsRegionIDValid(regionID) {
+		return BadID, BadRegionIDError(regionID)
+	}
+	return -(localID*MaxRegions + int64(regionID)), nil
+}
+
+// GlobalIDToLocalID converts a globalID back to a (local ID, region ID) pair.
+func GlobalIDToLocalID(globalID int64) (localID int64, regionID int, err error) {
+	if !IsGlobalIDValid(globalID) {
+		return BadID, BadID, BadGlobalIDError(globalID)
+	}
+	localID = -globalID / MaxRegions
+	regionID = int(-globalID % MaxRegions)
+	if !IsRegionIDValid(regionID) {
+		return BadID, BadID, BadGlobalIDError(globalID)
+	}
+	return localID, regionID, nil
+}
+
+// BadRegionIDError type is returned when an invalid region ID is used.
+type BadRegionIDError int
+
+// ID returns the ID that caused the error.
+func (n BadRegionIDError) ID() int {
+	return int(n)
+}
+
+// Error implements the error interface.
+func (n BadRegionIDError) Error() string {
+	return fmt.Sprintf("bad region ID: %d", n.ID())
+}
+
+// BadLocalIDError type is returned when an invalid local ID is used.
+type BadLocalIDError int64
+
+// ID returns the ID that caused the error.
+func (n BadLocalIDError) ID() int64 {
+	return int64(n)
+}
+
+// Error implements the error interface.
+func (n BadLocalIDError) Error() string {
+	return fmt.Sprintf("bad local ID: %d", n.ID())
+}
+
+// BadGlobalIDError type is returned when an invalid global ID is used.
+type BadGlobalIDError int64
+
+// ID returns the ID that caused the error.
+func (n BadGlobalIDError) ID() int64 {
+	return int64(n)
+}
+
+// Error implements the error interface.
+func (n BadGlobalIDError) Error() string {
+	return fmt.Sprintf("bad global ID: %d", n.ID())
+}

--- a/pkg/pb/synthetic_monitoring/ids_test.go
+++ b/pkg/pb/synthetic_monitoring/ids_test.go
@@ -50,7 +50,6 @@ func TestLocalIDToGlobalID(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			//t.Parallel()
 			result, err := LocalIDToGlobalID(test.localID, test.regionID)
 			require.Equal(t, test.err, err)
 			require.Equal(t, test.expected, result)

--- a/pkg/pb/synthetic_monitoring/ids_test.go
+++ b/pkg/pb/synthetic_monitoring/ids_test.go
@@ -1,0 +1,118 @@
+package synthetic_monitoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalIDToGlobalID(t *testing.T) {
+	for name, test := range map[string]struct {
+		localID  int64
+		regionID int
+		expected int64
+		err      error
+	}{
+		"simple": {
+			localID:  1234,
+			regionID: 3,
+			expected: -1234_003,
+		},
+		"min": {
+			localID:  MinLocalID,
+			regionID: MinRegionID,
+			expected: MaxGlobalID,
+		},
+		"max": {
+			localID:  MaxLocalID,
+			regionID: MaxRegionID,
+			expected: MinGlobalID,
+		},
+		"bad local ID": {
+			localID:  BadID,
+			regionID: 3,
+			err:      BadLocalIDError(BadID),
+		},
+		"global as local": {
+			localID:  -1234003,
+			regionID: 1,
+			err:      BadLocalIDError(-1234003),
+		},
+		"bad region ID": {
+			localID:  1234,
+			regionID: BadID,
+			err:      BadRegionIDError(BadID),
+		},
+		"bad region ID 2": {
+			localID:  1234,
+			regionID: MaxRegionID + 1,
+			err:      BadRegionIDError(MaxRegionID + 1),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			//t.Parallel()
+			result, err := LocalIDToGlobalID(test.localID, test.regionID)
+			require.Equal(t, test.err, err)
+			require.Equal(t, test.expected, result)
+			if test.err == nil {
+				require.True(t, IsLocalIDValid(test.localID))
+				require.True(t, IsRegionIDValid(test.regionID))
+				require.True(t, IsGlobalIDValid(result))
+			} else {
+				require.False(t, IsGlobalIDValid(result))
+				require.False(t, IsLocalIDValid(test.localID) && IsRegionIDValid(test.regionID))
+			}
+		})
+	}
+}
+
+func TestGlobalIDToLocalID(t *testing.T) {
+	for name, test := range map[string]struct {
+		globalID int64
+		regionID int
+		localID  int64
+		err      error
+	}{
+		"simple": {
+			globalID: -1234_003,
+			localID:  1234,
+			regionID: 3,
+		},
+		"min": {
+			globalID: MaxGlobalID,
+			localID:  MinLocalID,
+			regionID: MinRegionID,
+		},
+		"max": {
+			globalID: MinGlobalID,
+			localID:  MaxLocalID,
+			regionID: MaxRegionID,
+		},
+		"local as global": {
+			globalID: 3,
+			err:      BadGlobalIDError(3),
+		},
+		"invalid global": {
+			globalID: -3000, // Region ID == 0
+			err:      BadGlobalIDError(-3000),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			local, region, err := GlobalIDToLocalID(test.globalID)
+			require.Equal(t, test.err, err)
+			require.Equal(t, test.localID, local)
+			require.Equal(t, test.regionID, region)
+			if test.err == nil {
+				require.True(t, IsGlobalIDValid(test.globalID))
+				require.True(t, IsLocalIDValid(test.localID))
+				require.True(t, IsRegionIDValid(test.regionID))
+				gID, err2 := LocalIDToGlobalID(local, region)
+				require.NoError(t, err2)
+				require.Equal(t, test.globalID, gID)
+			} else {
+				require.False(t, IsLocalIDValid(test.localID))
+				require.False(t, IsRegionIDValid(test.regionID))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Updates the agent to support checks and tenants that use global IDs (IDs that are valid accross different deployment regions).

This allows the agent to run checks for different regions without risk of collisions.

Signed-off-by: Adrian Serrano <adrisr83@gmail.com>