### PR TITLE
Fix: do not resolve target in http with proxy

### DIFF
--- a/internal/prober/http/http.go
+++ b/internal/prober/http/http.go
@@ -146,6 +146,12 @@ func settingsToModule(ctx context.Context, settings *sm.HttpSettings, logger zer
 		return m, err
 	}
 
+	// Set BBE's SkipResolvePhaseWithProxy when a proxy is configured to avoid resolving the target.
+	// DNS should be done at the proxy server only.
+	if m.HTTP.HTTPClientConfig.ProxyURL.URL != nil {
+		m.HTTP.SkipResolvePhaseWithProxy = true
+	}
+
 	if settings.Oauth2Config != nil && settings.Oauth2Config.ClientId != "" {
 		var err error
 		m.HTTP.HTTPClientConfig.OAuth2, err = convertOAuth2Config(ctx, settings.Oauth2Config, logger.With().Str("prober", m.Prober).Logger())

--- a/internal/prober/http/http_test.go
+++ b/internal/prober/http/http_test.go
@@ -394,6 +394,7 @@ func TestSettingsToModule(t *testing.T) {
 			expected: getDefaultModule().
 				setProxyUrl("http://example.org/").
 				setProxyConnectHeaders(map[string]string{"h1": "v1", "h2": "v2"}).
+				setSkipResolvePhaseWithProxy(true).
 				getConfigModule(),
 		},
 	}
@@ -508,5 +509,10 @@ func (m *testModule) setProxyConnectHeaders(headers map[string]string) *testModu
 	for k, v := range headers {
 		m.HTTP.HTTPClientConfig.ProxyConnectHeader[k] = []httpConfig.Secret{httpConfig.Secret(v)}
 	}
+	return m
+}
+
+func (m *testModule) setSkipResolvePhaseWithProxy(value bool) *testModule {
+	m.HTTP.SkipResolvePhaseWithProxy = value
 	return m
 }


### PR DESCRIPTION
Disables the DNS resolution phase in the agent so that DNS is performed at the HTTP proxy.

This prevents checks to fail when the agent doesn't have DNS access.

Also it will cause dns metrics not to be reported when an HTTP proxy is configured.