### PR TITLE
Fix: use proxy values from environment in metrics publisher

### DIFF
--- a/internal/pkg/prom/prom.go
+++ b/internal/pkg/prom/prom.go
@@ -255,6 +255,7 @@ func newRoundTripperFromConfig(cfg HTTPClientConfig, name string, disableKeepAli
 			IdleConnTimeout:       5 * time.Minute,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
+			Proxy:                 http.ProxyFromEnvironment,
 			DialContext: conntrack.NewDialContextFunc(
 				conntrack.DialWithTracing(),
 				conntrack.DialWithName(name),


### PR DESCRIPTION
We are using a custom transport to publish metrics and logs to the remote databases. Because of that, in order to use a proxy specified in the environment, we need to pass a proxy function.