### PR TITLE
Add multihttp check type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/go-ping/ping v1.1.0
 	github.com/gogo/status v1.1.1
 	github.com/jpillora/backoff v1.0.0
+	github.com/mccutchen/go-httpbin/v2 v2.8.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.22
 	kernel.org/pub/linux/libs/security/libcap/cap v1.2.68
 )

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp9
 github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/mccutchen/go-httpbin/v2 v2.8.0 h1:5Ld/mII532zWV6Dn9UpOUZebfD8chkYmx3UIW3VZET8=
+github.com/mccutchen/go-httpbin/v2 v2.8.0/go.mod h1:+DBHcmg6EOeoizuiOI8iL12VIHXx+9YQNlz+gjB9uxk=
 github.com/miekg/dns v1.1.54 h1:5jon9mWcb0sFJGpnI99tOMhCPyJ+RPVz5b63MQG0VWI=
 github.com/miekg/dns v1.1.54/go.mod h1:uInx36IzPl7FYnDcMeVWxj9byh7DutNykX4G9Sj60FY=
 github.com/mmcloughlin/geohash v0.10.0 h1:9w1HchfDfdeLc+jFEf/04D27KP7E2QmpDu52wPbJWRE=

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -794,6 +794,14 @@ func (c *Updater) addAndStartScraperWithLock(ctx context.Context, check sm.Check
 			return nil
 		}
 
+	case sm.CheckTypeMultiHttp:
+		// This is correct, MultiHttp is a K6 check. We probably want
+		// to abstrct this by adding a function to the settings that
+		// returns whether the check requires k6 or not.
+		if !c.features.IsSet(feature.K6) {
+			return nil
+		}
+
 	default:
 	}
 

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -1,0 +1,74 @@
+package multihttp
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+)
+
+const proberName = "multi_http"
+
+var errUnsupportedCheck = errors.New("unsupported check")
+
+type Module struct {
+	Prober  string
+	Timeout time.Duration
+}
+
+type Prober struct {
+	logger zerolog.Logger
+	config Module
+	runner *runner
+}
+
+func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger) (Prober, error) {
+	var p Prober
+
+	if check.Settings.Multihttp == nil {
+		return p, errUnsupportedCheck
+	}
+
+	if err := check.Settings.Multihttp.Validate(); err != nil {
+		return p, err
+	}
+
+	p.config = settingsToModule(check.Settings.Multihttp)
+	p.config.Timeout = time.Duration(check.Timeout) * time.Millisecond
+
+	r, err := newRunner(check.Settings.Multihttp)
+	if err != nil {
+		return p, err
+	}
+
+	p.runner = r
+	p.logger = logger
+
+	return p, nil
+}
+
+func (p Prober) Name() string {
+	return proberName
+}
+
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+	err := p.runner.Run(ctx, registry, logger, p.logger)
+	if err != nil {
+		p.logger.Warn().Err(err).Msg("running probe")
+		return false
+	}
+
+	return true
+}
+
+func settingsToModule(settings *sm.MultiHttpSettings) Module {
+	var m Module
+
+	m.Prober = sm.CheckTypeMultiHttp.String()
+
+	return m
+}

--- a/internal/prober/multihttp/multihttp_test.go
+++ b/internal/prober/multihttp/multihttp_test.go
@@ -1,0 +1,100 @@
+package multihttp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProber(t *testing.T) {
+	ctx, cancel := testContext(t)
+	t.Cleanup(cancel)
+
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+
+	testcases := map[string]struct {
+		check         synthetic_monitoring.Check
+		expectFailure bool
+	}{
+		"valid": {
+			expectFailure: false,
+			check: synthetic_monitoring.Check{
+				Target:    "http://www.example.org",
+				Job:       "test",
+				Frequency: 10 * 1000,
+				Timeout:   10 * 1000,
+				Probes:    []int64{1},
+				Settings: synthetic_monitoring.CheckSettings{
+					Multihttp: &synthetic_monitoring.MultiHttpSettings{
+						Entries: []*synthetic_monitoring.MultiHttpEntry{
+							{
+								Request: &synthetic_monitoring.MultiHttpEntryRequest{
+									Url: "http://www.example.org",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"settings must be valid": {
+			expectFailure: true,
+			check: synthetic_monitoring.Check{
+				Target:    "http://www.example.org",
+				Job:       "test",
+				Frequency: 10 * 1000,
+				Timeout:   10 * 1000,
+				Probes:    []int64{1},
+				Settings: synthetic_monitoring.CheckSettings{
+					Multihttp: &synthetic_monitoring.MultiHttpSettings{
+						Entries: []*synthetic_monitoring.MultiHttpEntry{
+							// This is invalid because the requsest does not have a URL
+							{},
+						},
+					},
+				},
+			},
+		},
+		"must contain multihttp settings": {
+			expectFailure: true,
+			check: synthetic_monitoring.Check{
+				Target:    "http://www.example.org",
+				Job:       "test",
+				Frequency: 10 * 1000,
+				Timeout:   10 * 1000,
+				Probes:    []int64{1},
+				Settings: synthetic_monitoring.CheckSettings{
+					// The settings are valid for ping, but not for multihttp
+					Ping: &synthetic_monitoring.PingSettings{},
+				},
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			p, err := NewProber(ctx, tc.check, logger)
+			if tc.expectFailure {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, proberName, p.config.Prober)
+			require.Equal(t, 10*time.Second, p.config.Timeout)
+			// TODO: check script
+		})
+	}
+}
+
+func testContext(t *testing.T) (context.Context, func()) {
+	if deadline, ok := t.Deadline(); ok {
+		return context.WithDeadline(context.Background(), deadline)
+	}
+
+	return context.WithTimeout(context.Background(), 10*time.Second)
+}

--- a/internal/prober/multihttp/runner.go
+++ b/internal/prober/multihttp/runner.go
@@ -1,0 +1,192 @@
+package multihttp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/go-logfmt/logfmt"
+	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"github.com/rs/zerolog"
+)
+
+type runner struct {
+	script []byte
+}
+
+func newRunner(settings *sm.MultiHttpSettings) (*runner, error) {
+	// convert settings to script
+
+	script, err := settingsToScript(settings)
+	if err != nil {
+		return nil, fmt.Errorf("converting settings to script: %w", err)
+	}
+
+	r := runner{
+		script: script,
+	}
+
+	return &r, nil
+}
+
+type requestError struct {
+	Err     string `json:"error"`
+	Message string `json:"msg"`
+}
+
+var _ error = requestError{}
+
+func (r requestError) Error() string {
+	return fmt.Sprintf("%s: %s", r.Err, r.Message)
+}
+
+type requestResult struct {
+	Metrics []byte `json:"metrics"`
+	Logs    []byte `json:"logs"`
+}
+
+func (r runner) Run(ctx context.Context, registry *prometheus.Registry, logger logger.Logger, internalLogger zerolog.Logger) error {
+	resp, err := http.Post("http://localhost:4054/run", "application/json", bytes.NewBuffer(r.script))
+	if err != nil {
+		internalLogger.Error().Err(err).Msg("sending request")
+		return fmt.Errorf("running script: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	dec := json.NewDecoder(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		var result requestError
+
+		err := dec.Decode(&result)
+		if err != nil {
+			internalLogger.Error().Err(err).Msg("decoding request response")
+			return fmt.Errorf("running script: %w", err)
+		}
+
+		internalLogger.Error().Err(result).Msg("request response")
+		return fmt.Errorf("running script: %w", result)
+	}
+
+	var result requestResult
+
+	err = dec.Decode(&result)
+	if err != nil {
+		internalLogger.Error().Err(err).Msg("decoding script result")
+		return fmt.Errorf("decoding script result: %w", err)
+	}
+
+	// here we have metrics in text format and logs in logfmt format.
+
+	if err := textToRegistry(result.Metrics, registry, internalLogger); err != nil {
+		internalLogger.Debug().
+			Err(err).
+			Msg("cannot add metrics to registry")
+		return err
+	}
+
+	if err := k6LogsToLogger(result.Logs, logger); err != nil {
+		internalLogger.Debug().
+			Err(err).
+			Msg("cannot load logs to logger")
+		return err
+	}
+
+	return nil
+}
+
+func textToRegistry(metrics []byte, registry *prometheus.Registry, logger zerolog.Logger) error {
+	promDecoder := expfmt.NewDecoder(bytes.NewBuffer(metrics), expfmt.FmtText)
+	for {
+		var mf dto.MetricFamily
+		switch err := promDecoder.Decode(&mf); err {
+		case nil:
+			// Got one metric family
+			samples, err := expfmt.ExtractSamples(nil, &mf)
+			if err != nil {
+				logger.Error().Err(err).Msg("extracting samples")
+				return fmt.Errorf("extracting samples: %w", err)
+			}
+
+			for _, sample := range samples {
+				// TODO(mem): This is really crappy. We have a
+				// set of metric families, and we are
+				// converting back to samples to that we can
+				// add that to the registry. We need to rework
+				// the logic in the prober so that it can
+				// return a set of metric families. The probes
+				// that don't have this, can create a registry
+				// locally and get the metric families from
+				// that.
+				name, found := sample.Metric[model.MetricNameLabel]
+				if !found {
+					logger.Error().Err(err).Msg("missing metric name")
+					return fmt.Errorf("missing metric name")
+				}
+
+				delete(sample.Metric, model.MetricNameLabel)
+
+				g := prometheus.NewGauge(prometheus.GaugeOpts{
+					Name:        string(name),
+					ConstLabels: metricToLabels(sample.Metric),
+				})
+
+				err := registry.Register(g)
+				if err != nil {
+					return err
+				}
+
+				g.Set(float64(sample.Value))
+			}
+
+		case io.EOF:
+			// nothing was returned, we are done
+			return nil
+
+		default:
+			logger.Error().Err(err).Msg("decoding prometheus metrics")
+			return fmt.Errorf("decoding prometheus metrics: %w", err)
+		}
+	}
+}
+
+func metricToLabels(metrics model.Metric) prometheus.Labels {
+	// Ugh.
+	labels := make(prometheus.Labels)
+	for name, value := range metrics {
+		labels[string(name)] = string(value)
+	}
+	return labels
+}
+
+func k6LogsToLogger(logs []byte, logger logger.Logger) error {
+	// This seems a little silly, we should be able to take the out of k6
+	// and pass it directly to Loki. The problem with that is that the only
+	// thing probers have access to is the logger.Logger.
+	//
+	// We could pass another object to the prober, that would take Loki log
+	// entries, and the publisher could decorate that with the necessary
+	// labels.
+	dec := logfmt.NewDecoder(bytes.NewBuffer(logs))
+
+	for dec.ScanRecord() {
+		var line []interface{}
+		for dec.ScanKeyval() {
+			key := dec.Key()
+			value := dec.Value()
+			line = append(line, string(key), string(value))
+		}
+		_ = logger.Log(line...)
+	}
+
+	return nil
+}

--- a/internal/prober/multihttp/script.tmpl
+++ b/internal/prober/multihttp/script.tmpl
@@ -1,0 +1,63 @@
+import http from 'k6/http';
+import { check, fail } from 'k6';
+// TODO(mem): import jsonpath if there are json assertions
+import jsonpath from 'https://jslib.k6.io/jsonpath/1.0.2/index.js'
+
+export const options = {
+	scenarios: {
+		default: {
+			executor: 'shared-iterations',
+			tags: {
+				// TODO(mem): build tags out of options for the check?
+				environment: 'production',
+			},
+			// exec: 'runner',
+			maxDuration: '10s', // TODO(mem): this would be the timeout for the check
+			gracefulStop: '1s',
+		},
+	},
+
+	dns: {
+		ttl: '2m', // TODO(mem): this doesn't need to be much higher than the maxDuration
+		select: 'first',
+		// TODO(mem): we can build this maps to IP option in checks, more or less
+		policy: 'preferIPv4', // preferIPv6, onlyIPv4, onlyIPv6, any
+	},
+
+	// TODO(mem): we can build this out of check options
+	insecureSkipTLSVerify: false,
+	tlsVersion: {
+		// TODO(mem): we can build this out of check options
+		min: 'tls1.2',
+		max: 'tls1.3',
+	},
+	// TODO(mem): we can build this out of agent version
+	userAgent: 'synthetic-monitoring-agent/v0.14.3 (linux amd64; g64b8bab; +https://github.com/grafana/synthetic-monitoring-agent)',
+
+	maxRedirects: 10,
+	blacklistIPs: ['10.0.0.0/8'],
+	blockHostnames: ['*.cluster.local'],
+
+	// k6 options
+	vus: 1,
+	// linger: false,
+	summaryTimeUnit: 's',
+	discardResponseBodies: false, // enable only if there are checks?
+};
+
+export default function() {
+	let response;
+	const vars = {};
+
+	{{ range .Entries }}
+	response = http.request('{{ .Request.Method }}', '{{ buildUrl .Request }}', null, {
+		// TODO(mem): build params out of options for the check
+		redirects: 0,{{ if gt (len .Request.Headers) 0 }}
+		headers: {{ buildHeaders .Request.Headers }}{{ end }}
+	});
+	{{ range .Assertions }}{{ buildChecks . }}
+	{{ end -}}
+	{{ range .Variables }}{{ buildVars . }}
+	{{ end -}}
+	{{ end }}
+}

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -1,0 +1,500 @@
+package multihttp
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/mccutchen/go-httpbin/v2/httpbin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildUrl(t *testing.T) {
+	testcases := map[string]struct {
+		request  sm.MultiHttpEntryRequest
+		expected string
+	}{
+		"trivial": {
+			request: sm.MultiHttpEntryRequest{
+				Url: "https://www.example.org/",
+			},
+			expected: "https://www.example.org/",
+		},
+		"with query fields": {
+			request: sm.MultiHttpEntryRequest{
+				Url: "https://www.example.org/",
+				QueryFields: []*sm.QueryField{
+					{
+						Name:  "q",
+						Value: "hello",
+					},
+				},
+			},
+			expected: "https://www.example.org/?q\\u003Dhello",
+		},
+		"query without value": {
+			request: sm.MultiHttpEntryRequest{
+				Url: "https://www.example.org/",
+				QueryFields: []*sm.QueryField{
+					{
+						Name:  "q",
+						Value: "",
+					},
+				},
+			},
+			expected: "https://www.example.org/?q",
+		},
+		"query needs encoding": {
+			request: sm.MultiHttpEntryRequest{
+				Url: "https://www.example.org/",
+				QueryFields: []*sm.QueryField{
+					{
+						Name:  "p&q",
+						Value: "a b",
+					},
+				},
+			},
+			expected: "https://www.example.org/?p%26q\\u003Da+b",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := buildUrl(&tc.request)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestBuildHeaders(t *testing.T) {
+	testcases := map[string]struct {
+		input    []*sm.HttpHeader
+		expected string
+	}{
+		"one header": {
+			input: []*sm.HttpHeader{
+				{
+					Name:  "Content-Type",
+					Value: "application/json",
+				},
+			},
+			expected: `{'Content-Type':'application/json'}`,
+		},
+		"two headers": {
+			input: []*sm.HttpHeader{
+				{
+					Name:  "Content-Type",
+					Value: "application/json",
+				},
+				{
+					Name:  "Accept",
+					Value: "text/html",
+				},
+			},
+			expected: `{'Content-Type':'application/json','Accept':'text/html'}`,
+		},
+		"blank value": {
+			input: []*sm.HttpHeader{
+				{
+					Name:  "Content-Type",
+					Value: "",
+				},
+			},
+			expected: `{'Content-Type':''}`,
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := buildHeaders(testcase.input)
+			require.Equal(t, testcase.expected, actual)
+		})
+	}
+}
+
+func TestAssertionConditionName(t *testing.T) {
+	testcases := map[string]struct {
+		condition sm.MultiHttpEntryAssertionConditionVariant
+		subject   string
+		value     string
+		expected  string
+	}{
+		"TestAssertionConditionNameNotContains": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_NOT_CONTAINS,
+			subject:   "subject",
+			value:     "value",
+			expected:  "subject does not contain \"value\"",
+		},
+		"TestAssertionConditionNameContains": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+			subject:   "subject",
+			value:     "value",
+			expected:  "subject contains \"value\"",
+		},
+		"TestAssertionConditionNameEquals": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+			subject:   "subject",
+			value:     "value",
+			expected:  "subject equals \"value\"",
+		},
+		"TestAssertionConditionNameStartsWith": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_STARTS_WITH,
+			subject:   "subject",
+			value:     "value",
+			expected:  "subject starts with \"value\"",
+		},
+		"TestAssertionConditionNameEndsWith": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_ENDS_WITH,
+			subject:   "subject",
+			value:     "value",
+			expected:  "subject ends with \"value\"",
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			var b strings.Builder
+			cond := assertionCondition(testcase.condition)
+			cond.Name(&b, testcase.subject, testcase.value)
+			require.Equal(t, testcase.expected, b.String())
+		})
+	}
+}
+
+func TestAssertionConditionRender(t *testing.T) {
+	testcases := map[string]struct {
+		condition sm.MultiHttpEntryAssertionConditionVariant
+		subject   string
+		value     string
+		expected  string
+	}{
+		"TestAssertionConditionRenderNotContains": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_NOT_CONTAINS,
+			subject:   "subject",
+			value:     "val'ue",
+			expected:  "!subject.includes('val\\'ue')",
+		},
+		"TestAssertionConditionRenderContains": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+			subject:   "subject",
+			value:     "val'ue",
+			expected:  "subject.includes('val\\'ue')",
+		},
+		"TestAssertionConditionRenderEquals": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+			subject:   "subject",
+			value:     "val'ue",
+			expected:  "subject === 'val\\'ue'",
+		},
+		"TestAssertionConditionRenderStartsWith": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_STARTS_WITH,
+			subject:   "subject",
+			value:     "val'ue",
+			expected:  "subject.startsWith('val\\'ue')",
+		},
+		"TestAssertionConditionRenderEndsWith": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_ENDS_WITH,
+			subject:   "subject",
+			value:     "val'ue",
+			expected:  "subject.endsWith('val\\'ue')",
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			var b strings.Builder
+			cond := assertionCondition(testcase.condition)
+			cond.Render(&b, testcase.subject, testcase.value)
+			require.Equal(t, testcase.expected, b.String())
+		})
+	}
+}
+
+func TestBuildChecks(t *testing.T) {
+	testcases := map[string]struct {
+		assertion *sm.MultiHttpEntryAssertion
+		expected  string
+	}{
+		"TestBuildChecksTextAssertionWithBodySubject": {
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:      sm.MultiHttpEntryAssertionType_TEXT,
+				Condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+				Subject:   sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_BODY,
+				Value:     "value",
+			},
+			expected: `check(response, { 'body contains "value"': response => response.body.includes('value') });`,
+		},
+		"TestBuildChecksTextAssertionWithHeadersSubject": {
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:      sm.MultiHttpEntryAssertionType_TEXT,
+				Condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+				Subject:   sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_HEADERS,
+				Value:     "value",
+			},
+			expected: `check(response, { 'header contains "value"': response => { const values = Object.entries(response.headers).map((key, value) => key + ': ' + value); return !!values.find(value => value.includes('value')); } });`,
+		},
+		"TestBuildChecksTextAssertionWithStatusCodeSubject": {
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:      sm.MultiHttpEntryAssertionType_TEXT,
+				Condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+				Subject:   sm.MultiHttpEntryAssertionSubjectVariant_HTTP_STATUS_CODE,
+				Value:     "value",
+			},
+			expected: `check(response, { 'status code contains "value"': response => response.status.toString().includes('value') });`,
+		},
+		"TestBuildChecksJsonPathValueAssertionWithBodySubject": {
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_VALUE,
+				Condition:  sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+				Subject:    sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_BODY,
+				Expression: "/path/to/value",
+				Value:      "value",
+			},
+			expected: `check(response, { '/path/to/value contains "value"': response => jsonpath.query(response.json(), '/path/to/value').some(values => values.includes('value')) });`,
+		},
+		"TestBuildChecksJsonPathAssertionWithBodySubject": {
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_ASSERTION,
+				Subject:    sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_BODY,
+				Expression: "/path/to/value",
+			},
+			expected: `check(response, { '/path/to/value exists': response => jsonpath.query(response.json(), '/path/to/value').length > 0 });`,
+		},
+		"TestBuildChecksRegexAssertionWithBodySubject": {
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:       sm.MultiHttpEntryAssertionType_REGEX_ASSERTION,
+				Subject:    sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_BODY,
+				Expression: "regex",
+			},
+			expected: `check(response, { 'body matches /regex/': response => { const expr = new RegExp('regex'); return expr.test(response.body); } });`,
+		},
+		"TestBuildChecksRegexAssertionWithHeadersSubject": {
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:       sm.MultiHttpEntryAssertionType_REGEX_ASSERTION,
+				Subject:    sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_HEADERS,
+				Expression: "regex",
+			},
+			expected: `check(response, { 'headers matches /regex/': response => { const expr = new RegExp('regex'); const values = Object.entries(response.headers).map((key, value) => key + ': ' + value); return !!values.find(value => expr.test(value)); } });`,
+		},
+		"TestBuildChecksRegexAssertionWithStatusCodeSubject": {
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:       sm.MultiHttpEntryAssertionType_REGEX_ASSERTION,
+				Subject:    sm.MultiHttpEntryAssertionSubjectVariant_HTTP_STATUS_CODE,
+				Expression: "regex",
+			},
+			expected: `check(response, { 'status matches /regex/': response => { const expr = new RegExp('regex'); return expr.test(response.status.toString()); } });`,
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := buildChecks(testcase.assertion)
+			require.Equal(t, testcase.expected, actual)
+		})
+	}
+}
+
+func TestBuildVars(t *testing.T) {
+	testcases := map[string]struct {
+		input    sm.MultiHttpEntryVariable
+		expected string
+	}{
+		"TestBuildVarsJsonPath": {
+			input: sm.MultiHttpEntryVariable{
+				Name:       "name",
+				Type:       sm.MultiHttpEntryVariableType_JSON_PATH,
+				Expression: "jsonPath",
+			},
+			expected: `vars['name'] = jsonpath.query(response.json(), 'jsonPath')[0];`,
+		},
+		"TestBuildVarsRegex": {
+			input: sm.MultiHttpEntryVariable{
+				Name:       "name",
+				Type:       sm.MultiHttpEntryVariableType_REGEX,
+				Expression: "regex",
+			},
+			expected: `match = new RegExp('regex').exec(response.body); vars['name'] = match ? match[1] || match[0] : null;`,
+		},
+		"TestBuildVarsCssSelector": {
+			input: sm.MultiHttpEntryVariable{
+				Name:       "name",
+				Type:       sm.MultiHttpEntryVariableType_CSS_SELECTOR,
+				Expression: "cssSelector",
+			},
+			expected: `vars['name'] = response.html().find('cssSelector').html();`,
+		},
+		"TestBuildVarsCssSelectorWithAttribute": {
+			input: sm.MultiHttpEntryVariable{
+				Name:       "name",
+				Type:       sm.MultiHttpEntryVariableType_CSS_SELECTOR,
+				Expression: "cssSelector",
+				Attribute:  "attribute",
+			},
+			expected: `vars['name'] = response.html().find('cssSelector').first().attr('attribute');`,
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := buildVars(&testcase.input)
+			require.Equal(t, testcase.expected, actual)
+		})
+	}
+}
+
+// TestSettingsToScript tests the conversion of a MultiHttpSettings to a
+// Javascript script.
+func TestSettingsToScript(t *testing.T) {
+	testServer := httptest.NewServer(httpbin.New())
+	t.Cleanup(testServer.Close)
+
+	settings := &sm.MultiHttpSettings{
+		Entries: []*sm.MultiHttpEntry{
+			{
+				Request: &sm.MultiHttpEntryRequest{
+					Method: sm.HttpMethod_GET,
+					Url:    testServer.URL + "/response-headers?foo=bar",
+				},
+				Assertions: []*sm.MultiHttpEntryAssertion{
+					{
+						Type:      sm.MultiHttpEntryAssertionType_TEXT,
+						Subject:   sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_BODY,
+						Condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+						Value:     "httpbin",
+					},
+					{
+						Type:      sm.MultiHttpEntryAssertionType_TEXT,
+						Subject:   sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_HEADERS,
+						Condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+						Value:     "foo: bar",
+					},
+				},
+			},
+			{
+				Request: &sm.MultiHttpEntryRequest{
+					Method: sm.HttpMethod_GET,
+					Url:    testServer.URL + "/status/266",
+				},
+				Assertions: []*sm.MultiHttpEntryAssertion{
+					{
+						Type:      sm.MultiHttpEntryAssertionType_TEXT,
+						Subject:   sm.MultiHttpEntryAssertionSubjectVariant_HTTP_STATUS_CODE,
+						Condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+						Value:     "266",
+					},
+				},
+			},
+			{
+				Request: &sm.MultiHttpEntryRequest{
+					Method: sm.HttpMethod_GET,
+					Url:    testServer.URL + "/json",
+				},
+				Assertions: []*sm.MultiHttpEntryAssertion{
+					{
+						Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_VALUE,
+						Expression: "$.slideshow.author",
+						Condition:  sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+						Value:      "Yours",
+					},
+					{
+						Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_VALUE,
+						Expression: "$.slideshow.date",
+						Condition:  sm.MultiHttpEntryAssertionConditionVariant_NOT_CONTAINS,
+						Value:      "2023",
+					},
+					{
+						Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_VALUE,
+						Expression: "$.slideshow.author",
+						Condition:  sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+						Value:      "Yours Truly",
+					},
+					{
+						Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_VALUE,
+						Expression: "$.slideshow.author",
+						Condition:  sm.MultiHttpEntryAssertionConditionVariant_STARTS_WITH,
+						Value:      "Yours",
+					},
+					{
+						Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_VALUE,
+						Expression: "$.slideshow.author",
+						Condition:  sm.MultiHttpEntryAssertionConditionVariant_ENDS_WITH,
+						Value:      "Truly",
+					},
+				},
+				Variables: []*sm.MultiHttpEntryVariable{
+					{
+						Type:       sm.MultiHttpEntryVariableType_JSON_PATH,
+						Name:       "author",
+						Expression: "$.slideshow.author",
+					},
+					{
+						Type:       sm.MultiHttpEntryVariableType_JSON_PATH,
+						Name:       "date",
+						Expression: "$.slideshow.date",
+					},
+				},
+			},
+			{
+				Request: &sm.MultiHttpEntryRequest{
+					Method: sm.HttpMethod_GET,
+					Url:    testServer.URL + "/json",
+				},
+				Assertions: []*sm.MultiHttpEntryAssertion{
+					{
+						Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_ASSERTION,
+						Expression: `$.slideshow.title`,
+					},
+				},
+			},
+			{
+				Request: &sm.MultiHttpEntryRequest{
+					Method: sm.HttpMethod_GET,
+					Url:    testServer.URL + "/html",
+				},
+				Assertions: []*sm.MultiHttpEntryAssertion{
+					{
+						Type:       sm.MultiHttpEntryAssertionType_REGEX_ASSERTION,
+						Subject:    sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_BODY,
+						Expression: "had .+ excited the curiosity of the mariners",
+					},
+					{
+						Type:       sm.MultiHttpEntryAssertionType_REGEX_ASSERTION,
+						Subject:    sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_HEADERS,
+						Expression: "Content-Type: .*; charset=utf-8",
+					},
+					{
+						Type:       sm.MultiHttpEntryAssertionType_REGEX_ASSERTION,
+						Subject:    sm.MultiHttpEntryAssertionSubjectVariant_HTTP_STATUS_CODE,
+						Expression: "2..",
+					},
+				},
+			},
+			{
+				Request: &sm.MultiHttpEntryRequest{
+					Method: sm.HttpMethod_GET,
+					Url:    testServer.URL + "/get",
+					QueryFields: []*sm.QueryField{
+						{Name: "foo", Value: "bar"},
+						{Name: "baz", Value: ""},
+					},
+				},
+			},
+			{
+				Request: &sm.MultiHttpEntryRequest{
+					Url: testServer.URL + "/gzip",
+					Headers: []*sm.HttpHeader{
+						{Name: "Accept", Value: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"},
+						{Name: "Accept-Encoding", Value: "gzip, deflate, br"},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, settings.Validate())
+
+	actual, err := settingsToScript(settings)
+	require.NoError(t, err)
+	require.NotEmpty(t, actual)
+}

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -66,6 +66,7 @@ var (
 	ErrInvalidHttpUrl             = errors.New("invalid HTTP URL")
 	ErrInvalidHttpMethodString    = errors.New("invalid HTTP method string")
 	ErrInvalidHttpMethodValue     = errors.New("invalid HTTP method value")
+	ErrInvalidHttpUrlHost         = errors.New("invalid HTTP URL host")
 	ErrInvalidHttpHeaders         = errors.New("invalid HTTP headers")
 	ErrHttpUrlContainsPassword    = errors.New("HTTP URL contains username and password")
 	ErrHttpUrlContainsUsername    = errors.New("HTTP URL contains username")
@@ -649,6 +650,10 @@ func hasUniqueValues[U any, V comparable](slice []U, fn func(U) V) bool {
 }
 
 func (e *MultiHttpEntry) Validate() error {
+	if e.Request == nil {
+		return ErrInvalidMultiHttpTargets
+	}
+
 	if err := e.Request.Validate(); err != nil {
 		return err
 	}
@@ -1152,6 +1157,10 @@ func validateHostPort(target string) error {
 }
 
 func validateHttpUrl(target string) error {
+	if len(target) != len(strings.TrimSpace(target)) {
+		return ErrInvalidHttpUrl
+	}
+
 	u, err := url.Parse(target)
 	if err != nil {
 		return ErrInvalidHttpUrl
@@ -1167,6 +1176,10 @@ func validateHttpUrl(target string) error {
 
 	if !(u.Scheme == "http" || u.Scheme == "https") {
 		return ErrInvalidHttpUrl
+	}
+
+	if len(u.Host) == 0 {
+		return ErrInvalidHostname
 	}
 
 	hasPort := func(h string) bool {

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -690,6 +690,11 @@ func TestValidateHostPort(t *testing.T) {
 			expectError: false,
 		},
 
+		"blank": {
+			input:       "",
+			expectError: true,
+		},
+
 		// invalid hosts
 		"no host": {
 			input:       ":25",
@@ -782,6 +787,15 @@ func TestValidateHttpUrl(t *testing.T) {
 		},
 		"with username and password": {
 			input:       "http://user:password@example.org/",
+			expectError: true,
+		},
+
+		"blank": {
+			input:       "",
+			expectError: true,
+		},
+		"no host": {
+			input:       "http://",
 			expectError: true,
 		},
 


### PR DESCRIPTION
This supports the multihttp check type.

This shoud be used in tandem with sm-k6-runner (the address should be specified as a command line option).