### PR TITLE
build: Don't expose drone secrets on PR builds

### DIFF
--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -263,7 +263,7 @@ local docker_publish(repo, auth, tag, os, arch, version='') =
           NFPM_SIGNING_KEY_FILE: '/drone/src/release-private-key.key',
         },
       },
-      step('test release', ['make release-snapshot']) {
+      step('test release', ['make release-snapshot']) + devAndRelease + {
         environment: {
           NFPM_DEFAULT_PASSPHRASE: { from_secret: 'gpg_passphrase' },
           NFPM_SIGNING_KEY_FILE: '/drone/src/release-private-key.key',

--- a/.drone/drone.jsonnet
+++ b/.drone/drone.jsonnet
@@ -269,7 +269,7 @@ local docker_publish(repo, auth, tag, os, arch, version='') =
           NFPM_SIGNING_KEY_FILE: '/drone/src/release-private-key.key',
         },
       },
-      step('test deb package', ['./scripts/package/verify-deb-install.sh'], image='docker') {
+      step('test deb package', ['./scripts/package/verify-deb-install.sh'], image='docker') + devAndRelease + {
         volumes: [
           {
             name: 'docker',
@@ -278,7 +278,7 @@ local docker_publish(repo, auth, tag, os, arch, version='') =
         ],
         privileged: true,
       },
-      step('test rpm package', ['./scripts/package/verify-rpm-install.sh'], image='docker') {
+      step('test rpm package', ['./scripts/package/verify-rpm-install.sh'], image='docker') + devAndRelease + {
         volumes: [
           {
             name: 'docker',

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -240,6 +240,10 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+    - refs/heads/main
+    - refs/tags/v*.*.*
 - commands:
   - ./scripts/package/verify-rpm-install.sh
   image: docker
@@ -248,6 +252,10 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
+  when:
+    ref:
+    - refs/heads/main
+    - refs/tags/v*.*.*
 - commands:
   - make release
   environment:
@@ -319,6 +327,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 0de9197ff9b89e51995ff6aa989da96d4085be28fe67a242fc404f42b58b6174
+hmac: 751d5fb2434e22d46fb36e2132c32bcb404e799e3f96517f13a719865accdc9b
 
 ...

--- a/.drone/drone.yml
+++ b/.drone/drone.yml
@@ -228,6 +228,10 @@ steps:
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
   image: golang:1.18
   name: test release
+  when:
+    ref:
+    - refs/heads/main
+    - refs/tags/v*.*.*
 - commands:
   - ./scripts/package/verify-deb-install.sh
   image: docker
@@ -315,6 +319,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: aefbf1c6a02e7bc3976ee73ad5a35538f50f55b0360f7726ef8bb5957daf040e
+hmac: 0de9197ff9b89e51995ff6aa989da96d4085be28fe67a242fc404f42b58b6174
 
 ...

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ This is the 'worker' for Grafana's [Synthetic Monitoring application](https://gi
 Please [install](https://grafana.com/grafana/plugins/grafana-synthetic-monitoring-app/installation) Synthetic Monitoring 
 in your Grafana Cloud or local Grafana instance before setting up your own private probe. You may need to generate a [new API key](https://grafana.com/profile/api-keys) to initialize the app.
 
-(Test)
 
 Probes
 ------

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is the 'worker' for Grafana's [Synthetic Monitoring application](https://gi
 Please [install](https://grafana.com/grafana/plugins/grafana-synthetic-monitoring-app/installation) Synthetic Monitoring 
 in your Grafana Cloud or local Grafana instance before setting up your own private probe. You may need to generate a [new API key](https://grafana.com/profile/api-keys) to initialize the app.
 
+(Test)
 
 Probes
 ------


### PR DESCRIPTION
Due to security reasons Drone CI secrets are not exposed when the pull request is from a fork. That is why pipeline steps requiring secrets should be skipped.