### PR TITLE
Fix: truncate long label values

### DIFF
--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1171,3 +1171,52 @@ func mergeMaps(maps ...map[string]string) map[string]string {
 	}
 	return out
 }
+
+func TestTruncateLabelValue(t *testing.T) {
+	testcases := map[string]struct {
+		length         int
+		expectedLength int
+	}{
+		"zero": {
+			length:         0,
+			expectedLength: 0,
+		},
+		"one": {
+			length:         1,
+			expectedLength: 1,
+		},
+		"max/2": {
+			length:         maxLabelValueLength / 2,
+			expectedLength: maxLabelValueLength / 2,
+		},
+		"max-1": {
+			length:         maxLabelValueLength - 1,
+			expectedLength: maxLabelValueLength - 1,
+		},
+		"max": {
+			length:         maxLabelValueLength,
+			expectedLength: maxLabelValueLength,
+		},
+		"max+1": {
+			length:         maxLabelValueLength + 1,
+			expectedLength: maxLabelValueLength,
+		},
+		"2*max": {
+			length:         2 * maxLabelValueLength,
+			expectedLength: maxLabelValueLength,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			input := strings.Repeat("a", tc.length)
+			expected := strings.Repeat("a", tc.expectedLength)
+			actual := truncateLabelValue(input)
+			require.Equal(t, len(expected), len(actual))
+			if tc.expectedLength < tc.length {
+				require.Equal(t, expected[:len(expected)-3], actual[:len(actual)-3])
+				require.Equal(t, "...", actual[len(actual)-3:])
+			}
+		})
+	}
+}


### PR DESCRIPTION
We generate some label values, so they are not being subject to the constraints the labels provided by the user are.

In order to prevent the metrics from being dropped by Prometheus because the label values exceed the limit, truncate the values that exceed the limit, and replace the last three bytes by '...' to indicate that truncation took place.

For the specific case of certificates with a really long list of Subject Alternate Names (SAN), they end up in a label. It's a list that looks like `a.example.org,b.example.org,c.example.org`. We _could_ split that list and push each individual value as a separate label value just to avoid hitting the limit. The problem with that approach is that we have seen certificates with over 700+ SANs in the wild, so this strategy would push out 700+ metrics.