### PR TITLE
Disable validating k6 path

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -278,9 +278,11 @@ func validateK6URI(uri string) error {
 			return fmt.Errorf("missing path in %q", uri)
 		}
 
-		_, err := exec.LookPath(u.Path)
-		if err != nil {
-			return err
+		if false {
+			_, err := exec.LookPath(u.Path)
+			if err != nil {
+				return err
+			}
 		}
 
 	default:


### PR DESCRIPTION
For now, we need to ignore a missing k6 binary.