### PR TITLE
Gate k6 checks on runner being configured

### DIFF
--- a/internal/prober/prober.go
+++ b/internal/prober/prober.go
@@ -70,12 +70,20 @@ func (f proberFactory) New(ctx context.Context, logger zerolog.Logger, check sm.
 		target = check.Target
 
 	case sm.CheckTypeK6:
-		p, err = k6.NewProber(ctx, check, logger, f.runner)
-		target = check.Target
+		if f.runner != nil {
+			p, err = k6.NewProber(ctx, check, logger, f.runner)
+			target = check.Target
+		} else {
+			err = fmt.Errorf("k6 checks are not enabled")
+		}
 
 	case sm.CheckTypeMultiHttp:
-		p, err = multihttp.NewProber(ctx, check, logger, f.runner)
-		target = check.Target
+		if f.runner != nil {
+			p, err = multihttp.NewProber(ctx, check, logger, f.runner)
+			target = check.Target
+		} else {
+			err = fmt.Errorf("k6 checks are not enabled")
+		}
 
 	default:
 		return nil, "", fmt.Errorf("unsupported check type")


### PR DESCRIPTION
This is not necessary because k6 checks won't be actually created unless the feature flag is enabled, but to avoid issues, prevent the creation of k6 probers unless the k6 runner is correctly configured.