### PR TITLE
Add missing check class data to ClassInfo struct

### DIFF
--- a/pkg/accounting/accounting.go
+++ b/pkg/accounting/accounting.go
@@ -74,8 +74,9 @@ func GetCheckAccountingClass(check synthetic_monitoring.Check) (string, error) {
 
 // ClassInfo contains information about a specific accounting class
 type ClassInfo struct {
-	CheckType synthetic_monitoring.CheckType // the correspodning check type for this class
-	Series    int                            // how many series does this class of check produce
+	CheckType  synthetic_monitoring.CheckType  // the correspodning check type for this class
+	CheckClass synthetic_monitoring.CheckClass // the check class for this accounting class
+	Series     int                             // how many series does this class of check produce
 }
 
 // GetAccountingClassInfo returns all the known accounting classes and
@@ -84,9 +85,11 @@ func GetAccountingClassInfo() map[string]ClassInfo {
 	info := make(map[string]ClassInfo, len(activeSeriesByCheckType))
 
 	for class, as := range activeSeriesByCheckType {
+		checkType := getTypeFromClass(class)
 		info[class] = ClassInfo{
-			CheckType: getTypeFromClass(class),
-			Series:    as,
+			CheckType:  getTypeFromClass(class),
+			CheckClass: checkType.Class(),
+			Series:     as,
 		}
 	}
 

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -201,7 +201,11 @@ func (c Check) Type() CheckType {
 }
 
 func (c Check) Class() CheckClass {
-	switch c.Type() {
+	return c.Type().Class()
+}
+
+func (c CheckType) Class() CheckClass {
+	switch c {
 	case CheckTypeDns, CheckTypeHttp, CheckTypePing, CheckTypeTcp, CheckTypeTraceroute:
 		return CheckClassProtocol
 

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -426,6 +426,62 @@ func TestCheckTypeString(t *testing.T) {
 	}
 }
 
+func TestCheckTypeClass(t *testing.T) {
+	testcases := map[string]struct {
+		input    CheckType
+		expected CheckClass
+	}{
+		CheckTypeDns.String(): {
+			input:    CheckTypeDns,
+			expected: CheckClassProtocol,
+		},
+		CheckTypeHttp.String(): {
+			input:    CheckTypeHttp,
+			expected: CheckClassProtocol,
+		},
+		CheckTypePing.String(): {
+			input:    CheckTypePing,
+			expected: CheckClassProtocol,
+		},
+		CheckTypeTcp.String(): {
+			input:    CheckTypeTcp,
+			expected: CheckClassProtocol,
+		},
+		CheckTypeTraceroute.String(): {
+			input:    CheckTypeTraceroute,
+			expected: CheckClassProtocol,
+		},
+		CheckTypeK6.String(): {
+			input:    CheckTypeK6,
+			expected: CheckClassScripted,
+		},
+		CheckTypeMultiHttp.String(): {
+			input:    CheckTypeMultiHttp,
+			expected: CheckClassScripted,
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := testcase.input.Class()
+			require.Equal(t, testcase.expected, actual)
+		})
+	}
+
+	hasTest := make(map[CheckType]bool)
+	for _, checkType := range CheckTypeValues() {
+		hasTest[checkType] = false
+	}
+
+	for _, testcase := range testcases {
+		hasTest[testcase.input] = true
+	}
+
+	for checkType, found := range hasTest {
+		require.True(t, found, "missing test for check type %s", checkType)
+	}
+}
+
 func TestValidateHost(t *testing.T) {
 	testcases := map[string]struct {
 		input       string


### PR DESCRIPTION
This is necessary so that the API can map accounting classes to check types and ther corresponding class.