### PR TITLE
feat: Experimental per-tenant batched publisher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,16 @@ test-go: $(GOTESTSUM) ## Run Go tests.
 		$(GO_TEST_ARGS)
 	$(S) $(ROOTDIR)/scripts/report-test-coverage $(TEST_OUTPUT).cov
 
+.PHONY: test-go-fast
+test-go-fast: GO_TEST_ARGS += -short
+test-go-fast: test-go ## Run only fast Go tests.
+	$(S) true
+
 .PHONY: test
 test: test-go ## Run all tests.
+
+.PHONY: test-fast
+test-fast: test-go-fast ## Run only fast tests.
 
 ##@ Linting
 

--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
 	pusherV1 "github.com/grafana/synthetic-monitoring-agent/internal/pusher/v1"
+	pusherV2 "github.com/grafana/synthetic-monitoring-agent/internal/pusher/v2"
 	"github.com/grafana/synthetic-monitoring-agent/internal/version"
 	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
@@ -211,6 +212,7 @@ func run(args []string, stdout io.Writer) error {
 
 	pusherRegistry := pusher.NewRegistry[pusher.Factory]()
 	pusherRegistry.MustRegister(pusherV1.Name, pusherV1.NewPublisher)
+	pusherRegistry.MustRegister(pusherV2.Name, pusherV2.NewPublisher)
 
 	publisherFactory, err := pusherRegistry.Lookup(*selectedPublisher)
 	if err != nil {

--- a/internal/pkg/prom/prom_test.go
+++ b/internal/pkg/prom/prom_test.go
@@ -55,6 +55,7 @@ func TestSendBytesWithBackoffRetriesCounter(t *testing.T) {
 		args                 args
 		wantErr              bool
 		expectedRetriesCount float64
+		isSlow               bool
 	}{
 		{
 			name: "should count 0 retries when successful at first",
@@ -83,6 +84,7 @@ func TestSendBytesWithBackoffRetriesCounter(t *testing.T) {
 			},
 			wantErr:              true,
 			expectedRetriesCount: 10,
+			isSlow:               true,
 		},
 	}
 	for _, tt := range tests {
@@ -91,6 +93,10 @@ func TestSendBytesWithBackoffRetriesCounter(t *testing.T) {
 			FailuresLeft:   tt.args.timesToFail,
 		}
 		t.Run(tt.name, func(t *testing.T) {
+			if testing.Short() && tt.isSlow {
+				t.Skip("skipping in short mode")
+			}
+
 			if err := prom.SendBytesWithBackoff(tt.args.ctx, client, tt.args.req); (err != nil) != tt.wantErr {
 				t.Errorf("SendBytesWithBackoff() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/pkg/prom/prom_test.go
+++ b/internal/pkg/prom/prom_test.go
@@ -1,8 +1,10 @@
 package prom_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/prom"
@@ -13,7 +15,11 @@ type FailNTimesPrometheusClient struct {
 	FailuresLeft   int64
 }
 
-func (f *FailNTimesPrometheusClient) Store(ctx context.Context, req []byte) error {
+func (f *FailNTimesPrometheusClient) StoreBytes(ctx context.Context, req []byte) error {
+	return f.StoreStream(ctx, bytes.NewReader(req))
+}
+
+func (f *FailNTimesPrometheusClient) StoreStream(ctx context.Context, req io.Reader) error {
 	if f.FailuresLeft == 0 {
 		return nil
 	}

--- a/internal/pusher/clients.go
+++ b/internal/pusher/clients.go
@@ -1,0 +1,52 @@
+package pusher
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/prom"
+	"github.com/grafana/synthetic-monitoring-agent/internal/version"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+func ClientFromRemoteInfo(remote *sm.RemoteInfo) (*prom.ClientConfig, error) {
+	// TODO(mem): this is hacky.
+	//
+	// it's trying to deal with the fact that the URL shown to users
+	// is not the push URL but the base for the API endpoints
+	u, err := url.Parse(remote.Url + "/push")
+	if err != nil {
+		// XXX(mem): do we really return an error here?
+		return nil, fmt.Errorf("parsing URL: %w", err)
+	}
+
+	clientCfg := prom.ClientConfig{
+		URL:       u,
+		Timeout:   5 * time.Second,
+		UserAgent: version.UserAgent(),
+	}
+
+	if remote.Username != "" {
+		clientCfg.HTTPClientConfig.BasicAuth = &prom.BasicAuth{
+			Username: remote.Username,
+			Password: remote.Password,
+		}
+	}
+
+	if clientCfg.Headers == nil {
+		clientCfg.Headers = make(map[string]string)
+	}
+
+	clientCfg.Headers["X-Prometheus-Remote-Write-Version"] = "0.1.0"
+	return &clientCfg, nil
+}
+
+func GetLocalAndRegionIDs(id int64) (localID int64, regionID int) {
+	var err error
+	if localID, regionID, err = sm.GlobalIDToLocalID(id); err != nil {
+		// Id is already local, use region 0.
+		return id, 0
+	}
+	return localID, regionID
+}

--- a/internal/pusher/metrics.go
+++ b/internal/pusher/metrics.go
@@ -1,0 +1,155 @@
+package pusher
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	LabelValueMetrics        = "metrics"
+	LabelValueLogs           = "logs"
+	LabelValueClient         = "client"
+	LabelValueRetryExhausted = "retry_exhausted"
+	LabelValueTenant         = "tenant"
+)
+
+// Metrics contains the prometheus Metrics for a publisher.
+type Metrics struct {
+	PushCounter    *prometheus.CounterVec
+	ErrorCounter   *prometheus.CounterVec
+	BytesOut       *prometheus.CounterVec
+	FailedCounter  *prometheus.CounterVec
+	RetriesCounter *prometheus.CounterVec
+
+	// For experimental publisher only
+	DroppedCounter  *prometheus.CounterVec
+	ResponseCounter *prometheus.CounterVec
+}
+
+var (
+	labelsWithType       = []string{"regionID", "tenantID", "type"}
+	labelsWithTypeStatus = []string{"regionID", "tenantID", "type", "status"}
+	labelsWithTarget     = []string{"regionID", "tenantID", "target"}
+)
+
+// NewMetrics returns a new set of publisher metrics registered in the given registerer.
+func NewMetrics(promRegisterer prometheus.Registerer) (m Metrics) {
+	m.PushCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "sm_agent",
+			Subsystem: "publisher",
+			Name:      "push_total",
+			Help:      "Total number of push events by type.",
+		},
+		labelsWithType)
+
+	promRegisterer.MustRegister(m.PushCounter)
+
+	m.ErrorCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "sm_agent",
+			Subsystem: "publisher",
+			Name:      "push_errors_total",
+			Help:      "Total number of push errors by type and status.",
+		},
+		labelsWithTypeStatus)
+
+	promRegisterer.MustRegister(m.ErrorCounter)
+
+	m.FailedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "sm_agent",
+			Subsystem: "publisher",
+			Name:      "push_failed_total",
+			Help:      "Total number of push failures by type.",
+		},
+		labelsWithType)
+
+	promRegisterer.MustRegister(m.FailedCounter)
+
+	m.BytesOut = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "sm_agent",
+			Subsystem: "publisher",
+			Name:      "push_bytes",
+			Help:      "Total number of bytes pushed by target.",
+		},
+		labelsWithTarget)
+
+	promRegisterer.MustRegister(m.BytesOut)
+
+	m.RetriesCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "sm_agent",
+			Subsystem: "publisher",
+			Name:      "retries_total",
+			Help:      "Total number of retries performed by target.",
+		},
+		labelsWithTarget)
+
+	promRegisterer.MustRegister(m.RetriesCounter)
+
+	m.DroppedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "sm_agent",
+			Subsystem: "publisher",
+			Name:      "drop_total",
+			Help:      "Total number of results dropped by type.",
+		},
+		labelsWithType)
+
+	promRegisterer.MustRegister(m.DroppedCounter)
+
+	m.ResponseCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "sm_agent",
+			Subsystem: "publisher",
+			Name:      "responses_total",
+			Help:      "Total number of responses received by type and status code.",
+		},
+		labelsWithTypeStatus)
+
+	promRegisterer.MustRegister(m.ResponseCounter)
+
+	return m
+}
+
+// WithTenant returns a new set of Metrics with the local and region ID labels
+// already included.
+func (m Metrics) WithTenant(localID int64, regionID int) Metrics {
+	labels := prometheus.Labels{
+		"regionID": strconv.FormatInt(int64(regionID), 10),
+		"tenantID": strconv.FormatInt(localID, 10),
+	}
+	return Metrics{
+		PushCounter:     m.PushCounter.MustCurryWith(labels),
+		ErrorCounter:    m.ErrorCounter.MustCurryWith(labels),
+		BytesOut:        m.BytesOut.MustCurryWith(labels),
+		FailedCounter:   m.FailedCounter.MustCurryWith(labels),
+		RetriesCounter:  m.RetriesCounter.MustCurryWith(labels),
+		DroppedCounter:  m.DroppedCounter.MustCurryWith(labels),
+		ResponseCounter: m.ResponseCounter.MustCurryWith(labels),
+	}
+}
+
+// WithType returns a new set of Metrics with the given type label.
+func (m Metrics) WithType(t string) Metrics {
+	var (
+		typeLabels = prometheus.Labels{
+			"type": t,
+		}
+		targetLabels = prometheus.Labels{
+			"target": t,
+		}
+	)
+	return Metrics{
+		PushCounter:     m.PushCounter.MustCurryWith(typeLabels),
+		ErrorCounter:    m.ErrorCounter.MustCurryWith(typeLabels),
+		BytesOut:        m.BytesOut.MustCurryWith(targetLabels),
+		FailedCounter:   m.FailedCounter, // type in failed counter servers a different purpose.
+		RetriesCounter:  m.RetriesCounter.MustCurryWith(targetLabels),
+		DroppedCounter:  m.DroppedCounter.MustCurryWith(typeLabels),
+		ResponseCounter: m.ResponseCounter.MustCurryWith(typeLabels),
+	}
+}

--- a/internal/pusher/metrics_test.go
+++ b/internal/pusher/metrics_test.go
@@ -1,0 +1,55 @@
+package pusher
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMetrics(t *testing.T) {
+	t.Run("non-nil fields", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := NewMetrics(reg)
+		rVal := reflect.ValueOf(m)
+		for i := 0; i < rVal.NumField(); i++ {
+			fType := rVal.Type().Field(i)
+			fVal := rVal.Field(i)
+			require.Equal(t, reflect.Pointer, fVal.Kind(), fType.Name)
+			require.NotZero(t, fVal.Pointer(), fType.Name)
+		}
+	})
+	t.Run("registered fields", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := NewMetrics(reg).
+			WithTenant(1234, 50).
+			WithType(LabelValueMetrics)
+
+		m.PushCounter.WithLabelValues().Inc()
+		m.DroppedCounter.WithLabelValues().Inc()
+		m.FailedCounter.WithLabelValues(LabelValueRetryExhausted).Inc()
+		m.BytesOut.WithLabelValues().Add(1200)
+		m.ErrorCounter.WithLabelValues("500").Inc()
+		m.ResponseCounter.WithLabelValues("200").Inc()
+
+		fam, err := reg.Gather()
+		require.NoError(t, err)
+		var (
+			expected = []string{
+				"sm_agent_publisher_drop_total",
+				"sm_agent_publisher_push_bytes",
+				"sm_agent_publisher_push_errors_total",
+				"sm_agent_publisher_push_failed_total",
+				"sm_agent_publisher_push_total",
+				"sm_agent_publisher_responses_total",
+			}
+			actual []string
+		)
+		for _, metric := range fam {
+			actual = append(actual, metric.GetName())
+		}
+
+		require.Equal(t, expected, actual)
+	})
+}

--- a/internal/pusher/tenant_manager.go
+++ b/internal/pusher/tenant_manager.go
@@ -16,6 +16,8 @@ type TenantManager struct {
 	tenants       map[int64]*tenantInfo
 }
 
+var _ TenantProvider = &TenantManager{}
+
 type tenantInfo struct {
 	mutex      sync.Mutex // protects the entire structure
 	validUntil time.Time

--- a/internal/pusher/v2/condition.go
+++ b/internal/pusher/v2/condition.go
@@ -1,0 +1,22 @@
+package v2
+
+// condition is a simple, channel-based condition variable.
+type condition chan struct{}
+
+// Signal signals the condition. Waking up a waiting goroutine.
+func (c condition) Signal() {
+	select {
+	case c <- struct{}{}:
+	default:
+		// Already signaled
+	}
+}
+
+// C returns the channel used for waiting.
+func (c condition) C() <-chan struct{} {
+	return c
+}
+
+func newCondition() condition {
+	return make(chan struct{}, 1)
+}

--- a/internal/pusher/v2/condition_test.go
+++ b/internal/pusher/v2/condition_test.go
@@ -1,0 +1,68 @@
+package v2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCondition(t *testing.T) {
+	const timeout = time.Second
+	t.Run("don't fire until signaled", func(t *testing.T) {
+		c := newCondition()
+		wait(t, &c, false, timeout)
+	})
+	t.Run("fire after signaled", func(t *testing.T) {
+		c := newCondition()
+		c.Signal()
+		wait(t, &c, true, timeout)
+	})
+	t.Run("single fire", func(t *testing.T) {
+		c := newCondition()
+		c.Signal()
+		c.Signal()
+		wait(t, &c, true, timeout)
+		wait(t, &c, false, timeout)
+	})
+	t.Run("single fire", func(t *testing.T) {
+		c := newCondition()
+		c.Signal()
+		c.Signal()
+		wait(t, &c, true, timeout)
+		wait(t, &c, false, timeout)
+	})
+	t.Run("goroutine", func(t *testing.T) {
+		c := newCondition()
+		go func() {
+			c.Signal()
+		}()
+		wait(t, &c, true, timeout)
+	})
+	t.Run("loop", func(t *testing.T) {
+		const iterations = 100
+		a, b := newCondition(), newCondition()
+		go func() {
+			for i := 0; i < iterations; i++ {
+				a.Signal()
+				wait(t, &b, true, timeout)
+			}
+		}()
+		for i := 0; i < iterations; i++ {
+			wait(t, &a, true, timeout)
+			b.Signal()
+		}
+	})
+}
+
+func wait(t *testing.T, c *condition, fire bool, timeout time.Duration) {
+	tm := time.NewTimer(timeout)
+	defer tm.Stop()
+	fired := false
+	select {
+	case <-tm.C:
+	case <-c.C():
+		fired = true
+	}
+	require.Equal(t, fire, fired)
+}

--- a/internal/pusher/v2/condition_test.go
+++ b/internal/pusher/v2/condition_test.go
@@ -8,7 +8,14 @@ import (
 )
 
 func TestCondition(t *testing.T) {
-	const timeout = time.Second
+	const fastTimeout = 50 * time.Millisecond
+	const slowTimeout = 1000 * time.Millisecond
+
+	var timeout = slowTimeout
+	if testing.Short() {
+		timeout = fastTimeout
+	}
+
 	t.Run("don't fire until signaled", func(t *testing.T) {
 		c := newCondition()
 		wait(t, &c, false, timeout)

--- a/internal/pusher/v2/errors.go
+++ b/internal/pusher/v2/errors.go
@@ -1,0 +1,220 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/prom"
+)
+
+// errKind enum used to carry the category of a push error.
+type errKind int8
+
+const (
+	errKindNoError    errKind = iota // No error (never returned, always nil error).
+	errKindNetwork                   // Transient network error or other retriable error
+	errKindPayload                   // There is a problem with the data being sent. Discard it.
+	errKindWait                      // Sending too much data, delay publishing
+	errKindTenant                    // A problem with the tenant remotes. Fetch the tenant again.
+	errKindFatal                     // There is a problem that can't be fixed by fetching the tenant.
+	errKindTerminated                // Push terminated (context canceled)
+)
+
+func (k errKind) String() string {
+	switch k {
+	case errKindNoError:
+		return "no error"
+	case errKindNetwork:
+		return "network error"
+	case errKindPayload:
+		return "payload error"
+	case errKindWait:
+		return "waitable error"
+	case errKindTenant:
+		return "tenant error"
+	case errKindFatal:
+		return "fatal error"
+	case errKindTerminated:
+		return "terminate error"
+	}
+	return "unknown error"
+}
+
+// pushError encapsulates an existing error with an errKind
+type pushError struct {
+	kind  errKind
+	inner error
+}
+
+func (e pushError) Error() string {
+	return fmt.Sprintf("%s: %s", e.kind.String(), e.inner)
+}
+
+func (e pushError) Unwrap() error {
+	return e.inner
+}
+
+func (e pushError) Kind() errKind {
+	return e.kind
+}
+
+func (e pushError) IsRetriable() bool {
+	return e.kind == errKindNetwork
+}
+
+type alternativeMapping struct {
+	substr string
+	kind   errKind
+}
+
+// httpCodeMappings maps an HTTP Response Code to an errKind.
+// Alternative mappings can be provided by inspecting the error returned by the server.
+var httpCodeMappings = map[int]struct {
+	kind         errKind
+	alternatives []alternativeMapping
+}{
+	1: { // 1xx: retriable error
+		kind: errKindNetwork,
+	},
+	2: { // 2xx: No error
+		kind: errKindNoError,
+	},
+	3: { // 3xx: These usually indicate a misconfiguration (tenant is pointing to the wrong url?)
+		kind: errKindFatal,
+	},
+	4: { // 4xx: Not an error. Just part of the payload is unacceptable.
+		kind: errKindPayload,
+	},
+	5: { // 5xx: Transient error.
+		kind: errKindNetwork,
+	},
+
+	http.StatusInternalServerError: { // 500
+		kind: errKindNetwork,
+		alternatives: []alternativeMapping{
+			{
+				substr: "looks like there is an issue with this instance",
+				kind:   errKindTenant,
+			},
+		},
+	},
+
+	http.StatusBadRequest: { // 400
+		kind: errKindPayload,
+		alternatives: []alternativeMapping{
+			{
+				substr: "err-mimir-max-series-per-user",
+				kind:   errKindFatal,
+			},
+		},
+	},
+
+	http.StatusTooManyRequests: { // 429
+		kind: errKindWait,
+		alternatives: []alternativeMapping{
+			{
+				substr: "limit: 0 ",
+				kind:   errKindFatal,
+			},
+			{
+				substr: "Maximum active stream limit exceeded",
+				kind:   errKindFatal,
+			},
+		},
+	},
+
+	// Specific 4xx messages that don't translate to data error
+
+	http.StatusUnauthorized: { // 401
+		kind: errKindTenant,
+	},
+
+	http.StatusForbidden: { // 403
+		kind: errKindFatal,
+	},
+
+	http.StatusNotFound: { // 404
+		kind: errKindFatal,
+	},
+
+	http.StatusMethodNotAllowed: { // 405
+		kind: errKindFatal,
+	},
+
+	http.StatusRequestTimeout: { // 408
+		kind: errKindNetwork,
+	},
+}
+
+// parsePublishError parses the error resulting from a publish operation and converts it into a pushError.
+// The only exception is any error that wraps a context.Canceled error. In that case, context.Canceled
+// is returned.
+func parsePublishError(err error) (httpStatusCode int, pushErr pushError) {
+	const noHTTPCode = 0
+
+	if err == nil {
+		return http.StatusOK, pushError{
+			kind:  errKindNoError,
+			inner: nil,
+		}
+	}
+
+	// Context errors can be wrapped by various other error types, like
+	// prom.recoverableError and url.Error.
+	if errors.Is(err, context.Canceled) {
+		return noHTTPCode, pushError{
+			kind:  errKindTerminated,
+			inner: context.Canceled,
+		}
+	}
+
+	// Any DeadlineExceeded is assumed to be a network timeout of some kind.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return noHTTPCode, pushError{
+			kind:  errKindNetwork,
+			inner: err,
+		}
+	}
+
+	code, hasStatusCode := prom.GetHttpStatusCode(err)
+	if !hasStatusCode {
+		// Errors without an HTTP Status code are treated as network errors.
+		return noHTTPCode, pushError{
+			kind:  errKindNetwork,
+			inner: err,
+		}
+	}
+
+	mapping, found := httpCodeMappings[code]
+	if !found {
+		// No mapping for this specific HTTP status code. Try a general 5xx/4xx/etc.
+		if mapping, found = httpCodeMappings[code/100]; !found {
+			// No mapping for this http status at all?
+			// This should never happen.
+			return code, pushError{
+				kind:  errKindFatal,
+				inner: err,
+			}
+		}
+	}
+
+	// Check specific alternatives that look into the error message.
+	errText := err.Error()
+	for _, alt := range mapping.alternatives {
+		if strings.Contains(errText, alt.substr) {
+			return code, pushError{
+				kind:  alt.kind,
+				inner: err,
+			}
+		}
+	}
+
+	// return base mapping for this status code.
+	return code, pushError{
+		kind:  mapping.kind,
+		inner: err,
+	}
+}

--- a/internal/pusher/v2/errors_test.go
+++ b/internal/pusher/v2/errors_test.go
@@ -1,0 +1,210 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/prom"
+)
+
+func TestParsePushError(t *testing.T) {
+	for title, tc := range map[string]struct {
+		input    error
+		expected error
+		code     int
+	}{
+		"no error": {
+			input: nil,
+			expected: pushError{
+				kind: errKindNoError,
+			},
+			code: http.StatusOK,
+		},
+
+		"context canceled": {
+			input: context.Canceled,
+			expected: pushError{
+				kind: errKindTerminated,
+			},
+			code: 0,
+		},
+
+		"context deadline exceeded": {
+			input: context.DeadlineExceeded,
+			expected: pushError{
+				kind: errKindNetwork,
+			},
+			code: 0,
+		},
+
+		"other error is network": {
+			input: errors.New("something is wrong"),
+			expected: pushError{
+				kind: errKindNetwork,
+			},
+			code: 0,
+		},
+
+		"500 errors are temporary": {
+			input: &prom.HttpError{
+				StatusCode: 500,
+				Status:     "Internal Server Error",
+				Err:        errors.New(`something is wrong`),
+			},
+			expected: pushError{
+				kind: errKindNetwork,
+			},
+			code: 500,
+		},
+
+		"500 from grafana instance": {
+			input: &prom.HttpError{
+				StatusCode: 500,
+				Status:     "Internal Server Error",
+				Err:        errors.New(`It looks like there is an issue with this instance`),
+			},
+			expected: pushError{
+				kind: errKindTenant,
+			},
+			code: 500,
+		},
+
+		"400 errors are data errors": {
+			input: &prom.HttpError{
+				StatusCode: 400,
+				Status:     "Bad Request",
+				Err:        errors.New(`400 Bad Request: couldn't parse labels: 1:248: parse error: unexpected identifier "foo" in label set, expected "," or "}"`),
+			},
+			expected: pushError{
+				kind: errKindPayload,
+			},
+			code: 400,
+		},
+
+		"400 err-mimir-sample-out-of-order": {
+			input: &prom.HttpError{
+				StatusCode: 400,
+				Status:     "Bad Request",
+				Err:        errors.New(`400 Bad Request: failed pushing to ingester: user=275106: the sample has been rejected because another sample with a more recent timestamp has already been ingested and out-of-order samples are not allowed (err-mimir-sample-out-of-order). The affected sample has timestamp`),
+			},
+			expected: pushError{
+				kind: errKindPayload,
+			},
+			code: 400,
+		},
+
+		"400 err-mimir-max-series-per-user": {
+			input: &prom.HttpError{
+				StatusCode: 400,
+				Status:     "Bad Request",
+				Err:        errors.New(`400 Bad Request: failed pushing to ingester: user=1234: per-user series limit of 15000 exceeded (err-mimir-max-series-per-user). To adjust the related per-tenant limit, configure -ingester.max-global-series-per-user, or contact your service administrator.`),
+			},
+			expected: pushError{
+				kind: errKindFatal,
+			},
+			code: 400,
+		},
+
+		"429 generic": {
+			input: &prom.HttpError{
+				StatusCode: 429,
+				Status:     "Too Many Requests",
+				Err:        errors.New(`the request has been rejected because the tenant exceeded the request rate limit, set to 75 requests/s across all distributors with a maximum allowed burst of 750 (err-mimir-tenant-max-request-rate)`),
+			},
+			expected: pushError{
+				kind: errKindWait,
+			},
+			code: 429,
+		},
+
+		"429 loki ingest denied": {
+			input: &prom.HttpError{
+				StatusCode: 429,
+				Status:     "Too Many Requests",
+				Err:        errors.New(`Ingestion rate limit exceeded for user 1234 (limit: 0 bytes/sec) while attempting to ingest '7' lines totaling '1874' bytes, reduce log volume or contact your Loki administrator to see if the limit can be increased`),
+			},
+			expected: pushError{
+				kind: errKindFatal,
+			},
+			code: 429,
+		},
+
+		"429 loki active streams": {
+			input: &prom.HttpError{
+				StatusCode: 429,
+				Status:     "Too Many Requests",
+				Err:        errors.New(`Maximum active stream limit exceeded, reduce the number of active streams (reduce labels or reduce label values), or contact your Loki administrator to see if the limit can be increased, user: '1234'`),
+			},
+			expected: pushError{
+				kind: errKindFatal,
+			},
+			code: 429,
+		},
+
+		"404 Not Found": {
+			input: &prom.HttpError{
+				StatusCode: 404,
+				Status:     "Not Found",
+				Err:        errors.New("file not found"),
+			},
+			expected: pushError{
+				kind: errKindFatal,
+			},
+			code: 404,
+		},
+
+		"401 bad token": {
+			input: &prom.HttpError{
+				StatusCode: 401,
+				Status:     "Unauthorized",
+				Err:        errors.New(`{"status":"error","error":"authentication error: invalid token"}`),
+			},
+			expected: pushError{
+				kind: errKindTenant,
+			},
+			code: 401,
+		},
+
+		"403 Forbidden": {
+			input: &prom.HttpError{
+				StatusCode: 403,
+				Status:     "Forbidden",
+				Err:        errors.New(`Forbidden`),
+			},
+			expected: pushError{
+				kind: errKindFatal,
+			},
+			code: 403,
+		},
+
+		"300 response": {
+			input: &prom.HttpError{
+				StatusCode: 300,
+				Status:     "Multiple Choices",
+				Err:        errors.New("multiple choices"),
+			},
+			expected: pushError{
+				kind: errKindFatal,
+			},
+			code: 300,
+		},
+	} {
+		t.Run(title, func(t *testing.T) {
+			code, err := parsePublishError(tc.input)
+			var (
+				expectedErr = tc.expected
+				pErr        pushError
+			)
+			if errors.As(expectedErr, &pErr) {
+				pErr.inner = tc.input
+				expectedErr = pErr
+			}
+			require.Equal(t, expectedErr, err)
+			require.Equal(t, tc.code, code)
+		})
+	}
+}

--- a/internal/pusher/v2/options.go
+++ b/internal/pusher/v2/options.go
@@ -1,0 +1,191 @@
+package v2
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
+)
+
+const (
+	// This one is tricky. Most of the time, buffers are 1-2KiB in size. Are we allocating too much by default?
+	defaultBufferCapacity = 4096
+)
+
+var (
+	defaultPusherOptions = pusherOptions{
+		// Max bytes to send on a single push request
+		// Both loki and mimir can take at least 5MiB.
+		maxPushBytes: 64 * 1024,
+
+		// Max bytes to hold queued
+		// 0: Disabled
+		maxQueuedBytes: 128 * 1024,
+
+		// Max items (check results) to hold in memory (per tenant per type)
+		// 0: Disabled
+		maxQueuedItems: 128,
+
+		// Max time to keep an item in the queue before it's discarded
+		// Note that loki/mimir will probably reject data older than 1h anyway.
+		// 0: Disabled
+		maxQueuedTime: time.Hour,
+
+		// Max number of retries in case of network(retriable) error.
+		// Ideally we make this big and have data expired with the above limits.
+		maxRetries: 20,
+
+		// Backoff between retries. Doubling at each attempt.
+		minBackoff: time.Millisecond * 30,
+		maxBackoff: time.Second * 2,
+
+		// Max time a tenant pusher is active. This is useful to cause the tenant info
+		// to be refreshed.
+		maxLifetime: 2 * time.Hour,
+
+		// How long without receiving check results until a tenant pusher is stopped.
+		// This is to cleanup tenants that don't have active checks anymore.
+		// Set it to a value higher than the max interval between a single check run.
+		maxIdleTime: 5 * time.Minute,
+
+		// How long to wait before refreshing tenant due to an error.
+		tenantDelay: 10 * time.Second,
+
+		// How long to stop pushing new metrics when a 429 (Too Many Requests) is received.
+		waitPeriod: time.Minute,
+
+		// How long to discard metrics when a fatal error is encountered.
+		discardPeriod: 15 * time.Minute,
+
+		pool: bufferPool{
+			inner: &sync.Pool{
+				New: func() interface{} {
+					buf := make([]byte, 0, defaultBufferCapacity)
+					return &buf
+				},
+			},
+		},
+	}
+)
+
+type pusherOptions struct {
+	maxPushBytes   uint64        // Max bytes to send on a single push request
+	maxQueuedBytes uint64        // Max bytes to hold queued
+	maxQueuedItems int           // Max items (check results) to hold in memory
+	maxQueuedTime  time.Duration // Max time an item can be queued until it expires
+	maxRetries     int           // Max retries for a push
+	minBackoff     time.Duration
+	maxBackoff     time.Duration
+	maxLifetime    time.Duration // How long to run a tenant pusher before re-fetching the tenant
+	maxIdleTime    time.Duration // How long without receiving pushes until a tenant pusher is cleaned up
+	tenantDelay    time.Duration // How long to wait between GetTenant calls.
+	waitPeriod     time.Duration // How long to wait in case of errors
+	discardPeriod  time.Duration // How long to discard metrics when a fatal error is encountered.
+	logger         zerolog.Logger
+	metrics        pusher.Metrics
+	pool           bufferPool
+}
+
+func (o pusherOptions) withTenant(id int64) pusherOptions {
+	localID, regionID := pusher.GetLocalAndRegionIDs(id)
+	o.logger = o.logger.With().Int("region", regionID).Int64("tenant", localID).Logger()
+	o.metrics = o.metrics.WithTenant(localID, regionID)
+	return o
+}
+
+func (o pusherOptions) withType(t string) pusherOptions {
+	o.logger = o.logger.With().Str("type", t).Logger()
+	o.metrics = o.metrics.WithType(t)
+	return o
+}
+
+func (o pusherOptions) retriesCounter() retriesCounter {
+	return retriesCounter{
+		left: o.maxRetries,
+		max:  o.maxRetries,
+	}
+}
+
+func (o pusherOptions) backOffer() backoffer {
+	return backoffer{
+		min: o.minBackoff,
+		max: o.maxBackoff,
+	}
+}
+
+type bufferPool struct {
+	inner *sync.Pool
+}
+
+func (p *bufferPool) get() *[]byte {
+	if p == nil || p.inner == nil {
+		return nil
+	}
+	return p.inner.Get().(*[]byte)
+}
+
+func (p *bufferPool) put(buf *[]byte) {
+	if p == nil || p.inner == nil {
+		return
+	}
+	p.inner.Put(buf)
+}
+
+func (p *bufferPool) returnAll(records []queueEntry) (size uint64) {
+	for _, rec := range records {
+		size += uint64(len(*rec.data))
+		p.put(rec.data)
+		rec.data = nil // Ensure it can't be re-used after return.
+	}
+	return size
+}
+
+type retriesCounter struct {
+	left, max int
+}
+
+func (c *retriesCounter) retry() bool {
+	if c.left <= 0 {
+		return false
+	}
+	c.left--
+	return true
+}
+
+func (c *retriesCounter) reset() {
+	c.left = c.max
+}
+
+type backoffer struct {
+	last, min, max time.Duration
+}
+
+func (b *backoffer) wait(ctx context.Context) error {
+	if b.last < b.min {
+		b.last = b.min
+	} else {
+		b.last = 2 * b.last
+		if b.last > b.max {
+			b.last = b.max
+		}
+	}
+	return sleepCtx(ctx, b.last)
+}
+
+func (b *backoffer) reset() {
+	b.last = 0
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	select {
+	case <-ctx.Done():
+		t.Stop()
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/internal/pusher/v2/publisher.go
+++ b/internal/pusher/v2/publisher.go
@@ -1,0 +1,121 @@
+package v2
+
+import (
+	"context"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
+)
+
+const Name = "v2"
+
+// NewPublisher creates a new instance of the v2 Publisher.
+//
+// The provider context is used to control the lifetime of the publisher.
+func NewPublisher(ctx context.Context, tenantProvider pusher.TenantProvider, logger zerolog.Logger, pr prometheus.Registerer) pusher.Publisher {
+	impl := &publisherImpl{
+		ctx:            ctx,
+		tenantProvider: tenantProvider,
+		options:        defaultPusherOptions,
+		handlers:       make(map[int64]payloadHandler),
+	}
+	impl.options.logger = logger
+	impl.options.metrics = pusher.NewMetrics(pr)
+
+	return impl
+}
+
+type payloadHandler interface {
+	publish(payload pusher.Payload)
+	// run returns the handler that should run or nil to signal that it
+	// should be terminated.
+	run(ctx context.Context) payloadHandler
+}
+
+type publisherImpl struct {
+	ctx            context.Context
+	tenantProvider pusher.TenantProvider
+	options        pusherOptions
+	handlerMutex   sync.Mutex // protects the handlers map
+	handlers       map[int64]payloadHandler
+}
+
+var _ pusher.Publisher = &publisherImpl{}
+
+func (p *publisherImpl) Publish(payload pusher.Payload) {
+	tenantID := payload.Tenant()
+	handler, found := p.getHandler(tenantID)
+	if !found {
+		var swapped bool
+		newHandler := newTenantPusher(tenantID, p.tenantProvider, p.options.withTenant(tenantID))
+		handler, swapped = p.replaceHandler(tenantID, nil, newHandler)
+		if swapped {
+			go p.runHandler(tenantID, handler)
+		}
+	}
+	handler.publish(payload)
+}
+
+func (p *publisherImpl) runHandler(tenantID int64, h payloadHandler) {
+	p.options.logger.Info().Int64("tenantID", tenantID).Msg("started push handler")
+	defer p.options.logger.Info().Int64("tenantID", tenantID).Msg("stopped push handler")
+
+	for ok := true; ok && h != nil; {
+		next := h.run(p.ctx)
+		h, ok = p.replaceHandler(tenantID, h, next)
+		if !ok {
+			p.options.logger.Error().Int64("tenantID", tenantID).Msg("unable to swap handler, tenant hijacked")
+		}
+	}
+}
+
+// replaceHandler exchanges the old handler with the new handler for the tenant
+// identified by tenantID.
+//
+// By passing a nil new handler, you are trying to delete. A nil old handler
+// means you are trying to add.
+//
+// The handler currently in effect is returned, along with whether the handler
+// was changed or not.
+func (p *publisherImpl) replaceHandler(tenantID int64, old, new payloadHandler) (payloadHandler, bool) {
+	p.handlerMutex.Lock()
+	defer p.handlerMutex.Unlock()
+
+	// Get the existing handler if any.
+	current := p.handlers[tenantID]
+
+	// If old is nil, that means we are trying to add a handler. If current
+	// is not nil, that means there's an existing handler, and the addition
+	// is not necessary. If current is nil, we go ahead and add the new handler.
+	//
+	// If old is not nil, we are trying to replace or delete a handler.
+	//
+	// If there's nothing there, current is nil and therefore different from
+	// old. That means there's nothing to replace (somebody beat us to it)
+	// and nothing to delete (idem).
+	//
+	// If there's something there, current is not nil, we have to replace
+	// the existing one.
+	if current != old {
+		return current, false
+	}
+
+	if new != nil {
+		p.handlers[tenantID] = new
+	} else {
+		delete(p.handlers, tenantID)
+	}
+
+	return new, true
+}
+
+func (p *publisherImpl) getHandler(tenantID int64) (payloadHandler, bool) {
+	p.handlerMutex.Lock()
+	defer p.handlerMutex.Unlock()
+
+	handler, found := p.handlers[tenantID]
+	return handler, found
+}

--- a/internal/pusher/v2/queue.go
+++ b/internal/pusher/v2/queue.go
@@ -1,0 +1,261 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/prom"
+	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+type queue struct {
+	options   *pusherOptions
+	dataMutex sync.Mutex
+	data      []queueEntry
+	pending   condition
+}
+
+func newQueue(options *pusherOptions) queue {
+	return queue{
+		options: options,
+		pending: newCondition(),
+	}
+}
+
+func (q *queue) push(ctx context.Context, remote *sm.RemoteInfo) error {
+	cfg, err := pusher.ClientFromRemoteInfo(remote)
+	if err != nil {
+		return err
+	}
+	client, err := prom.NewClient(remote.Name, cfg, unusedRetryCounterFn)
+	if err != nil {
+		q.options.logger.Error().Err(err).Msg("get client failed")
+		q.options.metrics.FailedCounter.WithLabelValues(pusher.LabelValueClient).Inc()
+		return pushError{
+			kind:  errKindFatal,
+			inner: fmt.Errorf("creating client: %w", err),
+		}
+	}
+
+	var (
+		retries  = q.options.retriesCounter()
+		backoff  = q.options.backOffer()
+		retrying = false
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-q.WaitC():
+			records := q.get()
+			if len(records) == 0 {
+				continue
+			}
+
+			numRecords := float64(len(records))
+
+			if !retrying {
+				retries.reset()
+				backoff.reset()
+			}
+			retrying = false
+
+			concatReader := newConcatReader(records)
+			httpStatusCode, pushErr := parsePublishError(client.StoreStream(ctx, &concatReader))
+			statusCodeStr := strconv.Itoa(httpStatusCode)
+
+			// TODO(mem): this might be a problem, we are keeping a
+			// tally of the status codes received for each
+			// individual tenant. It might be better to send this
+			// to logs.
+			q.options.metrics.ResponseCounter.WithLabelValues(statusCodeStr).Inc()
+
+			if pushErr.IsRetriable() {
+				q.options.metrics.ErrorCounter.WithLabelValues(statusCodeStr).Add(numRecords)
+				if retrying = retries.retry(); retrying {
+					q.options.metrics.RetriesCounter.WithLabelValues().Add(numRecords)
+					// This causes each retry to use all pending records (up to maxPushBytes).
+					// Is this what we want?
+					// Conceptually it can make more sense to always retry with the same packet?
+					// In the case where something in the packet is causing the 500
+					q.requeue(records)
+					if err := backoff.wait(ctx); err != nil {
+						return err // ctx was cancelled
+					}
+					continue
+				}
+			}
+
+			size := q.options.pool.returnAll(records)
+
+			switch pushErr.Kind() {
+			case errKindNoError:
+				q.options.metrics.PushCounter.WithLabelValues().Add(numRecords)
+				q.options.metrics.BytesOut.WithLabelValues().Add(float64(size))
+				continue
+
+			case errKindNetwork:
+				q.options.metrics.FailedCounter.WithLabelValues(pusher.LabelValueRetryExhausted).Add(numRecords)
+
+			case errKindPayload:
+				// This is not necessarily errors! Possibly most of the data was ingested and only
+				// a sample was discarded.
+				q.options.metrics.ErrorCounter.WithLabelValues(statusCodeStr).Add(numRecords)
+
+			case errKindTenant, errKindFatal, errKindWait:
+				// Terminate publisher.
+				q.options.metrics.ErrorCounter.WithLabelValues(statusCodeStr).Add(numRecords)
+				return pushErr
+
+			case errKindTerminated:
+				// This can't really happen as client.StoreStream uses context.Background with a timeout.
+				return pushErr
+
+			default:
+				// What kind of error is this?
+				panic(pushErr)
+			}
+		}
+	}
+}
+
+func (q *queue) insert(data *[]byte) {
+	q.dataMutex.Lock()
+	defer q.dataMutex.Unlock()
+	q.data = append(q.data, queueEntry{
+		data: data,
+		ts:   time.Now(),
+	})
+	q.applyLimits()
+	q.pending.Signal()
+}
+
+func (q *queue) applyLimits() {
+	numDropped := q.limitNumItems(q.options.maxQueuedItems) + q.limitBytes(q.options.maxQueuedBytes) + q.limitAge(q.options.maxQueuedTime)
+	if numDropped > 0 {
+		q.options.metrics.DroppedCounter.WithLabelValues().Add(float64(numDropped))
+	}
+}
+
+func (q *queue) limitNumItems(max int) (numRemoved int) {
+	var (
+		n      = len(q.data)
+		excess = n - max
+	)
+	if max <= 0 || excess <= 0 {
+		return 0
+	}
+	q.options.pool.returnAll(q.data[:excess])
+	q.data = q.data[excess:]
+	return excess
+}
+
+func (q *queue) limitBytes(max uint64) (numRemoved int) {
+	n := len(q.data)
+	if max <= 0 {
+		return 0
+	}
+	for i, numBytes := n-1, uint64(0); i >= 0; i-- {
+		if numBytes += uint64(len(*q.data[i].data)); numBytes > max {
+			q.options.pool.returnAll(q.data[:i+1])
+			q.data = q.data[i+1:]
+			return i + 1
+		}
+	}
+	return 0
+}
+
+func (q *queue) limitAge(maxAge time.Duration) (numRemoved int) {
+	n := len(q.data)
+	if n == 0 || maxAge <= 0 {
+		return 0
+	}
+	limit := time.Now().Add(-maxAge)
+	if !q.data[0].ts.Before(limit) {
+		return 0
+	}
+
+	// As data is chronologically sorted (q.data[i].ts <= q.data[i+1].ts)
+	// find all items older than limit using binary search.
+	idx := sort.Search(n, func(i int) bool {
+		return !q.data[i].ts.Before(limit)
+	})
+	if idx < n {
+		q.options.pool.returnAll(q.data[:idx])
+		q.data = q.data[idx:]
+	}
+	return n - idx
+}
+
+func (q *queue) WaitC() <-chan struct{} {
+	return q.pending.C()
+}
+
+func (q *queue) get() []queueEntry {
+	q.dataMutex.Lock()
+	defer q.dataMutex.Unlock()
+
+	totalQueued := len(q.data)
+	if totalQueued == 0 {
+		return nil
+	}
+
+	limit, numBytes := 1, uint64(len(*q.data[0].data))
+	for limit < totalQueued {
+		thisSize := uint64(len(*q.data[limit].data))
+		if numBytes+thisSize > q.options.maxPushBytes {
+			break
+		}
+		numBytes += thisSize
+		limit++
+	}
+
+	// Copy the entries to return out of the slice, and move the remaining
+	// entries to the front of the slice. In this way we avoid growing the
+	// slice in case we add new data.
+	take := make([]queueEntry, limit)
+	copy(take, q.data[:limit])
+	copy(q.data, q.data[limit:])
+	q.data = q.data[:len(q.data[limit:])]
+
+	if limit < totalQueued {
+		q.pending.Signal()
+	}
+
+	return take
+}
+
+func (q *queue) requeue(data []queueEntry) {
+	if len(data) == 0 {
+		return
+	}
+	q.dataMutex.Lock()
+	defer q.dataMutex.Unlock()
+	q.data = append(data, q.data...)
+	q.applyLimits()
+	q.pending.Signal()
+}
+
+type queueEntry struct {
+	data *[]byte
+	ts   time.Time
+}
+
+func newConcatReader(records []queueEntry) SnappyConcatReader {
+	streams := make([][]byte, len(records))
+	for idx, rec := range records {
+		streams[idx] = *rec.data
+	}
+	return SnappyConcatReader{
+		Streams: streams,
+	}
+}
+
+func unusedRetryCounterFn(float64) {}

--- a/internal/pusher/v2/queue_test.go
+++ b/internal/pusher/v2/queue_test.go
@@ -1,0 +1,433 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+func TestQueue(t *testing.T) {
+	const timeout = time.Second * 5
+	defaultOptions := pusherOptions{
+		maxPushBytes:   1024 * 1024,
+		maxQueuedBytes: 0,
+		maxQueuedItems: 0,
+		maxQueuedTime:  0,
+	}
+
+	for title, tc := range map[string]struct {
+		actions      []testAction
+		options      *pusherOptions
+		countDropped int
+	}{
+		"single": {
+			actions: []testAction{
+				insert(30),
+				expect(timeout, []int{30}),
+			},
+		},
+		"get all": {
+			actions: []testAction{
+				insert(10),
+				insert(20),
+				insert(30),
+				expect(timeout, []int{10, 20, 30}),
+			},
+		},
+		"multiple operations": {
+			actions: []testAction{
+				insert(10),
+				insert(20),
+				insert(30),
+				expect(timeout, []int{10, 20, 30}),
+				insert(40),
+				insert(50),
+				expect(timeout, []int{40, 50}),
+			},
+		},
+		"max bytes": {
+			options: &pusherOptions{
+				maxPushBytes: 30,
+			},
+			actions: []testAction{
+				insert(30),
+				insert(10),
+				expect(timeout, []int{30}),
+				insert(20),
+				insert(30),
+				expect(timeout, []int{10, 20}),
+				insert(30),
+				expect(timeout, []int{30}),
+				expect(timeout, []int{30}),
+			},
+		},
+		"take at least one": {
+			options: &pusherOptions{
+				maxPushBytes: 1,
+			},
+			actions: []testAction{
+				insert(100),
+				insert(5),
+				insert(5),
+				expect(timeout, []int{100}),
+				expect(timeout, []int{5}),
+				expect(timeout, []int{5}),
+			},
+		},
+		"empty": {
+			actions: []testAction{
+				expectEmpty(),
+			},
+		},
+		"requeue": {
+			actions: []testAction{
+				insert(10),
+				insert(20),
+				expect(timeout, []int{10, 20}),
+				insert(30),
+				returnLast(),
+				expect(timeout, []int{10, 20, 30}),
+				expectEmpty(),
+			},
+		},
+		"max queued bytes": {
+			options: &pusherOptions{
+				maxPushBytes:   1024,
+				maxQueuedBytes: 20,
+			},
+			actions: []testAction{
+				insert(9),
+				insert(11),
+				expect(timeout, []int{9, 11}),
+				insert(10),
+				insert(15),
+				insert(5),
+				expect(timeout, []int{15, 5}),
+				expectEmpty(),
+			},
+			countDropped: 1,
+		},
+		"max queued bytes return last": {
+			options: &pusherOptions{
+				maxPushBytes:   1024,
+				maxQueuedBytes: 30,
+			},
+			actions: []testAction{
+				insert(2),
+				insert(9),
+				insert(11),
+				expect(timeout, []int{2, 9, 11}),
+				insert(10),
+				insert(5),
+				returnLast(),
+				expect(timeout, []int{11, 10, 5}),
+				expectEmpty(),
+			},
+			countDropped: 2,
+		},
+		"max queued items": {
+			options: &pusherOptions{
+				maxPushBytes:   1024,
+				maxQueuedItems: 2,
+			},
+			actions: []testAction{
+				insert(9),
+				insert(11),
+				expect(timeout, []int{9, 11}),
+				insert(10),
+				insert(11),
+				insert(15),
+				insert(5),
+				insert(1),
+				expect(timeout, []int{5, 1}),
+				expectEmpty(),
+			},
+			countDropped: 3,
+		},
+		"max queued items return last": {
+			options: &pusherOptions{
+				maxPushBytes:   1024,
+				maxQueuedItems: 3,
+			},
+			actions: []testAction{
+				insert(1),
+				insert(2),
+				expect(timeout, []int{1, 2}),
+				insert(3),
+				insert(4),
+				returnLast(),
+				expect(timeout, []int{2, 3, 4}),
+				expectEmpty(),
+			},
+			countDropped: 1,
+		},
+		"max queued time": {
+			options: &pusherOptions{
+				maxQueuedTime: time.Second,
+			},
+			actions: []testAction{
+				insert(1),
+				insert(2),
+				sleep(time.Second + time.Second/2),
+				insert(3),
+				expect(timeout, []int{3}),
+				expectEmpty(),
+			},
+			countDropped: 1,
+		},
+	} {
+		t.Run(title, func(t *testing.T) {
+			dropped := prometheus.NewCounterVec(prometheus.CounterOpts{
+				Name: "dropped",
+			}, nil)
+			if tc.options == nil {
+				tc.options = new(pusherOptions)
+				*tc.options = defaultOptions
+			}
+			tc.options.metrics.DroppedCounter = dropped
+			var st testSavedState
+			q := newQueue(tc.options)
+
+			for _, action := range tc.actions {
+				action(t, &q, &st)
+			}
+			m := dto.Metric{}
+			require.NoError(t, dropped.WithLabelValues().Write(&m))
+			require.NotNil(t, m.Counter)
+			require.NotNil(t, m.Counter.Value)
+			require.Equal(t, float64(tc.countDropped), *m.Counter.Value)
+		})
+	}
+}
+
+func TestQueuePush(t *testing.T) {
+	body := "HELLO WORLD!"
+	records := makeRecords([][]byte{
+		snap(body[:6]),
+		snap(body[6:]),
+	})
+	respond := func(code int, body string) func(w http.ResponseWriter, r *http.Request) {
+		return func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(code)
+			_, _ = w.Write([]byte(body))
+		}
+	}
+	for title, tc := range map[string]struct {
+		options     *pusherOptions
+		responses   []http.HandlerFunc
+		expectedErr error
+	}{
+		"200": {
+			responses: []http.HandlerFunc{
+				respond(http.StatusOK, "OK"),
+			},
+		},
+		"500, 200": {
+			responses: []http.HandlerFunc{
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusOK, "OK"),
+			},
+		},
+		"500x2, 200": {
+			responses: []http.HandlerFunc{
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusOK, "OK"),
+			},
+		},
+		"more 500": {
+			responses: []http.HandlerFunc{
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusOK, "OK"),
+			},
+			expectedErr: nil,
+		},
+		"tenant error": {
+			responses: []http.HandlerFunc{
+				respond(http.StatusUnauthorized, "invalid token"),
+			},
+			expectedErr: pushError{
+				kind:  errKindTenant,
+				inner: errors.New("server returned HTTP status 401 Unauthorized: invalid token"),
+			},
+		},
+		"max retries": {
+			options: func() *pusherOptions {
+				opt := defaultPusherOptions
+				opt.maxRetries = 3
+				return &opt
+			}(),
+			responses: []http.HandlerFunc{
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+				respond(http.StatusInternalServerError, "error"),
+			},
+		},
+		"discard": {
+			responses: []http.HandlerFunc{
+				respond(http.StatusBadRequest, "some data is bad"),
+			},
+		},
+		"rate limit": {
+			responses: []http.HandlerFunc{
+				respond(http.StatusTooManyRequests, "Too many requests"),
+			},
+			expectedErr: pushError{
+				kind:  errKindWait,
+				inner: errors.New(`server returned HTTP status 429 Too Many Requests: Too many requests`),
+			},
+		},
+		"fatal error": {
+			responses: []http.HandlerFunc{
+				respond(http.StatusTooManyRequests, "Maximum active stream limit exceeded"),
+			},
+			expectedErr: pushError{
+				kind:  errKindFatal,
+				inner: errors.New(`server returned HTTP status 429 Too Many Requests: Maximum active stream limit exceeded`),
+			},
+		},
+	} {
+		t.Run(title, func(t *testing.T) {
+			srv := testServer{
+				responses: tc.responses,
+			}
+			srv.start()
+			defer srv.stop()
+			url, err := url.Parse(srv.server.URL)
+			require.NoError(t, err)
+
+			registry := prometheus.NewRegistry()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+			defer cancel()
+
+			opt := defaultPusherOptions
+			if tc.options != nil {
+				opt = *tc.options
+			}
+			opt.metrics = pusher.NewMetrics(registry)
+			opt = opt.withTenant(1).withType("test")
+
+			q := newQueue(&opt)
+			for _, r := range records {
+				q.insert(r.data)
+			}
+
+			errGroup, gCtx := errgroup.WithContext(ctx)
+			errGroup.Go(func() error {
+				return q.push(gCtx, &sm.RemoteInfo{
+					Name: "test",
+					Url:  url.String(),
+				})
+			})
+			errGroup.Go(func() error {
+				defer cancel()
+				for {
+					if err := sleepCtx(gCtx, time.Second); err != nil {
+						return nil
+					}
+					if srv.done() {
+						return nil
+					}
+				}
+			})
+
+			if err = errGroup.Wait(); err == context.Canceled {
+				err = nil
+			}
+
+			if tc.expectedErr != nil {
+				require.Error(t, err)
+				require.Equal(t, err.Error(), tc.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+			require.True(t, srv.done())
+			require.Equal(t, []byte(body), srv.receivedBody)
+			require.Empty(t, q.get())
+		})
+	}
+}
+
+type testSavedState struct {
+	lastGet []queueEntry
+}
+
+type testAction func(*testing.T, *queue, *testSavedState)
+
+func insert(numBytes int) testAction {
+	data := make([]byte, numBytes)
+	return func(t *testing.T, q *queue, _ *testSavedState) {
+		q.insert(&data)
+	}
+}
+
+func expect(timeout time.Duration, expectedBlocks []int) testAction {
+	return func(t *testing.T, q *queue, st *testSavedState) {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-q.WaitC():
+		}
+		data := q.get()
+		st.lastGet = data
+		blocks := make([]int, len(data))
+		for idx, d := range data {
+			blocks[idx] = len(*d.data)
+		}
+		require.Equal(t, expectedBlocks, blocks)
+	}
+}
+
+func expectEmpty() testAction {
+	return func(t *testing.T, q *queue, st *testSavedState) {
+		select {
+		case <-q.WaitC():
+			t.Fatal("pending")
+		default:
+		}
+		require.Nil(t, q.get())
+		select {
+		case <-q.WaitC():
+			t.Fatal("pending")
+		default:
+		}
+	}
+}
+
+func returnLast() testAction {
+	return func(t *testing.T, q *queue, st *testSavedState) {
+		if st.lastGet == nil {
+			t.Fatal(st.lastGet)
+		}
+		q.requeue(st.lastGet)
+	}
+}
+
+func sleep(interval time.Duration) testAction {
+	return func(t *testing.T, q *queue, st *testSavedState) {
+		time.Sleep(interval)
+	}
+}

--- a/internal/pusher/v2/queue_test.go
+++ b/internal/pusher/v2/queue_test.go
@@ -174,12 +174,12 @@ func TestQueue(t *testing.T) {
 		},
 		"max queued time": {
 			options: &pusherOptions{
-				maxQueuedTime: time.Second,
+				maxQueuedTime: 100 * time.Millisecond,
 			},
 			actions: []testAction{
 				insert(1),
 				insert(2),
-				sleep(time.Second + time.Second/2),
+				sleep(150 * time.Millisecond),
 				insert(3),
 				expect(timeout, []int{3}),
 				expectEmpty(),
@@ -212,6 +212,10 @@ func TestQueue(t *testing.T) {
 }
 
 func TestQueuePush(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+
 	body := "HELLO WORLD!"
 	records := makeRecords([][]byte{
 		snap(body[:6]),

--- a/internal/pusher/v2/snappy_concat.go
+++ b/internal/pusher/v2/snappy_concat.go
@@ -1,0 +1,62 @@
+package v2
+
+import (
+	encoding_binary "encoding/binary"
+	"io"
+)
+
+// SnappyConcatReader is an io.Reader that takes a list of snappy-compressed buffers (Streams)
+// and returns a single valid snappy-compressed stream equivalent to the concatenation of those buffers
+// without additional allocation.
+type SnappyConcatReader struct {
+	Streams [][]byte
+	init    bool
+}
+
+// Read fulfills the io.Reader interface.
+func (s *SnappyConcatReader) Read(out []byte) (n int, err error) {
+	if !s.init {
+		s.init = true
+		decodedLen := s.stripHeaders()
+		// Check that we have room to write the uvarint
+		if fit := len(out); fit < encoding_binary.MaxVarintLen64 {
+			if maxValue := uint64(1) << (7 * fit); decodedLen >= maxValue {
+				return 0, io.ErrShortBuffer
+			}
+		}
+		n = encoding_binary.PutUvarint(out, decodedLen)
+		out = out[n:]
+	}
+	if n == 0 && len(s.Streams) == 0 {
+		return 0, io.EOF
+	}
+
+	// Copy all the streams that fit
+	for len(s.Streams) > 0 && len(out) >= len(s.Streams[0]) {
+		chunkLen := len(s.Streams[0])
+		copy(out, s.Streams[0])
+		s.Streams = s.Streams[1:]
+		n += chunkLen
+		out = out[chunkLen:]
+	}
+
+	// Copy a partial stream if there is room
+	if fit := len(out); fit > 0 && len(s.Streams) > 0 {
+		// Here s.Streams[0] is always larger than what's left in out.
+		// Otherwise it would've been copied by the previous loop.
+		copy(out, s.Streams[0][:fit])
+		s.Streams[0] = s.Streams[0][fit:]
+		n += fit
+	}
+	return n, nil
+}
+
+func (s *SnappyConcatReader) stripHeaders() uint64 {
+	var totalLength uint64
+	for idx := range s.Streams {
+		streamLen, skip := encoding_binary.Uvarint(s.Streams[idx])
+		totalLength += streamLen
+		s.Streams[idx] = s.Streams[idx][skip:]
+	}
+	return totalLength
+}

--- a/internal/pusher/v2/snappy_concat_test.go
+++ b/internal/pusher/v2/snappy_concat_test.go
@@ -1,0 +1,115 @@
+package v2
+
+import (
+	"crypto/rand"
+	"io"
+	"testing"
+
+	"github.com/golang/snappy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnappyConcatReader(t *testing.T) {
+	const bigRandSize = 4096 * 4
+	var bigRand [bigRandSize]byte
+	_, err := rand.Read(bigRand[:])
+	require.NoError(t, err)
+
+	for title, tc := range map[string]struct {
+		input    [][]byte
+		expected []byte
+		readFn   func(io.Reader) ([]byte, error)
+	}{
+		"sample": {
+			input: [][]byte{
+				snap("HELLO"),
+				snap(" WORL"),
+				snap("D!"),
+			},
+			expected: []byte("HELLO WORLD!"),
+		},
+		"single stream": {
+			input: [][]byte{
+				snap("Hello World!"),
+			},
+			expected: []byte("Hello World!"),
+		},
+		"sample small buf": {
+			input: [][]byte{
+				snap("HELLO WORLD 1\n"),
+				snap("HELLO WORLD 2!\n"),
+				snap("HELLO WORLD 3 AND LAST.\n"),
+			},
+			readFn:   readerWithBufSize(4),
+			expected: []byte("HELLO WORLD 1\nHELLO WORLD 2!\nHELLO WORLD 3 AND LAST.\n"),
+		},
+		"sample tiny buf": {
+			input: [][]byte{
+				snap("HELLO WORLD 1\n"),
+				snap("HELLO WORLD 2!\n"),
+				snap("HELLO WORLD 3 AND LAST.\n"),
+			},
+			readFn:   readerWithBufSize(1),
+			expected: []byte("HELLO WORLD 1\nHELLO WORLD 2!\nHELLO WORLD 3 AND LAST.\n"),
+		},
+		"sample mid buf": {
+			input: [][]byte{
+				snap("HELLO WORLD 1\n"),
+				snap("HELLO WORLD 2!\n"),
+				snap("HELLO WORLD 3 AND LAST.\n"),
+			},
+			readFn:   readerWithBufSize(16),
+			expected: []byte("HELLO WORLD 1\nHELLO WORLD 2!\nHELLO WORLD 3 AND LAST.\n"),
+		},
+		"very large": {
+			input: [][]byte{
+				snap(string(bigRand[:bigRandSize/4])),
+				snap(string(bigRand[bigRandSize/4 : bigRandSize/2])),
+				snap(string(bigRand[bigRandSize/2 : 3*bigRandSize/4])),
+				snap(string(bigRand[3*bigRandSize/4:])),
+			},
+			expected: bigRand[:],
+		},
+		"empty": {},
+	} {
+		t.Run(title, func(t *testing.T) {
+			r := &SnappyConcatReader{
+				Streams: tc.input,
+			}
+			if tc.readFn == nil {
+				tc.readFn = io.ReadAll
+			}
+			all, err := tc.readFn(r)
+			require.NoError(t, err)
+
+			result, err := snappy.Decode(nil, all)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func snap(data string) []byte {
+	return snappy.Encode(nil, []byte(data))
+}
+
+func readerWithBufSize(n int) func(io.Reader) ([]byte, error) {
+	buf := make([]byte, n)
+	return func(r io.Reader) ([]byte, error) {
+		var result []byte
+		for {
+			n, err := r.Read(buf)
+			if err != nil {
+				if err == io.EOF {
+					return result, nil
+				}
+				return nil, err
+			}
+			result = append(result, buf[:n]...)
+			if n != len(buf) {
+				return result, nil
+			}
+		}
+	}
+}

--- a/internal/pusher/v2/tenant_pusher.go
+++ b/internal/pusher/v2/tenant_pusher.go
@@ -1,0 +1,234 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/prometheus/prometheus/prompb"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/logproto"
+	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+// tenantPusher is in charge of pushing changes for a specific tenant.
+type tenantPusher struct {
+	tenantID       int64
+	pushCounter    uint64
+	logs, metrics  queue
+	tenantProvider pusher.TenantProvider
+	options        pusherOptions
+}
+
+var _ payloadHandler = &tenantPusher{}
+
+func newTenantPusher(tenantID int64, tenantProvider pusher.TenantProvider, options pusherOptions) *tenantPusher {
+	mOptions := options.withType(pusher.LabelValueMetrics)
+	eOptions := options.withType(pusher.LabelValueLogs)
+	tp := &tenantPusher{
+		tenantID:       tenantID,
+		tenantProvider: tenantProvider,
+		options:        options,
+		logs:           newQueue(&eOptions),
+		metrics:        newQueue(&mOptions),
+	}
+	return tp
+}
+
+func (p *tenantPusher) run(ctx context.Context) payloadHandler {
+	p.options.logger.Info().Msg("starting pusher")
+	err := p.runPushers(ctx)
+	p.options.logger.Info().Err(err).Msg("pusher terminated")
+
+	if err == nil || err == context.Canceled || err == errTenantIdle {
+		p.options.logger.Info().Err(err).Msg("clearing tenant slot")
+		return nil
+	}
+
+	var pErr pushError
+	if !errors.As(err, &pErr) {
+		p.options.logger.Warn().Err(err).Msg("unexpected error, clearing slot")
+		return nil
+	}
+
+	switch pErr.kind {
+	case errKindWait:
+		// Some failure forces us to stop pushing for a while, but keep accumulating metrics meanwhile.
+		p.options.logger.Info().Dur("delay", p.options.waitPeriod).Msg("delaying metrics publishing")
+		return &delayPusher{
+			next:  p,
+			delay: p.options.waitPeriod,
+		}
+
+	case errKindTenant:
+		p.options.logger.Debug().Msg("refreshing tenant")
+		// The tenant could be stale. Let's just restart the pusher with a minimal delay.
+		return &delayPusher{
+			next:  p,
+			delay: p.options.tenantDelay,
+		}
+
+	case errKindFatal:
+		// Possibly a situation where we can't push metrics and won't be able to push them
+		// in the future. Discard metrics for this tenant for an extended period of time.
+		p.options.logger.Warn().Dur("duration", p.options.discardPeriod).Msg("discarding metrics")
+		return &discardPusher{
+			duration: p.options.discardPeriod,
+			options:  p.options,
+		}
+
+	default:
+		p.options.logger.Warn().Err(err).Msg("unexpected error, clearing slot")
+		return nil
+	}
+}
+
+func (p *tenantPusher) runPushers(ctx context.Context) error {
+	// TODO(adrian): If tenant had the plan in here, we could have different retention for paid tenants.
+	tenant, err := p.tenantProvider.GetTenant(ctx, &sm.TenantInfo{
+		Id: p.tenantID,
+	})
+	if err != nil {
+		p.options.metrics.FailedCounter.WithLabelValues(pusher.LabelValueTenant).Inc()
+		return pushError{
+			kind:  errKindFatal,
+			inner: err,
+		}
+	}
+
+	g, gCtx := errgroup.WithContext(ctx)
+
+	g.Go(func() error {
+		return p.metrics.push(gCtx, tenant.MetricsRemote)
+	})
+
+	g.Go(func() error {
+		return p.logs.push(gCtx, tenant.EventsRemote)
+	})
+
+	// Optionally perform some validations.
+
+	if p.options.maxIdleTime > 0 {
+		g.Go(idleChecker(gCtx, p.options.maxIdleTime, &p.pushCounter))
+	}
+
+	if p.options.maxLifetime > 0 {
+		g.Go(maxLifetimeChecker(gCtx, p.options.maxLifetime))
+	}
+
+	return g.Wait()
+}
+
+var (
+	errMaxLifeTimeExceeded = pushError{
+		kind:  errKindTenant,
+		inner: errors.New("max life time exceeded"),
+	}
+	errTenantIdle = errors.New("tenant is idle")
+)
+
+func idleChecker(ctx context.Context, interval time.Duration, ptr *uint64) func() error {
+	return func() error {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		lastValue := atomic.LoadUint64(ptr)
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-t.C:
+				// check that source has changed
+				curValue := atomic.LoadUint64(ptr)
+				if curValue == lastValue {
+					return errTenantIdle
+				}
+				lastValue = curValue
+			}
+		}
+	}
+}
+
+func maxLifetimeChecker(ctx context.Context, maxLifetime time.Duration) func() error {
+	return func() error {
+		t := time.NewTimer(maxLifetime)
+		select {
+		case <-ctx.Done():
+			t.Stop()
+			return ctx.Err()
+		case <-t.C:
+			return errMaxLifeTimeExceeded
+		}
+	}
+}
+
+func (p *tenantPusher) publish(payload pusher.Payload) {
+	atomic.AddUint64(&p.pushCounter, 1)
+
+	if len(payload.Metrics()) > 0 {
+		p.metrics.insert(toRequest(&prompb.WriteRequest{Timeseries: payload.Metrics()}, p.options.pool))
+	}
+
+	if len(payload.Streams()) > 0 {
+		p.logs.insert(toRequest(&logproto.PushRequest{Streams: payload.Streams()}, p.options.pool))
+	}
+}
+
+func toRequest(m proto.Marshaler, p bufferPool) *[]byte {
+	data, err := m.Marshal()
+	if err != nil {
+		panic(err)
+	}
+	bufPtr := p.get()
+	*bufPtr = (*bufPtr)[0:cap(*bufPtr)]
+	encoded := snappy.Encode(*bufPtr, data)
+	return &encoded
+}
+
+type delayPusher struct {
+	next  payloadHandler
+	delay time.Duration
+}
+
+var _ payloadHandler = delayPusher{}
+
+func (p delayPusher) run(ctx context.Context) payloadHandler {
+	err := sleepCtx(ctx, p.delay)
+	if err != nil {
+		// Context cancelled
+		return nil
+	}
+
+	return p.next
+}
+
+func (p delayPusher) publish(payloads pusher.Payload) {
+	p.next.publish(payloads)
+}
+
+type discardPusher struct {
+	duration time.Duration
+	options  pusherOptions
+}
+
+var _ payloadHandler = discardPusher{}
+
+func (p discardPusher) run(ctx context.Context) payloadHandler {
+	// error can be ignored (only possible is context.Canceled)
+	// as it's returning a nil handler anyway.
+	_ = sleepCtx(ctx, p.duration)
+	return nil
+}
+
+func (p discardPusher) publish(payloads pusher.Payload) {
+	if len(payloads.Metrics()) > 0 {
+		p.options.metrics.DroppedCounter.WithLabelValues(pusher.LabelValueMetrics).Inc()
+	}
+	if len(payloads.Streams()) > 0 {
+		p.options.metrics.DroppedCounter.WithLabelValues(pusher.LabelValueLogs).Inc()
+	}
+}

--- a/internal/pusher/v2/tenant_pusher_test.go
+++ b/internal/pusher/v2/tenant_pusher_test.go
@@ -1,0 +1,108 @@
+package v2
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang/snappy"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+func TestTenantPusher(t *testing.T) {
+	tenantProvider := testTenantProvider{
+		1: &sm.Tenant{
+			Id:            1,
+			OrgId:         1,
+			MetricsRemote: nil,
+			EventsRemote:  nil,
+			Status:        sm.TenantStatus_ACTIVE,
+		},
+	}
+
+	for title, tc := range map[string]struct {
+		tenantID int64
+		options  pusherOptions
+	}{} {
+		t.Run(title, func(t *testing.T) {
+			p := newTenantPusher(tc.tenantID, tenantProvider, tc.options)
+			deadline, ok := t.Deadline()
+			if !ok {
+				deadline = time.Now().Add(time.Minute * 5)
+			}
+			ctx, cancel := context.WithDeadline(context.Background(), deadline)
+			defer cancel()
+			go p.run(ctx)
+		})
+	}
+}
+
+func makeRecords(blocks [][]byte) []queueEntry {
+	out := make([]queueEntry, len(blocks))
+	for idx, b := range blocks {
+		data := make([]byte, len(b))
+		copy(data, b)
+		out[idx].data = &data
+	}
+	return out
+}
+
+type testTenantProvider map[int64]*sm.Tenant
+
+var errTestNoTenant = errors.New("tenant not found")
+
+func (t testTenantProvider) GetTenant(ctx context.Context, info *sm.TenantInfo) (*sm.Tenant, error) {
+	tenant, found := t[info.Id]
+	if !found {
+		return nil, errTestNoTenant
+	}
+	return tenant, nil
+}
+
+type testServer struct {
+	mu           sync.Mutex
+	receivedBody []byte
+	responses    []http.HandlerFunc
+	server       *httptest.Server
+}
+
+func (s *testServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.responses) == 0 {
+		panic(len(s.responses))
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		panic(err)
+	}
+	content, err := snappy.Decode(nil, body)
+	if err != nil {
+		panic(err)
+	}
+	s.receivedBody = content
+	defer r.Body.Close()
+	act := s.responses[0]
+	s.responses = s.responses[1:]
+	act(w, r)
+}
+
+func (s *testServer) start() {
+	s.server = httptest.NewServer(s)
+}
+
+func (s *testServer) stop() {
+	s.server.Close()
+}
+
+func (s *testServer) done() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.responses) == 0
+}


### PR DESCRIPTION
This adds a new publisher (enable with `--publisher v2` flag):

- Uses a single pusher loop per-tenant and is able to submit the results of multiple check runs on a single request.
- Keeps the check results compressed in memory to reduce the memory impact, specially during network outages.
- Can react to various error conditions like rate-limits or out-of-quota.
- Is configurable in terms of memory use (max queued memory per tenant).
