### PR TITLE
feat: Prevent discontinuities in timeseries

### DIFF
--- a/internal/pusher/gaps.go
+++ b/internal/pusher/gaps.go
@@ -1,0 +1,120 @@
+package pusher
+
+import (
+	"time"
+
+	"github.com/prometheus/prometheus/prompb"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/logproto"
+)
+
+const (
+	// MetricsMaxGap is the maximum interval between two consecutive samples of a timeseries so that
+	// there is no discontinuity in it.
+	MetricsMaxGap = 5 * time.Minute
+
+	// maxHoles is the maximum number of gaps that is accepted between two consecutive samples of a timeseries
+	// for the purposes of making this metric continuous.
+	// If a gap in a timeseries is found that requires adding more than this number of extra samples, then it's
+	// ignored and the discontinuity left as is.
+	maxHoles = 5
+)
+
+// MetricGapFiller wraps a Publisher and pads the timeseries with repeated samples so that there is no
+// discontinuity in them. This is useful to prevent discontinuities in metrics that have a generation period
+// longer that MetricsMaxGap.
+type MetricGapFiller struct {
+	MaxGap      time.Duration
+	Publisher   Publisher
+	KnownSeries map[string]prompb.Sample
+}
+
+// Publish passes the Payload to the wrapped publisher, padding the metrics if necessary.
+func (m *MetricGapFiller) Publish(p Payload) {
+	m.Publisher.Publish(payloadImpl{
+		tenant: p.Tenant(),
+		series: m.process(p.Metrics()),
+		logs:   p.Streams(),
+	})
+}
+
+func (m *MetricGapFiller) process(next []prompb.TimeSeries) []prompb.TimeSeries {
+	series := make(map[string]prompb.Sample, len(next))
+	output := make([]prompb.TimeSeries, len(next))
+
+	for i := range next {
+		output[i] = next[i]
+		if !isSupported(next[i]) {
+			continue
+		}
+		key, err := seriesKey(next[i])
+		if err != nil {
+			continue
+		}
+		series[key] = next[i].Samples[0]
+		if prev, seen := m.KnownSeries[key]; seen {
+			output[i].Samples = fillGaps(prev, next[i].Samples, m.MaxGap)
+		}
+	}
+
+	m.KnownSeries = series
+	return output
+}
+
+func fillGaps(old prompb.Sample, newSlice []prompb.Sample, maxGap time.Duration) []prompb.Sample {
+	// Here newSlice has already been validated to have length 1, but just in case.
+	if len(newSlice) != 1 {
+		return newSlice
+	}
+	new := newSlice[0]
+	oldTime := time.UnixMilli(old.Timestamp)
+	newTime := time.UnixMilli(new.Timestamp)
+	diff := newTime.Sub(oldTime)
+	if diff <= maxGap {
+		return newSlice
+	}
+	repeats := int64(diff / maxGap)
+	if repeats > maxHoles {
+		return newSlice
+	}
+	if diff%maxGap == 0 {
+		repeats--
+	}
+	result := make([]prompb.Sample, repeats+1)
+	for i, base := int64(0), oldTime.Add(maxGap); i < repeats; i, base = i+1, base.Add(maxGap) {
+		result[i].Timestamp = base.UnixMilli()
+		result[i].Value = old.Value
+	}
+	result[repeats] = new
+	return result
+}
+
+func seriesKey(s prompb.TimeSeries) (string, error) {
+	obj := prompb.Labels{
+		Labels: s.Labels,
+	}
+	data, err := obj.Marshal()
+	return string(data), err
+}
+
+func isSupported(s prompb.TimeSeries) bool {
+	return len(s.Samples) == 1 && len(s.Exemplars) == 0 && len(s.Histograms) == 0
+}
+
+type payloadImpl struct {
+	tenant int64
+	series []prompb.TimeSeries
+	logs   []logproto.Stream
+}
+
+func (p payloadImpl) Tenant() int64 {
+	return p.tenant
+}
+
+func (p payloadImpl) Metrics() []prompb.TimeSeries {
+	return p.series
+}
+
+func (p payloadImpl) Streams() []logproto.Stream {
+	return p.logs
+}

--- a/internal/pusher/gaps_test.go
+++ b/internal/pusher/gaps_test.go
@@ -37,6 +37,12 @@ func TestGap(t *testing.T) {
 		}
 	}
 
+	// The format for representing a timeseries here is:
+	//
+	// metric_name{"key"="value",...} value@time[,value2@time2...]
+	//
+	// This results in a prompb.TimeSeries with Labels __name__="metric_name", the rest of the labels,
+	// and one or more samples with the given value and timestamp.
 	type subtest struct {
 		input, expected Payload
 	}

--- a/internal/pusher/gaps_test.go
+++ b/internal/pusher/gaps_test.go
@@ -37,12 +37,21 @@ func TestGap(t *testing.T) {
 		}
 	}
 
+	// Format
+	// ======
+	//
 	// The format for representing a timeseries here is:
 	//
 	// metric_name{"key"="value",...} value@time[,value2@time2...]
 	//
 	// This results in a prompb.TimeSeries with Labels __name__="metric_name", the rest of the labels,
 	// and one or more samples with the given value and timestamp.
+	//
+	// Expected
+	// ========
+	//
+	// A missing expected field for a test means the output is expected to be the same
+	// as the input.g
 	type subtest struct {
 		input, expected Payload
 	}

--- a/internal/pusher/gaps_test.go
+++ b/internal/pusher/gaps_test.go
@@ -1,0 +1,509 @@
+package pusher
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/prometheus/prompb"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/logproto"
+)
+
+func TestGap(t *testing.T) {
+	withHistogram := func(s prompb.TimeSeries, h prompb.Histogram) prompb.TimeSeries {
+		s.Histograms = append(s.Histograms, h)
+		return s
+	}
+
+	withExemplars := func(s prompb.TimeSeries, e prompb.Exemplar) prompb.TimeSeries {
+		s.Exemplars = append(s.Exemplars, e)
+		return s
+	}
+
+	baseTime := time.Now()
+	makeLogs := func(delta time.Duration) []logproto.Stream {
+		return []logproto.Stream{
+			{
+				Labels: "a=b,c=d",
+				Entries: []logproto.Entry{
+					{Timestamp: baseTime.Add(delta), Line: "hello world"},
+					{Timestamp: baseTime.Add(delta), Line: "this is a log message"},
+				},
+			},
+		}
+	}
+
+	type subtest struct {
+		input, expected Payload
+	}
+	for title, test := range map[string]struct {
+		filler MetricGapFiller
+		tests  []subtest
+	}{
+		"no gap": {
+			filler: MetricGapFiller{MaxGap: 5 * time.Millisecond},
+			tests: []subtest{
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@0`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@0`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@1`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@1`),
+						},
+					},
+				},
+			},
+		},
+
+		"single gap": {
+			filler: MetricGapFiller{MaxGap: 5 * time.Millisecond},
+			tests: []subtest{
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@0`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@0`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@10`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@10`),
+						},
+					},
+					expected: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@5,2@10`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@5,1@10`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 3@20`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@20`),
+						},
+					},
+					expected: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@15,3@20`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@15,0@20`),
+						},
+					},
+				},
+			},
+		},
+
+		"large gap": {
+			filler: MetricGapFiller{MaxGap: 5 * time.Millisecond},
+			tests: []subtest{
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@0`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@0`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@20`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@10`),
+						},
+					},
+					expected: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@5,1.5@10,1.5@15,2@20`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@5,1@10`),
+						},
+					},
+				},
+			},
+		},
+
+		"legitimate gap in metrics": {
+			filler: MetricGapFiller{MaxGap: 5 * time.Millisecond},
+			tests: []subtest{
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 10@0`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 20@5`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@5`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`other_metric{"foo"="bar"} = 2@10`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 30@15`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`other_metric{"foo"="bar"} = 0@20`),
+						},
+					},
+				},
+			},
+		},
+
+		"gap too big": {
+			filler: MetricGapFiller{MaxGap: 5 * time.Millisecond},
+			tests: []subtest{
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@0`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@0`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@30`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@30`),
+						},
+					},
+				},
+			},
+		},
+
+		"ignore metrics with more than one sample": {
+			filler: MetricGapFiller{MaxGap: 5 * time.Millisecond},
+			tests: []subtest{
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@0,2@5`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@0`),
+							stringToSeries(`third_metric{"foo"="bar"} = 10@0`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@20`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@10,2@15`),
+							stringToSeries(`third_metric{"foo"="bar"} = 10@15`),
+						},
+					},
+					expected: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@20`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@10,2@15`),
+							stringToSeries(`third_metric{"foo"="bar"} = 10@5,10@10,10@15`),
+						},
+					},
+				},
+			},
+		},
+
+		"ignore timeseries with histograms": {
+			filler: MetricGapFiller{MaxGap: 5 * time.Millisecond},
+			tests: []subtest{
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@0`),
+							withHistogram(
+								stringToSeries(`histogram_metric{"foo"="bar"} = 0@0`),
+								prompb.Histogram{Sum: 5},
+							),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@10`),
+							withHistogram(
+								stringToSeries(`histogram_metric{"foo"="bar"} = 1@10`),
+								prompb.Histogram{Sum: 10, Timestamp: 10},
+							),
+						},
+					},
+					expected: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@5,2@10`),
+							withHistogram(
+								stringToSeries(`histogram_metric{"foo"="bar"} = 1@10`),
+								prompb.Histogram{Sum: 10, Timestamp: 10},
+							),
+						},
+					},
+				},
+			},
+		},
+
+		"ignore timeseries with exemplars": {
+			filler: MetricGapFiller{MaxGap: 5 * time.Millisecond},
+			tests: []subtest{
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@0`),
+							withExemplars(
+								stringToSeries(`exemplars_metric{"foo"="bar"} = 0@0`),
+								prompb.Exemplar{Value: 1},
+							),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@10`),
+							withExemplars(
+								stringToSeries(`exemplars_metric{"foo"="bar"} = 100@10`),
+								prompb.Exemplar{Value: 100, Timestamp: 10},
+							),
+						},
+					},
+					expected: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@5,2@10`),
+							withExemplars(
+								stringToSeries(`exemplars_metric{"foo"="bar"} = 100@10`),
+								prompb.Exemplar{Value: 100, Timestamp: 10},
+							),
+						},
+					},
+				},
+			},
+		},
+
+		"pass logs": {
+			filler: MetricGapFiller{MaxGap: 5 * time.Millisecond},
+			tests: []subtest{
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@0`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@0`),
+						},
+						logs: makeLogs(0),
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@10`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@10`),
+						},
+						logs: makeLogs(100),
+					},
+					expected: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@5,2@10`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@5,1@10`),
+						},
+						logs: makeLogs(100),
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 3@20`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@20`),
+						},
+					},
+					expected: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@15,3@20`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@15,0@20`),
+						},
+					},
+				},
+			},
+		},
+
+		"small variance": {
+			filler: MetricGapFiller{MaxGap: 5 * time.Millisecond},
+			tests: []subtest{
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@0`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@0`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@9`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@9`),
+						},
+					},
+					expected: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 1.5@5,2@9`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@5,1@9`),
+						},
+					},
+				},
+				{
+					input: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 3@18`),
+							stringToSeries(`other_metric{"foo"="bar"} = 0@18`),
+						},
+					},
+					expected: payloadImpl{
+						tenant: 1,
+						series: []prompb.TimeSeries{
+							stringToSeries(`my_metric{"foo"="bar"} = 2@14,3@18`),
+							stringToSeries(`other_metric{"foo"="bar"} = 1@14,0@18`),
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(title, func(t *testing.T) {
+			for idx, subcase := range test.tests {
+				var recorder recordingPublisher
+				test.filler.Publisher = &recorder
+				test.filler.Publish(subcase.input)
+				if subcase.expected == nil {
+					subcase.expected = subcase.input
+				}
+				require.Equal(t, subcase.expected, recorder.last, idx)
+			}
+		})
+	}
+}
+
+type recordingPublisher struct {
+	last Payload
+}
+
+func (r *recordingPublisher) Publish(p Payload) {
+	r.last = p
+}
+
+var decodeRegexp = regexp.MustCompile(`^([^\ {]*){(.*)} = ([0-9\.@,]+)$`)
+
+func stringToSeries(str string) prompb.TimeSeries {
+	m := decodeRegexp.FindStringSubmatch(str)
+	if len(m) != 4 {
+		panic(str)
+	}
+
+	var l []prompb.Label
+	if len(m[1]) > 0 {
+		l = append(l, prompb.Label{
+			Name:  "__name__",
+			Value: m[1],
+		})
+	}
+	var err error
+	for _, chunk := range strings.Split(m[2], ",") {
+		parts := strings.Split(chunk, "=")
+		if len(parts) != 2 {
+			panic(parts)
+		}
+		var lab prompb.Label
+		lab.Name, err = strconv.Unquote(parts[0])
+		if err != nil {
+			panic(err)
+		}
+		lab.Value, err = strconv.Unquote(parts[1])
+		if err != nil {
+			panic(err)
+		}
+		l = append(l, lab)
+	}
+
+	var s []prompb.Sample
+	for _, chunk := range strings.Split(m[3], ",") {
+		var err error
+		parts := strings.Split(chunk, "@")
+		if len(parts) != 2 {
+			panic(parts)
+		}
+		var sample prompb.Sample
+		sample.Value, err = strconv.ParseFloat(parts[0], 64)
+		if err != nil {
+			panic(err)
+		}
+		sample.Timestamp, err = strconv.ParseInt(parts[1], 10, 64)
+		if err != nil {
+			panic(err)
+		}
+		s = append(s, sample)
+	}
+
+	return prompb.TimeSeries{
+		Labels:  l,
+		Samples: s,
+	}
+}

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -114,6 +114,16 @@ func NewWithOpts(ctx context.Context, check sm.Check, opts ScraperOpts) (*Scrape
 		return nil, err
 	}
 
+	// If the check frequency is longer than the maximum metrics gaps,
+	// wrap the publisher in a MetricGapFiller to prevent discontinuities
+	// in time series.
+	if time.Duration(check.Frequency)*time.Millisecond > pusher.MetricsMaxGap {
+		opts.Publisher = &pusher.MetricGapFiller{
+			MaxGap:    maxGap,
+			Publisher: opts.Publisher,
+		}
+	}
+
 	return &Scraper{
 		publisher:     opts.Publisher,
 		cancel:        cancel,

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -119,7 +119,7 @@ func NewWithOpts(ctx context.Context, check sm.Check, opts ScraperOpts) (*Scrape
 	// in time series.
 	if time.Duration(check.Frequency)*time.Millisecond > pusher.MetricsMaxGap {
 		opts.Publisher = &pusher.MetricGapFiller{
-			MaxGap:    maxGap,
+			MaxGap:    pusher.MetricsMaxGap,
 			Publisher: opts.Publisher,
 		}
 	}


### PR DESCRIPTION
If a check is configured with an interval longer than 5 minutes, the generated time series will have discontinuities in them.

This PR adds logic to prevent those by repeating the last value of a series at the required interval to prevent discontinuities.

This only affects metrics that are present between two consecutive executions of a check.