### PR TITLE
Feature: use expression to match specific headers in multiHTTP

### DIFF
--- a/internal/prober/multihttp/script.tmpl
+++ b/internal/prober/multihttp/script.tmpl
@@ -48,6 +48,23 @@ export const options = {
 	discardResponseBodies: false, // enable only if there are checks?
 };
 
+function assertHeader(headers, name, matcher) {
+	const lcName = name.toLowerCase();
+	const values = Object.entries(headers).
+		filter(h => h[0].toLowerCase() === lcName).
+		map(h => h[1]);
+
+	if (values.find(v => matcher(v)) !== undefined) {
+		return true;
+	} else if (values.length === 0) {
+		console.warn(`'${name}' not present in response`);
+	} else {
+		values.forEach(v => console.warn(`'${name}' has the value '${v}'`));
+	}
+
+	return false;
+}
+
 export default function() {
 	let response;
 	const vars = {};

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -379,6 +379,18 @@ func TestBuildChecks(t *testing.T) {
 			},
 			expected: `check(response, { "header contains \"value\"": response => { const values = Object.entries(response.headers).map(header => header[0].toLowerCase() + ': ' + header[1]); return !!values.find(value => value.includes("value")); } }, {"url": "http://example.com", "method": "GET"});`,
 		},
+		"TestBuildChecksTextAssertionWithHeadersSubjectAndExpression": {
+			url:    "http://example.com",
+			method: "GET",
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:       sm.MultiHttpEntryAssertionType_TEXT,
+				Condition:  sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+				Subject:    sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_HEADERS,
+				Expression: "Content-Type",
+				Value:      "value",
+			},
+			expected: `check(response, { "header contains \"value\"": response => { return assertHeader(response.headers, "Content-Type", v => value.includes("value")); } }, {"url": "http://example.com", "method": "GET"});`,
+		},
 		"TestBuildChecksTextAssertionWithStatusCodeSubject": {
 			url:    "http://example.com",
 			method: "GET",

--- a/pkg/pb/synthetic_monitoring/checks.pb.go
+++ b/pkg/pb/synthetic_monitoring/checks.pb.go
@@ -2007,6 +2007,19 @@ func (m *HttpRequestBody) XXX_DiscardUnknown() {
 var xxx_messageInfo_HttpRequestBody proto.InternalMessageInfo
 
 // MultiHttpEntryAssertion represents a single assertion to be made on the response.
+//
+// The `value` field specifies the _value_ that the subject and the condition
+// should meet, e.g. if the subject is body and the condition is contains,
+// value specifies the substring that should be found in the body.
+//
+// For the JSON_PATH_VALUE type, `expression` specifies the JSON path to match against `value`.
+//
+// For the JSON_PATH_ASSERTION type, `expression` specifies the JSON path to assert.
+//
+// For the TEXT type, if the subject is `RESPONSE_HEADERS`, `expression`
+// specifies which specific header should be used as the subject of the
+// operation. Headers are case-insensitive (RFC 7230, section 3.2,
+// https://datatracker.ietf.org/doc/html/rfc7230#section-3.2).
 type MultiHttpEntryAssertion struct {
 	Type       MultiHttpEntryAssertionType             `protobuf:"varint,1,opt,name=type,proto3,enum=synthetic_monitoring.MultiHttpEntryAssertionType" json:"type"`
 	Subject    MultiHttpEntryAssertionSubjectVariant   `protobuf:"varint,2,opt,name=subject,proto3,enum=synthetic_monitoring.MultiHttpEntryAssertionSubjectVariant" json:"subject,omitempty"`

--- a/pkg/pb/synthetic_monitoring/checks.proto
+++ b/pkg/pb/synthetic_monitoring/checks.proto
@@ -525,6 +525,19 @@ enum MultiHttpEntryAssertionConditionVariant {
 }
 
 // MultiHttpEntryAssertion represents a single assertion to be made on the response.
+//
+// The `value` field specifies the _value_ that the subject and the condition
+// should meet, e.g. if the subject is body and the condition is contains,
+// value specifies the substring that should be found in the body.
+//
+// For the JSON_PATH_VALUE type, `expression` specifies the JSON path to match against `value`.
+//
+// For the JSON_PATH_ASSERTION type, `expression` specifies the JSON path to assert.
+//
+// For the TEXT type, if the subject is `RESPONSE_HEADERS`, `expression`
+// specifies which specific header should be used as the subject of the
+// operation. Headers are case-insensitive (RFC 7230, section 3.2,
+// https://datatracker.ietf.org/doc/html/rfc7230#section-3.2).
 message MultiHttpEntryAssertion {
   MultiHttpEntryAssertionType             type       = 1 [(gogoproto.jsontag) = "type"];
   MultiHttpEntryAssertionSubjectVariant   subject    = 2 [(gogoproto.jsontag) = "subject,omitempty"];

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -108,8 +108,11 @@ var (
 	ErrInvalidHttpRequestBodyPayload     = errors.New("invalid HTTP request body payload")
 	ErrInvalidQueryFieldName             = errors.New("invalid query field name")
 
-	ErrInvalidMultiHttpAssertion     = errors.New("invalid multi-http assertion")
-	ErrInvalidMultiHttpEntryVariable = errors.New("invalid multi-http variable")
+	ErrInvalidMultiHttpAssertion                     = errors.New("invalid multi-http assertion")
+	ErrInvalidMultiHttpEntryVariable                 = errors.New("invalid multi-http variable")
+	ErrInvalidMultiHttpAssertionMissingValue         = errors.New("invalid multi-http assertion, missing value")
+	ErrInvalidMultiHttpAssertionExpressionNotAllowed = errors.New("invalid multi-http assertion, expression not allowed")
+	ErrInvalidMultiHttpAssertionMissingHeaderName    = errors.New("invalid multi-http assertion, missing header name")
 )
 
 const (
@@ -754,16 +757,12 @@ func (a *MultiHttpEntryAssertion) Validate() error {
 	case MultiHttpEntryAssertionType_TEXT:
 		// Value is required
 		if len(a.Value) == 0 {
-			return ErrInvalidMultiHttpAssertion
+			return ErrInvalidMultiHttpAssertionMissingValue
 		}
 
-		// Expression is not allowed.
-		//
-		// This is super annoying because headers are stuffed with
-		// text, and expression could be used to validate specific
-		// headers.
-		if len(a.Expression) != 0 {
-			return ErrInvalidMultiHttpAssertion
+		// Expression is not allowed for subjects other than response headers.
+		if a.Subject != MultiHttpEntryAssertionSubjectVariant_RESPONSE_HEADERS && len(a.Expression) != 0 {
+			return ErrInvalidMultiHttpAssertionExpressionNotAllowed
 		}
 
 	case MultiHttpEntryAssertionType_JSON_PATH_VALUE:


### PR DESCRIPTION
In order to be able to match specific headers in multiHTTP checks, we use the existing `expression` field to specify the header name to match. Other than this, everything works as before. There's a fallback in place, so that in case we have a check _without_ an expression, it uses the old behavior.