### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 ## [Unreleased]
 
 
+<a name="v0.17.0"></a>
+## [v0.17.0] - 2023-08-31
+### Feature
+- use expression to match specific headers in multiHTTP
+
+### Fix
+- use double quotes with JS-escaped strings
+- headers object might have extra commas
+- pass body to HTTP request if specified
+
+
 <a name="v0.16.5"></a>
 ## [v0.16.5] - 2023-07-14
 ### Fix
@@ -449,7 +460,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.16.5...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.17.0...HEAD
+[v0.17.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.16.5...v0.17.0
 [v0.16.5]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.16.4...v0.16.5
 [v0.16.4]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.16.3...v0.16.4
 [v0.16.3]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.16.2...v0.16.3


### PR DESCRIPTION
* Refactor pusher to allow multiple implementations (#488)
* Fix: pass body to HTTP request if specified
* Update golangci-lint and gotestsum
* Fix: headers object might have extra commas
* Fix: use double quotes with JS-escaped strings
* Feature: use expression to match specific headers in multiHTTP
* Move client logic to its own file
* Move metrics to its own file
* Export HttpError from prom package
* Add condition variable
* Add queue
* Add SnappyConcatReader
* Add errors
* Add options
* Add tenant pusher
* Add publisher
* Enable v2 publisher
* Assert that TenantManager is a TenantProvider
* Add option to run only fast tests
* Fix label names, it should be "type" not "target"