### PR TITLE
Extract TenantManager out of pusher into its own package

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
 	pusherV1 "github.com/grafana/synthetic-monitoring-agent/internal/pusher/v1"
 	pusherV2 "github.com/grafana/synthetic-monitoring-agent/internal/pusher/v2"
+	"github.com/grafana/synthetic-monitoring-agent/internal/tenants"
 	"github.com/grafana/synthetic-monitoring-agent/internal/version"
 	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
@@ -208,7 +209,7 @@ func run(args []string, stdout io.Writer) error {
 		k6Runner = k6runner.New(*k6URI)
 	}
 
-	tm := pusher.NewTenantManager(ctx, synthetic_monitoring.NewTenantsClient(conn), tenantCh, 15*time.Minute)
+	tm := tenants.NewManager(ctx, synthetic_monitoring.NewTenantsClient(conn), tenantCh, 15*time.Minute)
 
 	pusherRegistry := pusher.NewRegistry[pusher.Factory]()
 	pusherRegistry.MustRegister(pusherV1.Name, pusherV1.NewPublisher)

--- a/internal/tenants/manager_test.go
+++ b/internal/tenants/manager_test.go
@@ -1,4 +1,4 @@
-package pusher
+package tenants
 
 import (
 	"context"
@@ -61,7 +61,7 @@ func TestTenantManagerGetTenant(t *testing.T) {
 
 	tenantCh := make(chan sm.Tenant)
 
-	tm := NewTenantManager(ctx, &tc, tenantCh, 500*time.Millisecond)
+	tm := NewManager(ctx, &tc, tenantCh, 500*time.Millisecond)
 
 	t1 := tc.tenants[1]
 


### PR DESCRIPTION
The intention here is that it should be possible to use the tenant manager in more places than just the pusher, and it should be possible to share the cache.