### PR TITLE
Use local IDs in scraper, global IDs in pusher

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1,0 +1,68 @@
+package model
+
+import (
+	"fmt"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+type GlobalID int64
+
+type Check struct {
+	sm.Check
+	RegionId int `json:"regionId"`
+}
+
+func (c *Check) FromSM(check sm.Check) {
+	// This implementation is a bit wasteful, but it ensures that it
+	// remains in sync with the protobuf definition.
+
+	data, err := check.Marshal()
+	if err != nil {
+		panic(err)
+	}
+
+	if err := c.Check.Unmarshal(data); err != nil {
+		panic(err)
+	}
+
+	cid, crid := GetLocalAndRegionIDs(GlobalID(check.Id))
+	tid, trid := GetLocalAndRegionIDs(GlobalID(check.TenantId))
+
+	if crid != trid {
+		panic(fmt.Sprintf("inconsistent region ids %d and %d, checkId %d, tenantId %d", crid, trid, check.Id, check.TenantId))
+	}
+
+	c.Id = cid
+	c.TenantId = tid
+	c.RegionId = crid
+}
+
+func (c *Check) GlobalID() GlobalID {
+	id, err := sm.LocalIDToGlobalID(c.Id, c.RegionId)
+	if err != nil {
+		return GlobalID(c.Id)
+	}
+	return GlobalID(id)
+}
+
+func (c *Check) GlobalTenantID() GlobalID {
+	id, err := sm.LocalIDToGlobalID(c.TenantId, c.RegionId)
+	if err != nil {
+		return GlobalID(c.TenantId)
+	}
+	return GlobalID(id)
+}
+
+// GetLocalAndRegionIDs takes a Global ID as specified in the sm data
+// structures and returns a pair of ids corresponding to the local ID and the
+// region ID. If the provided id is already a local one, it's returned without
+// modification with the region set to 0.
+func GetLocalAndRegionIDs(id GlobalID) (localID int64, regionID int) {
+	localID, regionID, err := sm.GlobalIDToLocalID(int64(id))
+	if err != nil {
+		// Id is already local, use region 0.
+		return int64(id), 0
+	}
+	return localID, regionID
+}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -1,0 +1,133 @@
+package model
+
+import (
+	"testing"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLocalAndRegionIDs(t *testing.T) {
+	type expected struct {
+		localID  int64
+		regionID int
+	}
+
+	testcases := map[string]struct {
+		input    GlobalID
+		expected expected
+	}{
+		"local id": {
+			input:    1,
+			expected: expected{localID: 1, regionID: 0},
+		},
+		"min local id, min region id": {
+			input:    localToGlobal(t, sm.MinLocalID, sm.MinRegionID),
+			expected: expected{localID: sm.MinLocalID, regionID: sm.MinRegionID},
+		},
+		"min local id, max region id": {
+			input:    localToGlobal(t, sm.MinLocalID, sm.MaxRegionID),
+			expected: expected{localID: sm.MinLocalID, regionID: sm.MaxRegionID},
+		},
+		"max local id, min region id": {
+			input:    localToGlobal(t, sm.MaxLocalID, sm.MinRegionID),
+			expected: expected{localID: sm.MaxLocalID, regionID: sm.MinRegionID},
+		},
+		"max local id, max region id": {
+			input:    localToGlobal(t, sm.MaxLocalID, sm.MaxRegionID),
+			expected: expected{localID: sm.MaxLocalID, regionID: sm.MaxRegionID},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			localID, regionID := GetLocalAndRegionIDs(tc.input)
+			require.Equal(t, tc.expected.localID, localID)
+			require.Equal(t, tc.expected.regionID, regionID)
+		})
+	}
+}
+
+func TestCheckFromSM(t *testing.T) {
+	var (
+		testRid       = sm.MinRegionID
+		testCid       = int64(sm.MinLocalID)
+		testTid       = int64(sm.MinLocalID + 1)
+		testGlobalCid = int64(localToGlobal(t, testCid, testRid))
+		testGlobalTid = int64(localToGlobal(t, testTid, testRid))
+	)
+
+	type expected struct {
+		check Check
+	}
+
+	testcases := map[string]struct {
+		input    sm.Check
+		expected expected
+	}{
+		"empty check": {
+			input:    sm.Check{},
+			expected: expected{check: Check{}},
+		},
+		"local ids": {
+			input: sm.Check{
+				Id:       testCid,
+				TenantId: testTid,
+				Settings: sm.CheckSettings{
+					Ping: &sm.PingSettings{},
+				},
+			},
+			expected: expected{
+				check: Check{
+					Check: sm.Check{
+						Id:       testCid,
+						TenantId: testTid,
+						Settings: sm.CheckSettings{
+							Ping: &sm.PingSettings{},
+						},
+					},
+					RegionId: 0,
+				},
+			},
+		},
+		"global ids": {
+			input: sm.Check{
+				Id:       testGlobalCid,
+				TenantId: testGlobalTid,
+				Settings: sm.CheckSettings{
+					Ping: &sm.PingSettings{},
+				},
+			},
+			expected: expected{
+				check: Check{
+					Check: sm.Check{
+						Id:       testCid,
+						TenantId: testTid,
+						Settings: sm.CheckSettings{
+							Ping: &sm.PingSettings{},
+						},
+					},
+					RegionId: testRid,
+				},
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			var c Check
+			c.FromSM(tc.input)
+
+			require.Equal(t, tc.expected.check, c)
+			require.Equal(t, GlobalID(tc.input.Id), c.GlobalID())
+			require.Equal(t, GlobalID(tc.input.TenantId), c.GlobalTenantID())
+		})
+	}
+}
+
+func localToGlobal(t *testing.T, localID int64, regionID int) GlobalID {
+	t.Helper()
+	globalID, err := sm.LocalIDToGlobalID(localID, regionID)
+	require.NoError(t, err)
+	return GlobalID(globalID)
+}

--- a/internal/pusher/clients.go
+++ b/internal/pusher/clients.go
@@ -41,12 +41,3 @@ func ClientFromRemoteInfo(remote *sm.RemoteInfo) (*prom.ClientConfig, error) {
 	clientCfg.Headers["X-Prometheus-Remote-Write-Version"] = "0.1.0"
 	return &clientCfg, nil
 }
-
-func GetLocalAndRegionIDs(id int64) (localID int64, regionID int) {
-	var err error
-	if localID, regionID, err = sm.GlobalIDToLocalID(id); err != nil {
-		// Id is already local, use region 0.
-		return id, 0
-	}
-	return localID, regionID
-}

--- a/internal/pusher/pusher.go
+++ b/internal/pusher/pusher.go
@@ -7,12 +7,13 @@ import (
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/rs/zerolog"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pkg/logproto"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
 type Payload interface {
-	Tenant() int64
+	Tenant() model.GlobalID
 	Metrics() []prompb.TimeSeries
 	Streams() []logproto.Stream
 }

--- a/internal/pusher/v2/options.go
+++ b/internal/pusher/v2/options.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
 )
 
@@ -89,8 +90,8 @@ type pusherOptions struct {
 	pool           bufferPool
 }
 
-func (o pusherOptions) withTenant(id int64) pusherOptions {
-	localID, regionID := pusher.GetLocalAndRegionIDs(id)
+func (o pusherOptions) withTenant(id model.GlobalID) pusherOptions {
+	localID, regionID := model.GetLocalAndRegionIDs(id)
 	o.logger = o.logger.With().Int("region", regionID).Int64("tenant", localID).Logger()
 	o.metrics = o.metrics.WithTenant(localID, regionID)
 	return o


### PR DESCRIPTION
In order to avoid confusion as to which kind of ID is expected where, introduce a model package that takes a synthetic_monitoring.Check and produces a wrapped one that has the IDs decoded.

Introduce a model.GlobaID type to make it explicit which kind of ID is expected. In the scraper use local IDs, except for the lists of checks, which need to use a global one. In the publisher, use global IDs.

This allows the compiler to flag misuses.