### PR TITLE
Fix panic while handling changes

### DIFF
--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -680,7 +680,10 @@ func (c *Updater) handleFirstBatch(ctx context.Context, changes *sm.Changes) {
 		switch checkChange.Operation {
 		case sm.CheckOperation_CHECK_ADD:
 			var check model.Check
-			check.FromSM(checkChange.Check)
+			if err := check.FromSM(checkChange.Check); err != nil {
+				c.logger.Error().Err(err).Interface("check_change", checkChange).Msg("dropping check during add operation")
+				continue
+			}
 
 			if err := c.handleInitialChangeAddWithLock(ctx, check); err != nil {
 				c.metrics.changeErrorsCounter.WithLabelValues("add").Inc()
@@ -776,7 +779,10 @@ func (c *Updater) handleChangeBatch(ctx context.Context, changes *sm.Changes, fi
 		c.logger.Debug().Interface("check change", checkChange).Msg("got check change")
 
 		var check model.Check
-		check.FromSM(checkChange.Check)
+		if err := check.FromSM(checkChange.Check); err != nil {
+			c.logger.Error().Err(err).Interface("check_change", checkChange).Msg("droppping check change")
+			continue
+		}
 
 		switch checkChange.Operation {
 		case sm.CheckOperation_CHECK_ADD:

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -185,7 +185,7 @@ func TestHandleCheckOp(t *testing.T) {
 	defer cancel()
 
 	var check model.Check
-	check.FromSM(sm.Check{
+	err = check.FromSM(sm.Check{
 		Id:        5000,
 		TenantId:  1,
 		Frequency: 1000,
@@ -199,6 +199,7 @@ func TestHandleCheckOp(t *testing.T) {
 		Created:  0,
 		Modified: 0,
 	})
+	require.NoError(t, err)
 
 	scraperExists := func() bool {
 		u.scrapersMutex.Lock()

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -116,7 +116,7 @@ func TestCheckFromSM(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			var c Check
-			c.FromSM(tc.input)
+			require.NoError(t, c.FromSM(tc.input))
 
 			require.Equal(t, tc.expected.check, c)
 			require.Equal(t, GlobalID(tc.input.Id), c.GlobalID())

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1405,7 +1405,7 @@ func TestScraperRun(t *testing.T) {
 	t.Cleanup(cancel)
 
 	var check model.Check
-	check.FromSM(sm.Check{
+	err := check.FromSM(sm.Check{
 		Id:        1,
 		TenantId:  1000,
 		Frequency: 100,
@@ -1417,6 +1417,7 @@ func TestScraperRun(t *testing.T) {
 			Ping: &sm.PingSettings{},
 		},
 	})
+	require.NoError(t, err)
 
 	var counter testCounter
 	errCounter := testCounterVec{counters: make(map[string]Incrementer), t: t}


### PR DESCRIPTION
In beadaabb8b8408de166f851125867ad703911d53 I changed the code that handles check and tenant IDs. In dev this is panicing because the check and tenant IDs are inconsistent. Perhaps my expectation that they are consistent is invalid?