### PR TITLE
Fix: for CSS selectors, the expression is not a predicate

### DIFF
--- a/internal/prober/multihttp/script.go
+++ b/internal/prober/multihttp/script.go
@@ -294,7 +294,7 @@ func buildVars(variable *sm.MultiHttpEntryVariable) string {
 		b.WriteString(`match ? match[1] || match[0] : null`)
 
 	case sm.MultiHttpEntryVariableType_CSS_SELECTOR:
-		b.WriteString(`response.html().find('`)
+		b.WriteString(`response.html('`)
 		b.WriteString(template.JSEscapeString(variable.Expression))
 		b.WriteString(`')`)
 		if variable.Attribute == "" {

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -491,7 +491,7 @@ func TestBuildVars(t *testing.T) {
 				Type:       sm.MultiHttpEntryVariableType_CSS_SELECTOR,
 				Expression: "cssSelector",
 			},
-			expected: `vars['name'] = response.html().find('cssSelector').html();`,
+			expected: `vars['name'] = response.html('cssSelector').html();`,
 		},
 		"TestBuildVarsCssSelectorWithAttribute": {
 			input: sm.MultiHttpEntryVariable{
@@ -500,7 +500,7 @@ func TestBuildVars(t *testing.T) {
 				Expression: "cssSelector",
 				Attribute:  "attribute",
 			},
-			expected: `vars['name'] = response.html().find('cssSelector').first().attr('attribute');`,
+			expected: `vars['name'] = response.html('cssSelector').first().attr('attribute');`,
 		},
 	}
 


### PR DESCRIPTION
We want to have something like:

	response.html('body > h1').html()

The current code is using the CSS expression as if it were a predicate.