### PR TITLE
Fix: add type to failure metrics

### DIFF
--- a/internal/pusher/metrics.go
+++ b/internal/pusher/metrics.go
@@ -30,6 +30,7 @@ type Metrics struct {
 var (
 	labelsWithType       = []string{"regionID", "tenantID", "type"}
 	labelsWithTypeStatus = []string{"regionID", "tenantID", "type", "status"}
+	labelsWithTypeReason = []string{"regionID", "tenantID", "type", "reason"}
 )
 
 // NewMetrics returns a new set of publisher metrics registered in the given registerer.
@@ -63,7 +64,7 @@ func NewMetrics(promRegisterer prometheus.Registerer) (m Metrics) {
 			Name:      "push_failed_total",
 			Help:      "Total number of push failures by type.",
 		},
-		labelsWithType)
+		labelsWithTypeReason)
 
 	promRegisterer.MustRegister(m.FailedCounter)
 
@@ -142,7 +143,7 @@ func (m Metrics) WithType(t string) Metrics {
 		PushCounter:     m.PushCounter.MustCurryWith(typeLabels),
 		ErrorCounter:    m.ErrorCounter.MustCurryWith(typeLabels),
 		BytesOut:        m.BytesOut.MustCurryWith(typeLabels),
-		FailedCounter:   m.FailedCounter, // type in failed counter servers a different purpose.
+		FailedCounter:   m.FailedCounter.MustCurryWith(typeLabels),
 		RetriesCounter:  m.RetriesCounter.MustCurryWith(typeLabels),
 		DroppedCounter:  m.DroppedCounter.MustCurryWith(typeLabels),
 		ResponseCounter: m.ResponseCounter.MustCurryWith(typeLabels),


### PR DESCRIPTION
sm_agent_push_failed_total has a type label that indicates the type of failure, not the type of payload that is being pushed. Rename that label to `reason` and add a `type` label that has values `metrics` and `logs`.