### PR TITLE
Release v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 ## [Unreleased]
 
 
+<a name="v0.17.2"></a>
+## [v0.17.2] - 2023-09-27
+### Fix
+- handle failed counter correctly
+
+
 <a name="v0.17.1"></a>
-## [v0.17.1] - 2023-09-12
+## [v0.17.1] - 2023-09-14
 ### Feature
 - keep track of scraper executions on a per-tenant level
 
@@ -471,7 +477,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.17.1...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.17.2...HEAD
+[v0.17.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.17.1...v0.17.2
 [v0.17.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.17.0...v0.17.1
 [v0.17.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.16.5...v0.17.0
 [v0.16.5]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.16.4...v0.16.5


### PR DESCRIPTION
* Fix: handle failed counter correctly
* Chore(deps): Bump google.golang.org/grpc from 1.56.2 to 1.58.1
* Chore(deps): Bump github.com/miekg/dns from 1.1.54 to 1.1.56
* Chore(deps): Bump github.com/rs/zerolog from 1.29.1 to 1.30.0
* Chore(deps): Bump github.com/go-kit/kit from 0.12.0 to 0.13.0
* Chore(deps): Bump github.com/google/uuid from 1.3.0 to 1.3.1
* Chore(deps): Bump github.com/mccutchen/go-httpbin/v2
* Chore(deps): Bump google.golang.org/grpc from 1.58.1 to 1.58.2
* Chore(deps): Bump github.com/rs/zerolog from 1.30.0 to 1.31.0
* Add a gauge to track the number of installed publisher handlers
* Chore(deps): Bump github.com/spf13/afero from 1.9.5 to 1.10.0
* InstallerHandlers has no type