### PR TITLE
Add a source label to metrics

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -382,7 +382,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, erro
 		s.prober,
 		target,
 		time.Duration(s.check.Timeout)*time.Millisecond,
-		s.buildCheckInfoLabels(userLabels),
+		checkInfoLabels,
 		s.summaries, s.histograms,
 		sl,
 		s.check.BasicMetricsOnly,
@@ -398,6 +398,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, erro
 		{name: "config_version", value: s.check.ConfigVersion()},
 		{name: "instance", value: s.check.Target},
 		{name: "job", value: s.check.Job},
+		{name: "source", value: CheckInfoSource}, // identify metrics that belong to synthetic-monitoring-agent
 	}
 
 	ts := s.extractTimeseries(t, mfs, metricLabels)


### PR DESCRIPTION
This allows us to identify the metrics as coming from Synthetic Monitoring.