### PR TITLE
Feature: add k6 to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH
 
 COPY dist/${HOST_DIST}/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
+COPY dist/${HOST_DIST}/k6 /usr/local/bin/k6
 COPY scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/scripts/dummy-k6.sh
+++ b/scripts/dummy-k6.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+cat <<-EOT
+	k6 does not (yet?) work on this platform.
+EOT
+
+exit 10

--- a/scripts/make/xk6.mk
+++ b/scripts/make/xk6.mk
@@ -32,11 +32,26 @@ $(DISTDIR)/$(1)-$(2)/k6) : $(wildcard $(ROOTDIR)/xk6/sm/*.go $(ROOTDIR)/xk6/sm/g
 
 endef
 
+define build_dummy_xk6_template
+BUILD_DUMMY_XK6_TARGETS += build-dummy-xk6-$(1)-$(2)
+
+build-dummy-xk6-$(1)-$(2) : GOOS := $(1)
+build-dummy-xk6-$(1)-$(2) : GOARCH := $(2)
+build-dummy-xk6-$(1)-$(2) : DIST_FILENAME := $(firstword $(OUTPUT_FILE) $(DISTDIR)/$(1)-$(2)/k6)
+$(DISTDIR)/$(1)-$(2)/k6) :
+
+endef
+
 # TODO(mem): xk6 does not build on linux/arm yet
-XK6_PLATFORMS := $(filter-out linux/arm,$(PLATFORMS))
+DUMMY_XK6_PLATFORMS := linux/arm
+
+XK6_PLATFORMS := $(filter-out $(DUMMY_XK6_PLATFORMS),$(PLATFORMS))
 
 $(foreach BUILD_PLATFORM,$(XK6_PLATFORMS), \
 	$(eval $(call build_xk6_template,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
+
+$(foreach BUILD_PLATFORM,$(DUMMY_XK6_PLATFORMS), \
+	$(eval $(call build_dummy_xk6_template,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
 
 BUILD_XK6_NATIVE_TARGETS := $(filter build-xk6-$(HOST_OS)-$(HOST_ARCH), $(BUILD_XK6_TARGETS))
 
@@ -57,6 +72,21 @@ define build_xk6_command
 endef
 
 build: $(BUILD_XK6_TARGETS)
+
+.PHONY: $(BUILD_DUMMY_XK6_TARGETS)
+$(BUILD_DUMMY_XK6_TARGETS) : build-dummy-xk6-% :
+	$(call build_dummy_xk6_command)
+
+define build_dummy_xk6_command
+	$(S) echo 'Building $(notdir $(DIST_FILENAME)) ($(GOOS)-$(GOARCH))'
+	$(S) mkdir -p $(DISTDIR)/$(GOOS)-$(GOARCH)
+	$(V) install -m 0755 $(ROOTDIR)/scripts/dummy-k6.sh '$(DIST_FILENAME)'
+	$(V) test '$(GOOS)' = '$(HOST_OS)' -a '$(GOARCH)' = '$(HOST_ARCH)' && \
+		cp -a '$(DIST_FILENAME)' '$(DISTDIR)/$(notdir $(DIST_FILENAME))' || \
+		true
+endef
+
+build: $(BUILD_DUMMY_XK6_TARGETS)
 
 .PHONY: native-k6
 native-k6: build-xk6-$(HOST_OS)-$(HOST_ARCH)


### PR DESCRIPTION
Add the k6 binary with the sm extension built-in to the generated docker image. This allows users to deploy the agent and enabling multihttp checks.