### PR TITLE
Fix: add a `name` label to metrics

### DIFF
--- a/internal/prober/multihttp/script.tmpl
+++ b/internal/prober/multihttp/script.tmpl
@@ -74,7 +74,7 @@ export default function() {
 	let match;
 	const vars = {};
 
- {{ range .Entries }}
+ {{ range $idx, $entry := .Entries }}
 	console.log("Starting request to {{.Request.Url}}...");
 	try {
 		url = new URL({{ buildUrl .Request.Url }});
@@ -90,6 +90,10 @@ export default function() {
 	{{- $headers := buildHeaders .Request.Headers .Request.Body }}
 	response = http.request('{{ $method }}', url.toString(), {{ $body }}, {
 		// TODO(mem): build params out of options for the check
+		tags: {
+		  name: '{{ $idx }}', // TODO(mem): give the user some control over this?
+		  __raw_url__: url.toString(),
+		},
 		redirects: 0{{ if gt (len $headers) 0 }},
 		headers: {{ $headers }}{{ end }}
 	});

--- a/scripts/make/xk6.mk
+++ b/scripts/make/xk6.mk
@@ -1,7 +1,7 @@
 XK6_PKG_DIR := $(ROOTDIR)/xk6/sm
 XK6_OUT_DIR := $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)
 K6_BIN      := $(XK6_OUT_DIR)/k6
-K6_VERSION  := v0.46.0
+K6_VERSION  := v0.47.0
 
 LOCAL_GOPATH ?= $(shell go env GOPATH)
 


### PR DESCRIPTION
By adding a `name` tag to each request, we get that in the result as a `name` label with the corresponding value.

Since the [k6
documentation](https://k6.io/docs/using-k6/http-requests/#url-grouping) says that setting `name` should not affect `url` but [in reality it does](https://github.com/grafana/k6/issues/3435), implement a nasty workaround to preserve the URL. If there's a tag with the special name `__raw_url__`, use that as the actual URL that was requested.

Modify the generated script so that we add both the `name` tag (set to a sequential number based on the position of the request in the entries list) and a `__raw_url__` tag (workaround). Then in the output extension, include `name` in the metric labels and convert `__raw_url__` to `url`.