### PR TITLE
Log requests to ops server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 )
 
 require (
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/go-kit/log v0.2.1
 	github.com/go-ping/ping v1.1.0
 	github.com/gogo/status v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/felixge/httpsnoop"
 	"github.com/rs/zerolog"
 )
 
@@ -18,10 +19,31 @@ type server struct {
 func NewServer(ctx context.Context, handler http.Handler, cfg Config) *server {
 	stdlog := log.New(cfg.Logger, "", 0)
 
+	wrapper := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m := httpsnoop.CaptureMetrics(handler, w, r)
+		var level zerolog.Level
+		switch m.Code / 100 {
+		case 1, 2, 3:
+			level = zerolog.InfoLevel
+		case 4:
+			level = zerolog.WarnLevel
+		case 5:
+			level = zerolog.ErrorLevel
+		default:
+			level = zerolog.WarnLevel
+		}
+		cfg.Logger.WithLevel(level).
+			Str("method", r.Method).
+			Stringer("url", r.URL).
+			Int("code", m.Code).
+			Dur("duration", m.Duration).
+			Msg("handled request")
+	})
+
 	return &server{
 		srv: &http.Server{
 			Addr:         cfg.ListenAddr,
-			Handler:      handler,
+			Handler:      wrapper,
 			ErrorLog:     stdlog,
 			ReadTimeout:  cfg.ReadTimeout,
 			WriteTimeout: cfg.WriteTimeout,


### PR DESCRIPTION
We are seeing some scrape failures in one agent instance, and there are no errors recorded. Log all the requests to see if it shows up there.