### PR TITLE
examples/k8s: listen on all addresses to make health/readiness eps reachable

### DIFF
--- a/examples/kubernetes/deployment.yaml
+++ b/examples/kubernetes/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - args:
-            - /usr/local/bin/synthetic-monitoring-agent --api-server-address=${API_SERVER} --api-token=${API_TOKEN} --verbose=true
+            - /usr/local/bin/synthetic-monitoring-agent --api-server-address=${API_SERVER} --api-token=${API_TOKEN} --verbose=true --listen-address=0.0.0.0:4050
           command:
             - sh
             - -c


### PR DESCRIPTION
Currently, the agent spawns its HTTP server listening in `localhost` only:
https://github.com/grafana/synthetic-monitoring-agent/blob/1a7c9f62ab0332e4292e791dfdf6f170d5304313/cmd/synthetic-monitoring-agent/main.go#L54

This setting is at odds with the example k8s deployment, which defines readiness and healthiness probes:
https://github.com/grafana/synthetic-monitoring-agent/blob/1a7c9f62ab0332e4292e791dfdf6f170d5304313/examples/kubernetes/deployment.yaml#L42-L49

By default, the kubelet will attempt to connect to the podIP, and will get a connection refused error as the HTTP server is listening in localhost only. As a result, the kubelet will periodically kill the agent pod as it think it is not responding.

This PR modifies the agent command so it listens on all addresses, making probes reachable by the kubelet.