### PR TITLE
allow scripted checks to have anything as the target value

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -286,7 +286,7 @@ func (c Check) validateTarget() error {
 		}
 
 	case CheckTypeK6:
-		return validateHttpUrl(c.Target)
+		return nil
 
 	case CheckTypeMultiHttp:
 		// TODO(mem): checks MUST have a target, but in this case it's


### PR DESCRIPTION
Currently scripted checks still need a job/target combo like all the other kinds of checks. Currently the target must be a valid HTTP url, but that really doesn't make sense in context:

![Screenshot 2024-01-24 at 08 40 44](https://github.com/grafana/synthetic-monitoring-agent/assets/8377044/54e4edbd-fd64-433a-8a4c-518336412761)

There's probably no way around requiring a job/target combo, but we should allow any value the users want to enter
