### PR TITLE
Fix: make label names uniform

### DIFF
--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -612,7 +612,7 @@ func (c *Updater) handleCheckUpdateWithLock(ctx context.Context, check model.Che
 
 	scraper, found := c.scrapers[cid]
 	if !found {
-		c.logger.Warn().Int64("check_id", check.Id).Int("region_id", check.RegionId).Msg("update request for an unknown check")
+		c.logger.Warn().Int64("checkId", check.Id).Int("regionId", check.RegionId).Msg("update request for an unknown check")
 		return c.addAndStartScraperWithLock(ctx, check)
 	}
 
@@ -638,7 +638,7 @@ func (c *Updater) handleCheckDelete(ctx context.Context, check model.Check) erro
 
 	scraper, found := c.scrapers[cid]
 	if !found {
-		c.logger.Warn().Int64("check_id", check.Id).Int("region_id", check.RegionId).Msg("delete request for an unknown check")
+		c.logger.Warn().Int64("checkId", check.Id).Int("regionId", check.RegionId).Msg("delete request for an unknown check")
 		return errors.New("check not found")
 	}
 
@@ -687,7 +687,7 @@ func (c *Updater) handleFirstBatch(ctx context.Context, changes *sm.Changes) {
 
 			if err := c.handleInitialChangeAddWithLock(ctx, check); err != nil {
 				c.metrics.changeErrorsCounter.WithLabelValues("add").Inc()
-				c.logger.Error().Err(err).Int64("check_id", check.Id).Int("region_id", check.RegionId).
+				c.logger.Error().Err(err).Int64("checkId", check.Id).Int("regionId", check.RegionId).
 					Msg("adding check failed, dropping check")
 				continue
 			}
@@ -715,8 +715,8 @@ func (c *Updater) handleFirstBatch(ctx context.Context, changes *sm.Changes) {
 
 		cid, rid := model.GetLocalAndRegionIDs(id)
 		c.logger.Debug().
-			Int64("check_id", cid).
-			Int("region_id", rid).
+			Int64("checkId", cid).
+			Int("regionId", rid).
 			Msg("stopping scraper during first batch handling")
 
 		checkType := scraper.CheckType().String()

--- a/internal/pusher/metrics.go
+++ b/internal/pusher/metrics.go
@@ -30,9 +30,9 @@ type Metrics struct {
 }
 
 var (
-	labelsWithTenantType       = []string{"regionID", "tenantID", "type"}
-	labelsWithTenantTypeStatus = []string{"regionID", "tenantID", "type", "status"}
-	labelsWithTenantTypeReason = []string{"regionID", "tenantID", "type", "reason"}
+	labelsWithTenantType       = []string{"regionId", "tenantId", "type"}
+	labelsWithTenantTypeStatus = []string{"regionId", "tenantId", "type", "status"}
+	labelsWithTenantTypeReason = []string{"regionId", "tenantId", "type", "reason"}
 )
 
 // NewMetrics returns a new set of publisher metrics registered in the given registerer.
@@ -132,8 +132,8 @@ func NewMetrics(promRegisterer prometheus.Registerer) (m Metrics) {
 // already included.
 func (m Metrics) WithTenant(localID int64, regionID int) Metrics {
 	labels := prometheus.Labels{
-		"regionID": strconv.FormatInt(int64(regionID), 10),
-		"tenantID": strconv.FormatInt(localID, 10),
+		"regionId": strconv.FormatInt(int64(regionID), 10),
+		"tenantId": strconv.FormatInt(localID, 10),
 	}
 	return Metrics{
 		PushCounter:       m.PushCounter.MustCurryWith(labels),

--- a/internal/pusher/v1/pusher.go
+++ b/internal/pusher/v1/pusher.go
@@ -74,7 +74,7 @@ func (p *publisherImpl) publish(ctx context.Context, payload pusher.Payload) {
 		tenantStr         = strconv.FormatInt(localID, 10)
 
 		newClient = false
-		logger    = p.logger.With().Int("region", regionID).Int64("tenant", localID).Logger()
+		logger    = p.logger.With().Int("regionId", regionID).Int64("tenantId", localID).Logger()
 	)
 
 	streams := payload.Streams()

--- a/internal/pusher/v2/options.go
+++ b/internal/pusher/v2/options.go
@@ -96,7 +96,7 @@ type pusherOptions struct {
 
 func (o pusherOptions) withTenant(id model.GlobalID) pusherOptions {
 	localID, regionID := model.GetLocalAndRegionIDs(id)
-	o.logger = o.logger.With().Int("region", regionID).Int64("tenant", localID).Logger()
+	o.logger = o.logger.With().Int("regionId", regionID).Int64("tenantId", localID).Logger()
 	o.metrics = o.metrics.WithTenant(localID, regionID)
 	return o
 }

--- a/internal/pusher/v2/publisher.go
+++ b/internal/pusher/v2/publisher.go
@@ -62,14 +62,14 @@ func (p *publisherImpl) Publish(payload pusher.Payload) {
 
 func (p *publisherImpl) runHandler(tenantID model.GlobalID, h payloadHandler) {
 	tid, rid := model.GetLocalAndRegionIDs(tenantID)
-	p.options.logger.Info().Int64("tenant_id", tid).Int("region_id", rid).Msg("started push handler")
-	defer p.options.logger.Info().Int64("tenant_id", tid).Int("region_id", rid).Msg("stopped push handler")
+	p.options.logger.Info().Int64("tenantId", tid).Int("regionId", rid).Msg("started push handler")
+	defer p.options.logger.Info().Int64("tenantId", tid).Int("regionId", rid).Msg("stopped push handler")
 
 	for ok := true; ok && h != nil; {
 		next := h.run(p.ctx)
 		h, ok = p.replaceHandler(tenantID, h, next)
 		if !ok {
-			p.options.logger.Error().Int64("tenant_id", tid).Int("region_id", rid).Msg("unable to swap handler, tenant hijacked")
+			p.options.logger.Error().Int64("tenantId", tid).Int("regionId", rid).Msg("unable to swap handler, tenant hijacked")
 		}
 	}
 }

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -122,9 +122,9 @@ func NewWithOpts(ctx context.Context, check model.Check, opts ScraperOpts) (*Scr
 	checkName := check.Type().String()
 
 	logger := opts.Logger.With().
-		Int("region_id", check.RegionId).
+		Int("regionId", check.RegionId).
 		Int64("tenantId", check.TenantId).
-		Int64("check_id", check.Id).
+		Int64("checkId", check.Id).
 		Str("probe", opts.Probe.Name).
 		Str("target", check.Target).
 		Str("job", check.Job).


### PR DESCRIPTION
Our use of labels names in logs and metrics is not uniform and this is causing a lot of pain.

We have `foo_id`, `fooID` and other variations.

Pick one.

It's `fooId` from now on.

It's going to be painful to change everywhere else to match this, but it's better than dealing with the existing pain.