### PR TITLE
Fix: check targets must be valid label values

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -45,6 +45,7 @@ var (
 	ErrInvalidLabelName       = errors.New("invalid label name")
 	ErrInvalidLabelValue      = errors.New("invalid label value")
 	ErrDuplicateLabelName     = errors.New("duplicate label name")
+	ErrInvalidTargetValue     = errors.New("invalid target value")
 
 	ErrInvalidCheckSettings = errors.New("invalid check settings")
 
@@ -263,6 +264,11 @@ func (c Check) Validate() error {
 }
 
 func (c Check) validateTarget() error {
+	// All targets must be valid label values.
+	if err := validateLabelValue(c.Target); err != nil {
+		return ErrInvalidTargetValue
+	}
+
 	switch c.Type() {
 	case CheckTypeDns:
 		if err := validateDnsTarget(c.Target); err != nil {
@@ -970,7 +976,7 @@ func (p *Probe) Validate() error {
 }
 
 func (l Label) Validate() error {
-	if len(l.Name) == 0 || len(l.Name) > MaxLabelValueLength {
+	if err := validateLabelValue(l.Name); err != nil {
 		return ErrInvalidLabelName
 	}
 
@@ -984,7 +990,11 @@ func (l Label) Validate() error {
 		}
 	}
 
-	if len(l.Value) == 0 || len(l.Value) > MaxLabelValueLength {
+	return validateLabelValue(l.Value)
+}
+
+func validateLabelValue(v string) error {
+	if len(v) == 0 || len(v) > MaxLabelValueLength {
 		return ErrInvalidLabelValue
 	}
 	return nil

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -308,6 +308,29 @@ func TestCheckValidate(t *testing.T) {
 			},
 			expectError: true,
 		},
+		"valid multihttp check": {
+			input: Check{
+				Id:        1,
+				TenantId:  1,
+				Target:    "https://example.org/",
+				Job:       "job",
+				Frequency: 60000,
+				Timeout:   10000,
+				Probes:    []int64{1},
+				Settings: CheckSettings{
+					Multihttp: &MultiHttpSettings{
+						Entries: []*MultiHttpEntry{
+							{
+								Request: &MultiHttpEntryRequest{
+									Url: "https://example.org/",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
 		"valid multihttp variable": {
 			input: Check{
 				Id:        1,
@@ -359,11 +382,11 @@ func TestCheckValidate(t *testing.T) {
 			},
 			expectError: false,
 		},
-		"invalid multihttp target": {
+		"empty multihttp check": {
 			input: Check{
 				Id:        1,
 				TenantId:  1,
-				Target:    "example.com",
+				Target:    "",
 				Job:       "job",
 				Frequency: 60000,
 				Timeout:   10000,
@@ -373,7 +396,7 @@ func TestCheckValidate(t *testing.T) {
 						Entries: []*MultiHttpEntry{
 							{
 								Request: &MultiHttpEntryRequest{
-									Url: "example.com",
+									Url: "https://example.org/",
 								},
 							},
 						},
@@ -381,6 +404,52 @@ func TestCheckValidate(t *testing.T) {
 				},
 			},
 			expectError: true,
+		},
+		"invalid multihttp URL": {
+			input: Check{
+				Id:        1,
+				TenantId:  1,
+				Target:    "example.com", // this is fine
+				Job:       "job",
+				Frequency: 60000,
+				Timeout:   10000,
+				Probes:    []int64{1},
+				Settings: CheckSettings{
+					Multihttp: &MultiHttpSettings{
+						Entries: []*MultiHttpEntry{
+							{
+								Request: &MultiHttpEntryRequest{
+									Url: "example.com", // this is the problem
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		"multihttp target must not be an URL": {
+			input: Check{
+				Id:        1,
+				TenantId:  1,
+				Target:    "example.com", // this is fine
+				Job:       "job",
+				Frequency: 60000,
+				Timeout:   10000,
+				Probes:    []int64{1},
+				Settings: CheckSettings{
+					Multihttp: &MultiHttpSettings{
+						Entries: []*MultiHttpEntry{
+							{
+								Request: &MultiHttpEntryRequest{
+									Url: "http://example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
 		},
 		"invalid multihttp second target": {
 			input: Check{


### PR DESCRIPTION
The check target is going to be used as the value of the `instance` label and as such, it must be a valid label value. The current validations for label values only look at the length of the value.