### PR TITLE
Release v0.19.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 ## [Unreleased]
 
 
+<a name="v0.19.5"></a>
+## [v0.19.5] - 2024-02-02
+### Fix
+- check targets must be valid label values
+
+
 <a name="v0.19.4"></a>
-## [v0.19.4] - 2024-01-26
+## [v0.19.4] - 2024-01-30
 ### Fix
 - allow scripted checks to have anything as the target value ([#592](https://github.com/grafana/synthetic-monitoring-agent/issues/592))
 
@@ -527,7 +533,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.4...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.5...HEAD
+[v0.19.5]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.4...v0.19.5
 [v0.19.4]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.3...v0.19.4
 [v0.19.3]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.2...v0.19.3
 [v0.19.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.1...v0.19.2


### PR DESCRIPTION
* allow adhoc k6 checks with unvalidated targets (#598)
* Fix: check targets must be valid label values