### PR TITLE
add the check ID to the sm_check_info metric

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -647,6 +647,7 @@ func (s Scraper) buildCheckInfoLabels(userLabels []labelPair) map[string]string 
 		"region":     s.probe.Region,
 		"frequency":  strconv.FormatInt(s.check.Frequency, 10),
 		"geohash":    geohash.Encode(float64(s.probe.Latitude), float64(s.probe.Longitude)),
+		"check_id":   fmt.Sprint(s.check.Id),
 	}
 	if s.check.AlertSensitivity != "" && s.check.AlertSensitivity != "none" {
 		labels["alert_sensitivity"] = s.check.AlertSensitivity

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1045,6 +1045,7 @@ func (p testProber) Probe(ctx context.Context, target string, registry *promethe
 //nolint:gocyclo
 func TestScraperCollectData(t *testing.T) {
 	const (
+		checkId       = 1
 		checkName     = "check name"
 		checkTarget   = "target name"
 		frequency     = 2000
@@ -1067,6 +1068,7 @@ func TestScraperCollectData(t *testing.T) {
 		}
 		baseExpectedInfoLabels = map[string]string{
 			"check_name": checkName,
+			"check_id":   strconv.Itoa(checkId),
 			"frequency":  strconv.Itoa(frequency),
 			"geohash":    geohash.Encode(probeLatitude, probeLongitde),
 			"region":     region,


### PR DESCRIPTION
Not sure if this is OK. It would help me out a lot on the visualizing side to be able to extract the check ID from prometheus queries for building links and things like that.