### PR TITLE
Expose agent label constants

### DIFF
--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -71,338 +71,37 @@ func TestValidateMetrics(t *testing.T) {
 		setup func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func())
 	}{
 		"ping": {
-			setup: func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
-				check := sm.Check{
-					Target:  "127.0.0.1",
-					Timeout: 2000,
-					Settings: sm.CheckSettings{
-						Ping: &sm.PingSettings{
-							IpVersion: sm.IpVersion_V4,
-						},
-					},
-				}
-
-				prober, err := icmp.NewProber(check)
-				if err != nil {
-					t.Fatalf("cannot create ICMP prober: %s", err)
-				}
-
-				return prober, check, func() {}
-			},
+			setup: setupPingProbe,
 		},
-
 		"http": {
-			setup: func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
-				httpSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-					w.WriteHeader(http.StatusOK)
-				}))
-				httpSrv.Start()
-
-				check := sm.Check{
-					Target:  httpSrv.URL,
-					Timeout: 2000,
-					Settings: sm.CheckSettings{
-						Http: &sm.HttpSettings{
-							IpVersion: sm.IpVersion_V4,
-						},
-					},
-				}
-
-				prober, err := httpProber.NewProber(
-					ctx,
-					check,
-					zerolog.New(io.Discard),
-					http.Header{},
-				)
-				if err != nil {
-					t.Fatalf("cannot create HTTP prober: %s", err)
-				}
-
-				return prober, check, httpSrv.Close
-			},
+			setup: setupHTTPProbe,
 		},
-
 		"http_ssl": {
-			setup: func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
-				httpSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-					w.WriteHeader(http.StatusOK)
-				}))
-				httpSrv.StartTLS()
-
-				check := sm.Check{
-					Target:  httpSrv.URL,
-					Timeout: 2000,
-					Settings: sm.CheckSettings{
-						Http: &sm.HttpSettings{
-							IpVersion: sm.IpVersion_V4,
-							TlsConfig: &sm.TLSConfig{
-								InsecureSkipVerify: true,
-							},
-						},
-					},
-				}
-
-				prober, err := httpProber.NewProber(
-					ctx,
-					check,
-					zerolog.New(io.Discard),
-					http.Header{},
-				)
-				if err != nil {
-					t.Fatalf("cannot create HTTP prober: %s", err)
-				}
-
-				return prober, check, httpSrv.Close
-			},
+			setup: setupHTTPSSLProbe,
 		},
-
 		"dns": {
-			setup: func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
-				srv, clean := setupDNSServer(t)
-				check := sm.Check{
-					Target:  "example.org",
-					Timeout: 2000,
-					Settings: sm.CheckSettings{
-						// target is "example.com"
-						Dns: &sm.DnsSettings{
-							Server:    srv,
-							IpVersion: sm.IpVersion_V4,
-							Protocol:  sm.DnsProtocol_UDP,
-						},
-					},
-				}
-				prober, err := dnsProber.NewProber(check)
-				if err != nil {
-					clean()
-					t.Fatalf("cannot create DNS prober: %s", err)
-				}
-				return prober, check, clean
-			},
+			setup: setupDNSProbe,
 		},
-
 		"tcp": {
-			setup: func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
-				srv, clean := setupTCPServer(t)
-				check := sm.Check{
-					Target:  srv,
-					Timeout: 2000,
-					Settings: sm.CheckSettings{
-						Tcp: &sm.TcpSettings{
-							IpVersion: sm.IpVersion_V4,
-						},
-					},
-				}
-				prober, err := tcp.NewProber(
-					ctx,
-					check,
-					zerolog.New(io.Discard))
-				if err != nil {
-					clean()
-					t.Fatalf("cannot create TCP prober: %s", err)
-				}
-				return prober, check, clean
-			},
+			setup: setupTCPProbe,
 		},
-
 		"tcp_ssl": {
-			setup: func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
-				srv, clean := setupTCPServerWithSSL(t)
-				check := sm.Check{
-					Target:  srv,
-					Timeout: 2000,
-					Settings: sm.CheckSettings{
-						Tcp: &sm.TcpSettings{
-							IpVersion: sm.IpVersion_V4,
-							Tls:       true,
-							TlsConfig: &sm.TLSConfig{
-								InsecureSkipVerify: true,
-							},
-						},
-					},
-				}
-				prober, err := tcp.NewProber(
-					ctx,
-					check,
-					zerolog.New(io.Discard))
-				if err != nil {
-					clean()
-					t.Fatalf("cannot create TCP prober: %s", err)
-				}
-				return prober, check, clean
-			},
+			setup: setupTCPSSLProbe,
 		},
-
 		"traceroute": {
-			setup: func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
-				checkCap := func(set *cap.Set, v cap.Value) {
-					if permitted, err := set.GetFlag(cap.Permitted, v); err != nil {
-						t.Fatalf("cannot get %s flag: %s", v, err)
-					} else if !permitted {
-						t.Skipf("traceroute cannot run, process doesn't have %s capability", v)
-					}
-				}
-				c := cap.GetProc()
-				checkCap(c, cap.NET_ADMIN)
-				checkCap(c, cap.NET_RAW)
-
-				check := sm.Check{
-					Target: "127.0.0.1",
-					Settings: sm.CheckSettings{
-						Traceroute: &sm.TracerouteSettings{},
-					},
-				}
-
-				p, err := traceroute.NewProber(check, zerolog.New(io.Discard))
-				if err != nil {
-					t.Fatalf("cannot create traceroute prober %s", err)
-				}
-
-				return p, check, func() {}
-			},
+			setup: setupTracerouteProbe,
 		},
-
 		"scripted": {
-			setup: func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
-				httpSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-					w.WriteHeader(http.StatusOK)
-				}))
-				httpSrv.Start()
-
-				check := sm.Check{
-					Target:  httpSrv.URL,
-					Timeout: 2000,
-					Settings: sm.CheckSettings{
-						Scripted: &sm.ScriptedSettings{
-							Script: []byte(`export default function() {}`),
-						},
-					},
-				}
-
-				var runner k6runner.Runner
-
-				if k6Path := os.Getenv("K6_PATH"); k6Path != "" {
-					runner = k6runner.New(k6runner.RunnerOpts{Uri: k6Path})
-				} else {
-					runner = &testRunner{
-						metrics: testhelper.MustReadFile(t, "testdata/k6.dat"),
-						logs:    nil,
-					}
-				}
-
-				prober, err := scripted.NewProber(
-					ctx,
-					check,
-					zerolog.New(zerolog.NewTestWriter(t)),
-					runner,
-				)
-				if err != nil {
-					t.Fatalf("cannot create scripted prober: %s", err)
-				}
-
-				return prober, check, httpSrv.Close
-			},
+			setup: setupScriptedProbe,
 		},
-
 		"multihttp": {
-			setup: func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
-				httpSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-					w.WriteHeader(http.StatusOK)
-				}))
-				httpSrv.Start()
-
-				check := sm.Check{
-					Target:  httpSrv.URL,
-					Timeout: 2000,
-					Settings: sm.CheckSettings{
-						Multihttp: &sm.MultiHttpSettings{
-							Entries: []*sm.MultiHttpEntry{
-								{
-									Request: &sm.MultiHttpEntryRequest{
-										Method: sm.HttpMethod_GET,
-										Url:    httpSrv.URL,
-									},
-								},
-							},
-						},
-					},
-				}
-
-				var runner k6runner.Runner
-
-				if k6Path := os.Getenv("K6_PATH"); k6Path != "" {
-					runner = k6runner.New(k6runner.RunnerOpts{Uri: k6Path})
-				} else {
-					runner = &testRunner{
-						metrics: testhelper.MustReadFile(t, "testdata/multihttp.dat"),
-						logs:    nil,
-					}
-				}
-
-				prober, err := multihttp.NewProber(
-					ctx,
-					check,
-					zerolog.New(zerolog.NewTestWriter(t)),
-					runner,
-					http.Header{},
-				)
-				if err != nil {
-					t.Fatalf("cannot create MultiHTTP prober: %s", err)
-				}
-
-				return prober, check, httpSrv.Close
-			},
+			setup: setupMultiHTTPProbe,
 		},
-
 		"grpc": {
-			setup: func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
-				srv, clean := setupGRPCServer(t)
-				check := sm.Check{
-					Target:  srv,
-					Timeout: 2000,
-					Settings: sm.CheckSettings{
-						Grpc: &sm.GrpcSettings{
-							IpVersion: sm.IpVersion_V4,
-						},
-					},
-				}
-				prober, err := grpcProber.NewProber(
-					ctx,
-					check,
-					zerolog.New(io.Discard))
-				if err != nil {
-					clean()
-					t.Fatalf("cannot create gRPC prober: %s", err)
-				}
-				return prober, check, clean
-			},
+			setup: setupGRPCProbe,
 		},
-
 		"grpc_ssl": {
-			setup: func(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
-				srv, clean := setupGRPCServerWithSSL(t)
-				check := sm.Check{
-					Target:  srv,
-					Timeout: 2000,
-					Settings: sm.CheckSettings{
-						Grpc: &sm.GrpcSettings{
-							IpVersion: sm.IpVersion_V4,
-							Tls:       true,
-							TlsConfig: &sm.TLSConfig{
-								InsecureSkipVerify: true,
-							},
-						},
-					},
-				}
-				prober, err := grpcProber.NewProber(
-					ctx,
-					check,
-					zerolog.New(io.Discard))
-				if err != nil {
-					clean()
-					t.Fatalf("cannot create gRPC prober: %s", err)
-				}
-				return prober, check, clean
-			},
+			setup: setupGRPCSSLProbe,
 		},
 	}
 
@@ -532,6 +231,319 @@ func readGoldenFile(fn string) (map[string]struct{}, error) {
 
 		addMetricToIndex(&mf, metrics)
 	}
+}
+
+func setupPingProbe(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
+	check := sm.Check{
+		Target:  "127.0.0.1",
+		Timeout: 2000,
+		Settings: sm.CheckSettings{
+			Ping: &sm.PingSettings{
+				IpVersion: sm.IpVersion_V4,
+			},
+		},
+	}
+
+	prober, err := icmp.NewProber(check)
+	if err != nil {
+		t.Fatalf("cannot create ICMP prober: %s", err)
+	}
+
+	return prober, check, func() {}
+}
+
+func setupHTTPProbe(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
+	httpSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	httpSrv.Start()
+
+	check := sm.Check{
+		Target:  httpSrv.URL,
+		Timeout: 2000,
+		Settings: sm.CheckSettings{
+			Http: &sm.HttpSettings{
+				IpVersion: sm.IpVersion_V4,
+			},
+		},
+	}
+
+	prober, err := httpProber.NewProber(
+		ctx,
+		check,
+		zerolog.New(io.Discard),
+		http.Header{},
+	)
+	if err != nil {
+		t.Fatalf("cannot create HTTP prober: %s", err)
+	}
+
+	return prober, check, httpSrv.Close
+}
+
+func setupHTTPSSLProbe(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
+	httpSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	httpSrv.StartTLS()
+
+	check := sm.Check{
+		Target:  httpSrv.URL,
+		Timeout: 2000,
+		Settings: sm.CheckSettings{
+			Http: &sm.HttpSettings{
+				IpVersion: sm.IpVersion_V4,
+				TlsConfig: &sm.TLSConfig{
+					InsecureSkipVerify: true,
+				},
+			},
+		},
+	}
+
+	prober, err := httpProber.NewProber(
+		ctx,
+		check,
+		zerolog.New(io.Discard),
+		http.Header{},
+	)
+	if err != nil {
+		t.Fatalf("cannot create HTTP prober: %s", err)
+	}
+
+	return prober, check, httpSrv.Close
+}
+
+func setupDNSProbe(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
+	srv, clean := setupDNSServer(t)
+	check := sm.Check{
+		Target:  "example.org",
+		Timeout: 2000,
+		Settings: sm.CheckSettings{
+			// target is "example.com"
+			Dns: &sm.DnsSettings{
+				Server:    srv,
+				IpVersion: sm.IpVersion_V4,
+				Protocol:  sm.DnsProtocol_UDP,
+			},
+		},
+	}
+	prober, err := dnsProber.NewProber(check)
+	if err != nil {
+		clean()
+		t.Fatalf("cannot create DNS prober: %s", err)
+	}
+	return prober, check, clean
+}
+
+func setupTCPProbe(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
+	srv, clean := setupTCPServer(t)
+	check := sm.Check{
+		Target:  srv,
+		Timeout: 2000,
+		Settings: sm.CheckSettings{
+			Tcp: &sm.TcpSettings{
+				IpVersion: sm.IpVersion_V4,
+			},
+		},
+	}
+	prober, err := tcp.NewProber(
+		ctx,
+		check,
+		zerolog.New(io.Discard))
+	if err != nil {
+		clean()
+		t.Fatalf("cannot create TCP prober: %s", err)
+	}
+	return prober, check, clean
+}
+
+func setupTCPSSLProbe(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
+	srv, clean := setupTCPServerWithSSL(t)
+	check := sm.Check{
+		Target:  srv,
+		Timeout: 2000,
+		Settings: sm.CheckSettings{
+			Tcp: &sm.TcpSettings{
+				IpVersion: sm.IpVersion_V4,
+				Tls:       true,
+				TlsConfig: &sm.TLSConfig{
+					InsecureSkipVerify: true,
+				},
+			},
+		},
+	}
+	prober, err := tcp.NewProber(
+		ctx,
+		check,
+		zerolog.New(io.Discard))
+	if err != nil {
+		clean()
+		t.Fatalf("cannot create TCP prober: %s", err)
+	}
+	return prober, check, clean
+}
+
+func setupTracerouteProbe(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
+	checkCap := func(set *cap.Set, v cap.Value) {
+		if permitted, err := set.GetFlag(cap.Permitted, v); err != nil {
+			t.Fatalf("cannot get %s flag: %s", v, err)
+		} else if !permitted {
+			t.Skipf("traceroute cannot run, process doesn't have %s capability", v)
+		}
+	}
+	c := cap.GetProc()
+	checkCap(c, cap.NET_ADMIN)
+	checkCap(c, cap.NET_RAW)
+
+	check := sm.Check{
+		Target: "127.0.0.1",
+		Settings: sm.CheckSettings{
+			Traceroute: &sm.TracerouteSettings{},
+		},
+	}
+
+	p, err := traceroute.NewProber(check, zerolog.New(io.Discard))
+	if err != nil {
+		t.Fatalf("cannot create traceroute prober %s", err)
+	}
+
+	return p, check, func() {}
+}
+
+func setupScriptedProbe(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
+	httpSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	httpSrv.Start()
+
+	check := sm.Check{
+		Target:  httpSrv.URL,
+		Timeout: 2000,
+		Settings: sm.CheckSettings{
+			Scripted: &sm.ScriptedSettings{
+				Script: []byte(`export default function() {}`),
+			},
+		},
+	}
+
+	var runner k6runner.Runner
+
+	if k6Path := os.Getenv("K6_PATH"); k6Path != "" {
+		runner = k6runner.New(k6runner.RunnerOpts{Uri: k6Path})
+	} else {
+		runner = &testRunner{
+			metrics: testhelper.MustReadFile(t, "testdata/k6.dat"),
+			logs:    nil,
+		}
+	}
+
+	prober, err := scripted.NewProber(
+		ctx,
+		check,
+		zerolog.New(zerolog.NewTestWriter(t)),
+		runner,
+	)
+	if err != nil {
+		t.Fatalf("cannot create scripted prober: %s", err)
+	}
+
+	return prober, check, httpSrv.Close
+}
+
+func setupMultiHTTPProbe(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
+	httpSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	httpSrv.Start()
+
+	check := sm.Check{
+		Target:  httpSrv.URL,
+		Timeout: 2000,
+		Settings: sm.CheckSettings{
+			Multihttp: &sm.MultiHttpSettings{
+				Entries: []*sm.MultiHttpEntry{
+					{
+						Request: &sm.MultiHttpEntryRequest{
+							Method: sm.HttpMethod_GET,
+							Url:    httpSrv.URL,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var runner k6runner.Runner
+
+	if k6Path := os.Getenv("K6_PATH"); k6Path != "" {
+		runner = k6runner.New(k6runner.RunnerOpts{Uri: k6Path})
+	} else {
+		runner = &testRunner{
+			metrics: testhelper.MustReadFile(t, "testdata/multihttp.dat"),
+			logs:    nil,
+		}
+	}
+
+	prober, err := multihttp.NewProber(
+		ctx,
+		check,
+		zerolog.New(zerolog.NewTestWriter(t)),
+		runner,
+		http.Header{},
+	)
+	if err != nil {
+		t.Fatalf("cannot create MultiHTTP prober: %s", err)
+	}
+
+	return prober, check, httpSrv.Close
+}
+
+func setupGRPCProbe(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
+	srv, clean := setupGRPCServer(t)
+	check := sm.Check{
+		Target:  srv,
+		Timeout: 2000,
+		Settings: sm.CheckSettings{
+			Grpc: &sm.GrpcSettings{
+				IpVersion: sm.IpVersion_V4,
+			},
+		},
+	}
+	prober, err := grpcProber.NewProber(
+		ctx,
+		check,
+		zerolog.New(io.Discard))
+	if err != nil {
+		clean()
+		t.Fatalf("cannot create gRPC prober: %s", err)
+	}
+	return prober, check, clean
+}
+
+func setupGRPCSSLProbe(ctx context.Context, t *testing.T) (prober.Prober, sm.Check, func()) {
+	srv, clean := setupGRPCServerWithSSL(t)
+	check := sm.Check{
+		Target:  srv,
+		Timeout: 2000,
+		Settings: sm.CheckSettings{
+			Grpc: &sm.GrpcSettings{
+				IpVersion: sm.IpVersion_V4,
+				Tls:       true,
+				TlsConfig: &sm.TLSConfig{
+					InsecureSkipVerify: true,
+				},
+			},
+		},
+	}
+	prober, err := grpcProber.NewProber(
+		ctx,
+		check,
+		zerolog.New(io.Discard))
+	if err != nil {
+		clean()
+		t.Fatalf("cannot create gRPC prober: %s", err)
+	}
+	return prober, check, clean
 }
 
 func setupDNSServer(t *testing.T) (string, func()) {
@@ -1676,7 +1688,8 @@ func TestTickWithOffset(t *testing.T) {
 				IDLE, // 800
 				IDLE, // 900
 				WORK, // 1000
-				CLEANUP},
+				CLEANUP,
+			},
 		},
 		"An idle worker trying to run within gap duration of regular runs.": {
 			timeout: 1050 * time.Millisecond,
@@ -1692,7 +1705,8 @@ func TestTickWithOffset(t *testing.T) {
 				IDLE, // 700, there's no idle at 600 because it's too close to the previous run
 				IDLE, // 800
 				WORK, // 1000, there's no idle at 900 because it's too close to the next run
-				CLEANUP},
+				CLEANUP,
+			},
 		},
 		"A zero offset and a scraper that has already been cancelled.": {
 			timeout:  0, // this asks for immediate cancellation

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -41,6 +41,7 @@ var (
 	ErrInvalidCheckFrequency  = errors.New("invalid check frequency")
 	ErrInvalidCheckTimeout    = errors.New("invalid check timeout")
 	ErrInvalidCheckLabelName  = errors.New("invalid check label name")
+	ErrTooManyCheckLabels     = errors.New("too many check labels")
 	ErrInvalidCheckLabelValue = errors.New("invalid check label value")
 	ErrInvalidLabelName       = errors.New("invalid label name")
 	ErrInvalidLabelValue      = errors.New("invalid label value")
@@ -129,6 +130,7 @@ const (
 const (
 	MaxMetricLabels          = 20   // Prometheus allows for 32 labels, but limit to 20.
 	MaxLogLabels             = 15   // Loki allows a maximum of 15 labels.
+	MaxCheckLabels           = 10   // Allow 10 user labels for checks,
 	MaxProbeLabels           = 3    // 3 for probes, leaving 7 for internal use.
 	maxValidLabelValueLength = 2048 // This is the actual max label value length.
 	MaxLabelValueLength      = 128  // Keep this number low so that the UI remains usable.
@@ -404,6 +406,10 @@ func (c Check) validateTimeout() error {
 }
 
 func validateLabels(labels []Label) error {
+	if len(labels) > MaxCheckLabels {
+		return ErrTooManyCheckLabels
+	}
+
 	seenLabels := make(map[string]struct{})
 
 	for _, label := range labels {

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -146,6 +146,39 @@ const (
 	minK6Frequency         = 60 * 1000  // Minimum value for k6-class check's frequency.
 )
 
+const (
+	// These constants specify the maximum number of labels set by the agent
+	// for any metric and log stream for all supported probes, as well as the
+	// max number of labels set for the sm_check_info metric.
+	// These are constant per agent version but might vary between versions.
+	// They can be queried through MaxAgentMetricLabels(), MaxAgentLogLabels()
+	// and MaxAgentCheckInfoLabels() exported functions. These are required in
+	// order to calculate how many check labels can be set without exceeding
+	// specific tenant limits.
+
+	maxAgentMetricLabels    = 9 // Max metric labels set by the agent for any check type
+	maxAgentLogLabels       = 7 // Max log labels set by the agent for any check type
+	maxAgentCheckInfoLabels = 9 // Max labels set by the agent for sm_check_info metric
+)
+
+// MaxAgentMetricLabels returns the maximum number of labels set by the agent
+// to any metric.
+func MaxAgentMetricLabels() int {
+	return maxAgentMetricLabels
+}
+
+// MaxAgentLogLabels returns the maximum number of labels set by the agent
+// to any log stream.
+func MaxAgentLogLabels() int {
+	return maxAgentLogLabels
+}
+
+// MaxAgentCheckInfoLabels returns the maximum number of labels set by the agent
+// for sm_check_info metric.
+func MaxAgentCheckInfoLabels() int {
+	return maxAgentCheckInfoLabels
+}
+
 type validatable interface {
 	Validate() error
 }

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -41,7 +41,6 @@ var (
 	ErrInvalidCheckFrequency  = errors.New("invalid check frequency")
 	ErrInvalidCheckTimeout    = errors.New("invalid check timeout")
 	ErrInvalidCheckLabelName  = errors.New("invalid check label name")
-	ErrTooManyCheckLabels     = errors.New("too many check labels")
 	ErrInvalidCheckLabelValue = errors.New("invalid check label value")
 	ErrInvalidLabelName       = errors.New("invalid label name")
 	ErrInvalidLabelValue      = errors.New("invalid label value")
@@ -130,7 +129,6 @@ const (
 const (
 	MaxMetricLabels          = 20   // Prometheus allows for 32 labels, but limit to 20.
 	MaxLogLabels             = 15   // Loki allows a maximum of 15 labels.
-	MaxCheckLabels           = 10   // Allow 10 user labels for checks,
 	MaxProbeLabels           = 3    // 3 for probes, leaving 7 for internal use.
 	maxValidLabelValueLength = 2048 // This is the actual max label value length.
 	MaxLabelValueLength      = 128  // Keep this number low so that the UI remains usable.
@@ -406,10 +404,6 @@ func (c Check) validateTimeout() error {
 }
 
 func validateLabels(labels []Label) error {
-	if len(labels) > MaxCheckLabels {
-		return ErrTooManyCheckLabels
-	}
-
 	seenLabels := make(map[string]struct{})
 
 	for _, label := range labels {


### PR DESCRIPTION
This PR makes modifications to the agent in order to expose how many max labels are associated for any metric and log for each of the supported probes. For example, how many labels are associated at max for any metric from the ones reported when running an HTTP probe.

This information is required in order to validate that the check labels set from the API will not exceed the particular tenant limits for the metrics and logs backends (e.g.: mimir and loki).

A change in the number of max labels being generated from the agent could potentially make some check exceed the tenant limits, therefore there is a test in place (`TestValidateLabels`) which should alert us to update the values and review the tenant limits and possibly take some actions prior to the release. Other possible strategies such as giving extra room when defining the max number of check labels allowed should be taken into account from the API.

Updates https://github.com/grafana/synthetic-monitoring/issues/5