### PR TITLE
Update to grafana-build-tools v0.6.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,13 +13,13 @@ steps:
   - ./scripts/enforce-clean
   depends_on:
   - runner identification
-  image: ghcr.io/grafana/grafana-build-tools:v0.4.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.6.0
   name: deps
 - commands:
   - make lint
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.4.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.6.0
   name: lint
 - commands:
   - git fetch origin --tags
@@ -30,14 +30,14 @@ steps:
   - make build
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.4.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.6.0
   name: build
 - commands:
   - make test
   depends_on:
   - lint
   - build
-  image: ghcr.io/grafana/grafana-build-tools:v0.4.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.6.0
   name: test
 - commands: []
   depends_on:
@@ -203,7 +203,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.4.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.6.0
   name: write-key
 - commands:
   - make release-snapshot
@@ -211,7 +211,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.4.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.6.0
   name: test release
 - commands:
   - ./scripts/package/verify-deb-install.sh
@@ -237,7 +237,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.4.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.6.0
   name: release
   when:
     ref:
@@ -300,6 +300,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 5fb7efe6e79672a68aadbece06cb2ab9a879000265c58781d68d0998967ca9bb
+hmac: 7a87d71fd8d78e4074fc310905bf83094a6c1fd91c218c7e110c2732f6f6350d
 
 ...

--- a/config.mk
+++ b/config.mk
@@ -3,6 +3,6 @@
 
 DOCKER_TAG = grafana/synthetic-monitoring-agent
 
-GO_TOOLS_IMAGE := ghcr.io/grafana/grafana-build-tools:v0.4.0
+GO_TOOLS_IMAGE := ghcr.io/grafana/grafana-build-tools:v0.6.0
 
 PLATFORMS := $(sort $(HOST_OS)/$(HOST_ARCH) linux/amd64 linux/arm64)

--- a/scripts/configs/drone/main.jsonnet
+++ b/scripts/configs/drone/main.jsonnet
@@ -1,4 +1,4 @@
-local go_tools_image = 'ghcr.io/grafana/grafana-build-tools:v0.4.0';
+local go_tools_image = 'ghcr.io/grafana/grafana-build-tools:v0.6.0';
 
 local step(name, commands, image=go_tools_image) = {
   name: name,


### PR DESCRIPTION
This pulls in Go 1.22.0 and some tool updates.