### PR TITLE
Fix: missing http check regex validations

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -25,6 +25,7 @@ import (
 	"mime"
 	"net"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -67,16 +68,20 @@ var (
 	ErrInvalidDnsRecordTypeString = errors.New("invalid DNS record type string")
 	ErrInvalidDnsRecordTypeValue  = errors.New("invalid DNS record type value")
 
-	ErrInvalidHttpUrl             = errors.New("invalid HTTP URL")
-	ErrInvalidHttpMethodString    = errors.New("invalid HTTP method string")
-	ErrInvalidHttpMethodValue     = errors.New("invalid HTTP method value")
-	ErrInvalidHttpUrlHost         = errors.New("invalid HTTP URL host")
-	ErrInvalidHttpHeaders         = errors.New("invalid HTTP headers")
-	ErrHttpUrlContainsPassword    = errors.New("HTTP URL contains username and password")
-	ErrHttpUrlContainsUsername    = errors.New("HTTP URL contains username")
-	ErrInvalidProxyConnectHeaders = errors.New("invalid HTTP proxy connect headers")
-	ErrInvalidProxyUrl            = errors.New("invalid proxy URL")
-	ErrInvalidProxySettings       = errors.New("invalid proxy settings")
+	ErrInvalidHttpUrl                          = errors.New("invalid HTTP URL")
+	ErrInvalidHttpMethodString                 = errors.New("invalid HTTP method string")
+	ErrInvalidHttpMethodValue                  = errors.New("invalid HTTP method value")
+	ErrInvalidHttpUrlHost                      = errors.New("invalid HTTP URL host")
+	ErrInvalidHttpHeaders                      = errors.New("invalid HTTP headers")
+	ErrInvalidHttpFailIfBodyMatchesRegexp      = errors.New("invalid HTTP fail if body matches regexp")
+	ErrInvalidHttpFailIfBodyNotMatchesRegexp   = errors.New("invalid HTTP fail if body not matches regexp")
+	ErrInvalidHttpFailIfHeaderMatchesRegexp    = errors.New("invalid HTTP fail if header matches regexp")
+	ErrInvalidHttpFailIfHeaderNotMatchesRegexp = errors.New("invalid HTTP fail if header not matches regexp")
+	ErrHttpUrlContainsPassword                 = errors.New("HTTP URL contains username and password")
+	ErrHttpUrlContainsUsername                 = errors.New("HTTP URL contains username")
+	ErrInvalidProxyConnectHeaders              = errors.New("invalid HTTP proxy connect headers")
+	ErrInvalidProxyUrl                         = errors.New("invalid proxy URL")
+	ErrInvalidProxySettings                    = errors.New("invalid proxy settings")
 
 	ErrInvalidTracerouteHostname = errors.New("invalid traceroute hostname")
 
@@ -630,6 +635,34 @@ func (s *HttpSettings) Validate() error {
 
 		if !httpguts.ValidHeaderFieldValue(fields[1]) {
 			return ErrInvalidProxyConnectHeaders
+		}
+	}
+
+	for _, reg := range s.FailIfBodyMatchesRegexp {
+		_, err := regexp.Compile(reg)
+		if err != nil {
+			return ErrInvalidHttpFailIfBodyMatchesRegexp
+		}
+	}
+
+	for _, reg := range s.FailIfBodyNotMatchesRegexp {
+		_, err := regexp.Compile(reg)
+		if err != nil {
+			return ErrInvalidHttpFailIfBodyNotMatchesRegexp
+		}
+	}
+
+	for _, match := range s.FailIfHeaderMatchesRegexp {
+		_, err := regexp.Compile(match.Regexp)
+		if err != nil {
+			return ErrInvalidHttpFailIfHeaderMatchesRegexp
+		}
+	}
+
+	for _, match := range s.FailIfHeaderNotMatchesRegexp {
+		_, err := regexp.Compile(match.Regexp)
+		if err != nil {
+			return ErrInvalidHttpFailIfHeaderNotMatchesRegexp
 		}
 	}
 

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -1715,6 +1715,59 @@ func TestMultiHttpEntryAssertionValidate(t *testing.T) {
 	})
 }
 
+func TestHttpRegexFields(t *testing.T) {
+	testValidate(t, TestCases[*HttpSettings]{
+		"body matches regexp parses": {
+			input: &HttpSettings{
+				FailIfBodyMatchesRegexp: []string{".*good stuff.*"},
+			},
+			expectError: false,
+		},
+		"body matches invalid regexp errors": {
+			input: &HttpSettings{
+				FailIfBodyMatchesRegexp: []string{"*good stuff*"},
+			},
+			expectError: true,
+		},
+		"body not matches regexp parses": {
+			input: &HttpSettings{
+				FailIfBodyNotMatchesRegexp: []string{".*good stuff.*"},
+			},
+			expectError: false,
+		},
+		"body not matches invalid regexp errors": {
+			input: &HttpSettings{
+				FailIfBodyNotMatchesRegexp: []string{"*good stuff*"},
+			},
+			expectError: true,
+		},
+		"header matches regexp parses": {
+			input: &HttpSettings{
+				FailIfHeaderMatchesRegexp: []HeaderMatch{{Regexp: ".*good stuff.*"}},
+			},
+			expectError: false,
+		},
+		"header matches invalid regexp errors": {
+			input: &HttpSettings{
+				FailIfHeaderMatchesRegexp: []HeaderMatch{{Regexp: "*good stuff*"}},
+			},
+			expectError: true,
+		},
+		"header not matches regexp parses": {
+			input: &HttpSettings{
+				FailIfHeaderNotMatchesRegexp: []HeaderMatch{{Regexp: ".*good stuff.*"}},
+			},
+			expectError: false,
+		},
+		"header not matches invalid regexp errors": {
+			input: &HttpSettings{
+				FailIfHeaderNotMatchesRegexp: []HeaderMatch{{Regexp: "*good stuff*"}},
+			},
+			expectError: true,
+		},
+	})
+}
+
 func TestMultiHttpEntryVariableValidate(t *testing.T) {
 	testValidate(t, TestCases[*MultiHttpEntryVariable]{
 		"zero value": {


### PR DESCRIPTION
Adds back regex validations on the fields of an HTTP check which use them, such as `fail_if_body_matches_regexp`.

It looks like the only other place these fields get validated is [here](https://github.com/grafana/synthetic-monitoring-agent/blob/a02485f1054df991c0e8289c6893650f6190ce77/internal/prober/http/http.go#L101) (converting `HttpSettings` to BBE config module). From [this line](https://github.com/grafana/synthetic-monitoring-agent/blob/a02485f1054df991c0e8289c6893650f6190ce77/internal/scraper/scraper.go#L136), I figure if the validation doesn't go through when creating the HTTP Probe, then a `Scraper` isn't created for that check/probe and it doesn't get executed (@mem suggested this in the original support issue).

Fixes https://github.com/grafana/synthetic-monitoring-agent/issues/597.