### PR TITLE
Fix: global tenant id usage for label limits query

### DIFF
--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -286,11 +286,11 @@ type testLabelsLimiter struct {
 	logLabelsLimit    int
 }
 
-func (l testLabelsLimiter) MetricLabels(ctx context.Context, tenantID int64) (int, error) {
+func (l testLabelsLimiter) MetricLabels(ctx context.Context, tenantID model.GlobalID) (int, error) {
 	return l.metricLabelsLimit, nil
 }
 
-func (l testLabelsLimiter) LogLabels(ctx context.Context, tenantID int64) (int, error) {
+func (l testLabelsLimiter) LogLabels(ctx context.Context, tenantID model.GlobalID) (int, error) {
 	return l.logLabelsLimit, nil
 }
 

--- a/internal/limits/tenant.go
+++ b/internal/limits/tenant.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
@@ -36,9 +37,9 @@ func NewTenantLimits(tp TenantProvider) *TenantLimits {
 }
 
 // MetricLabels returns the metric labels limit for the specified tenant.
-func (tl *TenantLimits) MetricLabels(ctx context.Context, tenantID int64) (int, error) {
+func (tl *TenantLimits) MetricLabels(ctx context.Context, tenantID model.GlobalID) (int, error) {
 	tenant, err := tl.tp.GetTenant(ctx, &sm.TenantInfo{
-		Id: tenantID,
+		Id: int64(tenantID),
 	})
 	if err != nil {
 		return 0, err
@@ -53,9 +54,9 @@ func (tl *TenantLimits) MetricLabels(ctx context.Context, tenantID int64) (int, 
 }
 
 // LogLabels returns the log labels limit for the specified tenant.
-func (tl *TenantLimits) LogLabels(ctx context.Context, tenantID int64) (int, error) {
+func (tl *TenantLimits) LogLabels(ctx context.Context, tenantID model.GlobalID) (int, error) {
 	tenant, err := tl.tp.GetTenant(ctx, &sm.TenantInfo{
-		Id: tenantID,
+		Id: int64(tenantID),
 	})
 	if err != nil {
 		return 0, err
@@ -70,7 +71,7 @@ func (tl *TenantLimits) LogLabels(ctx context.Context, tenantID int64) (int, err
 }
 
 // ValidateMetricLabels validates the given number of metric labels against the specific tenant limits.
-func (tl *TenantLimits) ValidateMetricLabels(ctx context.Context, tenantID int64, n int) error {
+func (tl *TenantLimits) ValidateMetricLabels(ctx context.Context, tenantID model.GlobalID, n int) error {
 	max, err := tl.MetricLabels(ctx, tenantID)
 	if err != nil {
 		return err
@@ -84,7 +85,7 @@ func (tl *TenantLimits) ValidateMetricLabels(ctx context.Context, tenantID int64
 }
 
 // ValidateLogLabels validates the given number of log labels against the specific tenant limits.
-func (tl *TenantLimits) ValidateLogLabels(ctx context.Context, tenantID int64, n int) error {
+func (tl *TenantLimits) ValidateLogLabels(ctx context.Context, tenantID model.GlobalID, n int) error {
 	max, err := tl.LogLabels(ctx, tenantID)
 	if err != nil {
 		return err

--- a/internal/limits/tenant_test.go
+++ b/internal/limits/tenant_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +46,7 @@ func TestMetricLabels(t *testing.T) {
 
 	testCases := []struct {
 		name      string
-		tenantID  int
+		tenantID  model.GlobalID
 		expLabels int
 		expErr    error
 	}{
@@ -73,7 +74,7 @@ func TestMetricLabels(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ll, err := tl.MetricLabels(ctx, int64(tc.tenantID))
+			ll, err := tl.MetricLabels(ctx, tc.tenantID)
 			if err != nil {
 				require.Equal(t, tc.expErr, err)
 			}
@@ -87,7 +88,7 @@ func TestLogLabels(t *testing.T) {
 
 	testCases := []struct {
 		name      string
-		tenantID  int
+		tenantID  model.GlobalID
 		expLabels int
 		expErr    error
 	}{
@@ -115,7 +116,7 @@ func TestLogLabels(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ll, err := tl.LogLabels(ctx, int64(tc.tenantID))
+			ll, err := tl.LogLabels(ctx, tc.tenantID)
 			if err != nil {
 				require.Equal(t, tc.expErr, err)
 			}
@@ -129,7 +130,7 @@ func TestValidateMetricLabels(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		tenantID int
+		tenantID model.GlobalID
 		nLabels  int
 		expErr   error
 	}{
@@ -169,7 +170,7 @@ func TestValidateMetricLabels(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tl.ValidateMetricLabels(ctx, int64(tc.tenantID), tc.nLabels)
+			err := tl.ValidateMetricLabels(ctx, tc.tenantID, tc.nLabels)
 			require.Equal(t, tc.expErr, err)
 		})
 	}
@@ -180,7 +181,7 @@ func TestValidateLogLabels(t *testing.T) {
 
 	testCases := []struct {
 		name     string
-		tenantID int
+		tenantID model.GlobalID
 		nLabels  int
 		expErr   error
 	}{
@@ -220,7 +221,7 @@ func TestValidateLogLabels(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tl.ValidateLogLabels(ctx, int64(tc.tenantID), tc.nLabels)
+			err := tl.ValidateLogLabels(ctx, tc.tenantID, tc.nLabels)
 			require.Equal(t, tc.expErr, err)
 		})
 	}

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -62,8 +62,8 @@ func NewIncrementerFromCounterVec(c *prometheus.CounterVec) IncrementerVec {
 }
 
 type LabelsLimiter interface {
-	MetricLabels(ctx context.Context, tenantID int64) (int, error)
-	LogLabels(ctx context.Context, tenantID int64) (int, error)
+	MetricLabels(ctx context.Context, tenantID model.GlobalID) (int, error)
+	LogLabels(ctx context.Context, tenantID model.GlobalID) (int, error)
 }
 
 type Scraper struct {
@@ -365,11 +365,11 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, erro
 		checkInfoLabels = s.buildCheckInfoLabels(userLabels)
 	)
 
-	maxMetricLabels, err := s.labelsLimiter.MetricLabels(ctx, s.check.TenantId)
+	maxMetricLabels, err := s.labelsLimiter.MetricLabels(ctx, s.check.GlobalTenantID())
 	if err != nil {
 		return nil, fmt.Errorf("retrieving tenant metric labels limit: %w", err)
 	}
-	maxLogLabels, err := s.labelsLimiter.LogLabels(ctx, s.check.TenantId)
+	maxLogLabels, err := s.labelsLimiter.LogLabels(ctx, s.check.GlobalTenantID())
 	if err != nil {
 		return nil, fmt.Errorf("retrieving tenant log labels limit: %w", err)
 	}

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1047,11 +1047,11 @@ type testLabelsLimiter struct {
 	maxLogLabels    int
 }
 
-func (l testLabelsLimiter) MetricLabels(ctx context.Context, tenantID int64) (int, error) {
+func (l testLabelsLimiter) MetricLabels(ctx context.Context, tenantID model.GlobalID) (int, error) {
 	return l.maxMetricLabels, nil
 }
 
-func (l testLabelsLimiter) LogLabels(ctx context.Context, tenantID int64) (int, error) {
+func (l testLabelsLimiter) LogLabels(ctx context.Context, tenantID model.GlobalID) (int, error) {
 	return l.maxLogLabels, nil
 }
 


### PR DESCRIPTION
Modifies the label limits query methods to only accept global IDs, and updates the respective calls from scraper.