### PR TITLE
Feature: promote adhoc to permanent feature

### DIFF
--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -117,11 +117,6 @@ type HandlerOpts struct {
 
 // NewHandler creates a new Handler using the specified options.
 func NewHandler(opts HandlerOpts) (*Handler, error) {
-	// We should never hit this, but just in case.
-	if !opts.Features.IsSet(feature.AdHoc) {
-		return nil, fmt.Errorf("AdHoc feature is not enabled")
-	}
-
 	opsCounter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "sm",


### PR DESCRIPTION
This has caused a number of questions recently because the "test" functionality requires the "adhoc" feature to be enabled.

We have had this feature for a long time now and we are actively using it. Make it a permanent feature by removing the checks for whether or not it's enabled. Keep the feature flag in case someone is passing it on the command line to avoid breaking those set ups.