### PR TITLE
Release v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 ## [Unreleased]
 
 
-<a name="v0.20.0"></a>
-## [v0.20.0] - 2024-02-12
+<a name="v0.20.1"></a>
+## [v0.20.1] - 2024-02-12
 ### Fix
 - add test for HTTP check with a long URL
 
@@ -545,8 +545,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.20.0...HEAD
-[v0.20.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.6...v0.20.0
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.20.1...HEAD
+[v0.20.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.6...v0.20.1
 [v0.19.6]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.5...v0.19.6
 [v0.19.5]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.4...v0.19.5
 [v0.19.4]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.3...v0.19.4


### PR DESCRIPTION
* Add an option to log multihttp responses (#550)
* Update to grafana-build-tools v0.6.0
* Chore(deps): Bump golang.org/x/net from 0.20.0 to 0.21.0
* Chore(deps): Bump github.com/rs/zerolog from 1.31.0 to 1.32.0
* Chore(deps): Bump github.com/miekg/dns from 1.1.57 to 1.1.58
* Fix: add test for HTTP check with a long URL
* Add tenant label limits (#581)
* Release v0.20.0 (#613)
* Fix global tenant id usage for label limits query