### PR TITLE
Release v0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 ## [Unreleased]
 
 
+<a name="v0.20.2"></a>
+## [v0.20.2] - 2024-02-13
+### Feature
+- promote adhoc to permanent feature ([#615](https://github.com/grafana/synthetic-monitoring-agent/issues/615))
+
+### Fix
+- missing http check regex validations ([#612](https://github.com/grafana/synthetic-monitoring-agent/issues/612))
+
+
 <a name="v0.20.1"></a>
 ## [v0.20.1] - 2024-02-12
 ### Fix
@@ -545,7 +554,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.20.1...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.20.2...HEAD
+[v0.20.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.20.1...v0.20.2
 [v0.20.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.6...v0.20.1
 [v0.19.6]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.5...v0.19.6
 [v0.19.5]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.4...v0.19.5


### PR DESCRIPTION
* Add an option to log multihttp responses (#550)
* Update to grafana-build-tools v0.6.0
* Chore(deps): Bump golang.org/x/net from 0.20.0 to 0.21.0
* Chore(deps): Bump github.com/rs/zerolog from 1.31.0 to 1.32.0
* Chore(deps): Bump github.com/miekg/dns from 1.1.57 to 1.1.58
* Fix: add test for HTTP check with a long URL
* Add tenant label limits (#581)
* Release v0.20.0 (#613)
* Fix global tenant id usage for label limits query
* Release v0.20.1
* Feature: promote adhoc to permanent feature (#615)
* Update release script (#617)
* Chore(deps): Bump github.com/mccutchen/go-httpbin/v2 (#618)
* Fix: missing http check regex validations (#612)