### PR TITLE
Add telemetry

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -236,6 +236,7 @@ func run(args []string, stdout io.Writer) error {
 		ctx, uuid.New().String(), time.Duration(*telemetryTimeSpan)*time.Minute,
 		synthetic_monitoring.NewTelemetryClient(conn),
 		zl.With().Str("subsystem", "telemetry").Logger(),
+		promRegisterer,
 	)
 
 	checksUpdater, err := checks.NewUpdater(checks.UpdaterOptions{

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
 	"github.com/grafana/synthetic-monitoring-agent/internal/scraper"
+	"github.com/grafana/synthetic-monitoring-agent/internal/telemetry"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
@@ -296,7 +297,7 @@ func (l testLabelsLimiter) LogLabels(ctx context.Context, tenantID model.GlobalI
 
 func testScraperFactory(ctx context.Context, check model.Check, publisher pusher.Publisher,
 	_ sm.Probe, logger zerolog.Logger, scrapeCounter scraper.Incrementer, scrapeErrorCounter scraper.IncrementerVec,
-	k6Runner k6runner.Runner, labelsLimiter scraper.LabelsLimiter,
+	k6Runner k6runner.Runner, labelsLimiter scraper.LabelsLimiter, telemeter *telemetry.Telemeter,
 ) (*scraper.Scraper, error) {
 	return scraper.NewWithOpts(
 		ctx,
@@ -308,6 +309,7 @@ func testScraperFactory(ctx context.Context, check model.Check, publisher pusher
 			Publisher:     publisher,
 			ScrapeCounter: scrapeCounter,
 			LabelsLimiter: testLabelsLimiter{},
+			Telemeter:     telemeter,
 		},
 	)
 }

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -241,7 +241,16 @@ func (s *Scraper) Run(ctx context.Context) {
 		s.scrapeCounter.Inc()
 
 		var err error
+		start := time.Now()
 		payload, err = s.collectData(ctx, t)
+		end := time.Now()
+
+		s.telemeter.AddExecution(telemetry.Execution{
+			LocalTenantID: s.check.TenantId,
+			RegionID:      int32(s.check.RegionId),
+			CheckClass:    s.check.Class(),
+			Duration:      end.Sub(start),
+		})
 
 		switch {
 		case errors.Is(err, errCheckFailed):

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -248,6 +248,7 @@ func (s *Scraper) Run(ctx context.Context) {
 		s.telemeter.AddExecution(telemetry.Execution{
 			LocalTenantID: s.check.TenantId,
 			RegionID:      int32(s.check.RegionId),
+			Region:        s.probe.Region,
 			CheckClass:    s.check.Class(),
 			Duration:      end.Sub(start),
 		})

--- a/internal/telemetry/region_pusher.go
+++ b/internal/telemetry/region_pusher.go
@@ -74,6 +74,7 @@ LOOP:
 			p.logger.Debug().Msg("region pusher stopping")
 			m := p.next()
 			p.push(m)
+			ticker.Stop()
 			break LOOP
 		}
 	}

--- a/internal/telemetry/region_pusher.go
+++ b/internal/telemetry/region_pusher.go
@@ -1,0 +1,147 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/rs/zerolog"
+)
+
+// RegionPusher periodically sends telemetry data for a specific region.
+type RegionPusher struct {
+	client sm.TelemetryClient
+	logger zerolog.Logger
+
+	instance string
+	regionID int32
+
+	telemetry   map[int64]map[sm.CheckClass]*sm.CheckClassTelemetry // Indexed by local tenant ID
+	telemetryMu sync.Mutex
+}
+
+// NewRegionPusher builds a new RegionPusher.
+// Notice that the effective time span used to dictate the pace for periodic
+// push events will be defined based on the given time span plus a random
+// jitter [0,59)s.
+func NewRegionPusher(
+	ctx context.Context, timeSpan time.Duration,
+	client sm.TelemetryClient, logger zerolog.Logger, instance string, regionID int32,
+	opts ...any,
+) *RegionPusher {
+	tp := &RegionPusher{
+		client:    client,
+		logger:    logger,
+		instance:  instance,
+		regionID:  regionID,
+		telemetry: make(map[int64]map[sm.CheckClass]*sm.CheckClassTelemetry),
+	}
+
+	var ticker ticker = newStdTicker(timeSpan)
+
+	for _, o := range opts {
+		switch o := o.(type) { //nolint:gocritic
+		case withTicker:
+			ticker = o
+		}
+	}
+
+	go tp.run(ctx, ticker)
+
+	return tp
+}
+
+type withTicker ticker
+
+func (p *RegionPusher) run(ctx context.Context, ticker ticker) {
+	p.logger.Info().Msg("region pusher starting")
+
+	// TODO: We could potentially create here a pushCtx, pass that to push, and
+	// from push keep retrying sending the data if it fails initially until the
+	// pushCtx is canceled, which should happen once the ticker ticks again, to
+	// avoid overlapping push requests.
+	// By now, only retry folllowing the ticker's pace.
+
+LOOP:
+	for {
+		select {
+		case <-ticker.C():
+			p.logger.Info().Msg("pushing telemetry")
+			m := p.next()
+			go p.push(m) // Avoid blocking
+		case <-ctx.Done():
+			p.logger.Debug().Msg("region pusher stopping")
+			m := p.next()
+			p.push(m)
+			break LOOP
+		}
+	}
+}
+
+// AddExecution adds a new execution to the tenant telemetry.
+func (p *RegionPusher) AddExecution(e Execution) {
+	p.telemetryMu.Lock()
+	defer p.telemetryMu.Unlock()
+
+	tenantTele, ok := p.telemetry[e.LocalTenantID]
+	if !ok {
+		tenantTele = make(map[sm.CheckClass]*sm.CheckClassTelemetry)
+		p.telemetry[e.LocalTenantID] = tenantTele
+	}
+
+	clTele, ok := tenantTele[e.CheckClass]
+	if !ok {
+		clTele = &sm.CheckClassTelemetry{CheckClass: e.CheckClass}
+		tenantTele[e.CheckClass] = clTele
+	}
+
+	clTele.Executions++
+	clTele.Duration += float32(e.Duration.Seconds())
+}
+
+func (p *RegionPusher) next() sm.RegionTelemetry {
+	m := sm.RegionTelemetry{
+		Instance:  p.instance,
+		RegionId:  p.regionID,
+		Telemetry: make([]*sm.TenantTelemetry, 0, len(p.telemetry)),
+	}
+
+	p.telemetryMu.Lock()
+	defer p.telemetryMu.Unlock()
+
+	// Copy current telemetry data
+	for tenantID, tTele := range p.telemetry {
+		tenantTele := &sm.TenantTelemetry{
+			TenantId:  tenantID,
+			Telemetry: make([]*sm.CheckClassTelemetry, 0, len(tTele)),
+		}
+		for _, clTele := range tTele {
+			tenantTele.Telemetry = append(tenantTele.Telemetry, &sm.CheckClassTelemetry{
+				CheckClass: clTele.CheckClass,
+				Executions: clTele.Executions,
+				Duration:   clTele.Duration,
+			})
+		}
+		m.Telemetry = append(m.Telemetry, tenantTele)
+	}
+
+	return m
+}
+
+func (p *RegionPusher) push(m sm.RegionTelemetry) {
+	// We don't want to cancel a possibly ongoing request even if the agent
+	// context is done, therefore use background context
+	ctx := context.Background()
+	r, err := p.client.PushTelemetry(ctx, &m)
+	if err != nil {
+		p.logger.Err(err).Msg("error pushing telemetry")
+		return
+	}
+	if r.Status.Code != sm.StatusCode_OK {
+		p.logger.Error().
+			Int32("statusCode", int32(r.Status.Code)).
+			Str("statusMessage", r.Status.Message).
+			Msg("error pushing telemetry")
+	}
+}

--- a/internal/telemetry/region_pusher_test.go
+++ b/internal/telemetry/region_pusher_test.go
@@ -147,6 +147,7 @@ var (
 		pushRequestsDuration: prom.NewHistogram(prom.HistogramOpts{}),
 		pushRequestsTotal:    prom.NewCounter(prom.CounterOpts{}),
 		pushRequestsError:    prom.NewCounter(prom.CounterOpts{}),
+		addExecutionDuration: prom.NewHistogram(prom.HistogramOpts{}),
 	}
 )
 

--- a/internal/telemetry/region_pusher_test.go
+++ b/internal/telemetry/region_pusher_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+
+	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -139,6 +141,13 @@ var (
 			},
 		},
 	}
+
+	m = RegionMetrics{
+		pushRequestsActive:   prom.NewGauge(prom.GaugeOpts{}),
+		pushRequestsDuration: prom.NewHistogram(prom.HistogramOpts{}),
+		pushRequestsTotal:    prom.NewCounter(prom.CounterOpts{}),
+		pushRequestsError:    prom.NewCounter(prom.CounterOpts{}),
+	}
 )
 
 func TestTenantPusher(t *testing.T) {
@@ -208,7 +217,7 @@ func TestTenantPusher(t *testing.T) {
 		}
 		var opt withTicker = ticker
 
-		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, opt)
+		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, m, opt)
 
 		// Add some executions
 		addExecutions(pusher, 0, 4)
@@ -236,7 +245,7 @@ func TestTenantPusher(t *testing.T) {
 		}
 		var opt withTicker = ticker
 
-		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, opt)
+		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, m, opt)
 
 		// Add some executions
 		addExecutions(pusher, 0, 4)
@@ -265,7 +274,7 @@ func TestTenantPusher(t *testing.T) {
 		}
 		var opt withTicker = ticker
 
-		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, opt)
+		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, m, opt)
 
 		// Add some executions
 		addExecutions(pusher, 0, 4)
@@ -296,7 +305,7 @@ func TestTenantPusher(t *testing.T) {
 		}
 		var opt withTicker = ticker
 
-		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, opt)
+		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, m, opt)
 
 		// Add some executions
 		addExecutions(pusher, 0, 4)

--- a/internal/telemetry/region_pusher_test.go
+++ b/internal/telemetry/region_pusher_test.go
@@ -1,0 +1,397 @@
+package telemetry
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+const (
+	instance = "instance"
+	regionID = 1
+)
+
+var (
+	ee = []Execution{
+		{
+			LocalTenantID: 1,
+			CheckClass:    sm.CheckClass_PROTOCOL,
+			Duration:      1 * time.Second,
+		},
+		{
+			LocalTenantID: 1,
+			CheckClass:    sm.CheckClass_PROTOCOL,
+			Duration:      2 * time.Second,
+		},
+		{
+			LocalTenantID: 2,
+			CheckClass:    sm.CheckClass_SCRIPTED,
+			Duration:      1 * time.Second,
+		},
+		{
+			LocalTenantID: 2,
+			CheckClass:    sm.CheckClass_SCRIPTED,
+			Duration:      2 * time.Second,
+		},
+
+		{
+			LocalTenantID: 1,
+			CheckClass:    sm.CheckClass_SCRIPTED,
+			Duration:      1 * time.Second,
+		},
+		{
+			LocalTenantID: 1,
+			CheckClass:    sm.CheckClass_SCRIPTED,
+			Duration:      5 * time.Second,
+		},
+		{
+			LocalTenantID: 1,
+			CheckClass:    sm.CheckClass_PROTOCOL,
+			Duration:      4 * time.Second,
+		},
+		{
+			LocalTenantID: 1,
+			CheckClass:    sm.CheckClass_SCRIPTED,
+			Duration:      5 * time.Second,
+		},
+		{
+			LocalTenantID: 2,
+			CheckClass:    sm.CheckClass_PROTOCOL,
+			Duration:      2 * time.Second,
+		},
+		{
+			LocalTenantID: 1,
+			CheckClass:    sm.CheckClass_SCRIPTED,
+			Duration:      2 * time.Second,
+		},
+	}
+
+	mm = []sm.RegionTelemetry{
+		// 0: this is the expected message for ee[0] -> ee[3] executions
+		{
+			Instance: instance,
+			RegionId: 1,
+			Telemetry: []*sm.TenantTelemetry{
+				{
+					TenantId: 1,
+					Telemetry: []*sm.CheckClassTelemetry{
+						{
+							CheckClass: sm.CheckClass_PROTOCOL,
+							Executions: 2,
+							Duration:   3,
+						},
+					},
+				},
+				{
+					TenantId: 2,
+					Telemetry: []*sm.CheckClassTelemetry{
+						{
+							CheckClass: sm.CheckClass_SCRIPTED,
+							Executions: 2,
+							Duration:   3,
+						},
+					},
+				},
+			},
+		},
+		// 1: this is the expected message for ee[0] -> ee[9] executions
+		{
+			Instance: instance,
+			RegionId: 1,
+			Telemetry: []*sm.TenantTelemetry{
+				{
+					TenantId: 1,
+					Telemetry: []*sm.CheckClassTelemetry{
+						{
+							CheckClass: sm.CheckClass_PROTOCOL,
+							Executions: 3,
+							Duration:   7,
+						},
+						{
+							CheckClass: sm.CheckClass_SCRIPTED,
+							Executions: 4,
+							Duration:   13,
+						},
+					},
+				},
+				{
+					TenantId: 2,
+					Telemetry: []*sm.CheckClassTelemetry{
+						{
+							CheckClass: sm.CheckClass_PROTOCOL,
+							Executions: 1,
+							Duration:   2,
+						},
+						{
+							CheckClass: sm.CheckClass_SCRIPTED,
+							Executions: 2,
+							Duration:   3,
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestTenantPusher(t *testing.T) {
+	var (
+		// This time span is passed to the tenant constructor, but it's ignored
+		// because we are overriding the ticker with one that we can control
+		timeSpan = 1 * time.Second
+
+		logger = zerolog.Nop()
+		ticker = &testTicker{
+			c: make(chan time.Time),
+		}
+
+		// Because the push happens in a separate goroutine, we use a waitgroup
+		// to wait for the mock push client to finish before verifying the data
+		wg         = &sync.WaitGroup{}
+		testClient = &testTelemetryClient{wg: wg}
+
+		testPushRespOK = testPushResp{
+			tr: &sm.PushTelemetryResponse{
+				Status: &sm.Status{Code: sm.StatusCode_OK},
+			},
+		}
+		testPushRespKO = testPushResp{
+			tr: &sm.PushTelemetryResponse{
+				Status: &sm.Status{Code: sm.StatusCode_INTERNAL_ERROR},
+			},
+		}
+	)
+
+	addExecutions := func(p *RegionPusher, from, to int) {
+		for i := from; i < to; i++ {
+			p.AddExecution(ee[i])
+		}
+	}
+
+	// tickAndWait will tick the ticker once, so the push
+	// process starts, and wait for the push client to finish
+	tickAndWait := func() {
+		wg.Add(1)
+		defer wg.Wait()
+		ticker.c <- time.Now()
+	}
+
+	// waitForShutdown will cancel the context passed to the
+	// tenant pusher and wait for it to finish its work
+	shutdownAndWait := func(cancel context.CancelFunc) {
+		defer wg.Wait()
+		// The pusher will send the current accumulated
+		// data before exiting
+		wg.Add(1)
+
+		cancel()
+	}
+
+	resetTestClient := func() {
+		testClient = &testTelemetryClient{wg: wg}
+	}
+
+	t.Run("should send telemetry data once", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		t.Cleanup(func() {
+			shutdownAndWait(cancel)
+			resetTestClient()
+		})
+
+		var opt withTicker = ticker
+		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, opt)
+
+		// Add some executions
+		addExecutions(pusher, 0, 4)
+
+		// Set mock response for client
+		testClient.rr = testPushRespOK
+
+		// Tick
+		tickAndWait()
+
+		// Verify sent data
+		testClient.assert(t, []sm.RegionTelemetry{mm[0]})
+	})
+
+	t.Run("should retry sending data once", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		t.Cleanup(func() {
+			shutdownAndWait(cancel)
+			resetTestClient()
+		})
+
+		var opt withTicker = ticker
+		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, opt)
+
+		// Add some executions
+		addExecutions(pusher, 0, 4)
+
+		// Set mock response for client
+		testClient.rr = testPushRespKO
+
+		// Tick twice, one for initial push and one for retry
+		tickAndWait()
+		tickAndWait()
+
+		// Verify sent data
+		testClient.assert(t, []sm.RegionTelemetry{mm[0], mm[0]})
+	})
+
+	t.Run("should retry and send more data", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		t.Cleanup(func() {
+			shutdownAndWait(cancel)
+			resetTestClient()
+		})
+
+		var opt withTicker = ticker
+		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, opt)
+
+		// Add some executions
+		addExecutions(pusher, 0, 4)
+
+		// Set KO mock response for client and tick once
+		testClient.rr = testPushRespKO
+		tickAndWait()
+
+		// Send more executions
+		addExecutions(pusher, 4, 10)
+
+		// Set OK mock response for client and tick again
+		testClient.rr = testPushRespOK
+		tickAndWait()
+
+		// Verify sent data
+		testClient.assert(t, []sm.RegionTelemetry{
+			mm[0], // First tick message
+			mm[1], // First message retry with newly accumulated data
+		})
+	})
+
+	t.Run("should push on context done", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var opt withTicker = ticker
+		pusher := NewRegionPusher(ctx, timeSpan, testClient, logger, instance, regionID, opt)
+
+		// Add some executions
+		addExecutions(pusher, 0, 4)
+
+		// Set mock response for client
+		testClient.rr = testPushRespKO
+
+		// Tick once, which should make the push fail
+		tickAndWait()
+
+		// Verify sent data
+		testClient.assert(t, []sm.RegionTelemetry{mm[0]})
+
+		// Send more executions
+		addExecutions(pusher, 4, 10)
+
+		// Cancel the context
+		// Which should make the pusher send
+		// the currently accumulated data
+		shutdownAndWait(cancel)
+
+		// Verify sent data on exit
+		testClient.assert(t, []sm.RegionTelemetry{mm[1]})
+	})
+}
+
+type testTicker struct {
+	c chan time.Time
+}
+
+func (t *testTicker) C() <-chan time.Time {
+	return t.c
+}
+
+type testPushResp struct {
+	tr  *sm.PushTelemetryResponse
+	err error
+}
+
+type testTelemetryClient struct {
+	mu sync.Mutex
+	wg *sync.WaitGroup
+
+	rr testPushResp
+	mm []sm.RegionTelemetry
+}
+
+func (tc *testTelemetryClient) PushTelemetry(
+	ctx context.Context, in *sm.RegionTelemetry, opts ...grpc.CallOption,
+) (*sm.PushTelemetryResponse, error) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	defer tc.wg.Done()
+
+	tc.mm = append(tc.mm, *in)
+
+	return tc.rr.tr, tc.rr.err
+}
+
+func (tc *testTelemetryClient) assert(t *testing.T, exp []sm.RegionTelemetry) {
+	t.Helper()
+
+	defer func() {
+		// reslice got messages moving forward for each one verified
+		// so these are not taken into account if assert is called again
+		tc.mm = tc.mm[len(exp):]
+	}()
+	for i, expM := range exp {
+		assertInfoData(t, &expM, &tc.mm[i])
+		assertRegionTelemetryData(t, &expM, &tc.mm[i])
+	}
+}
+
+func assertInfoData(t *testing.T, exp, got *sm.RegionTelemetry) {
+	t.Helper()
+	require.Equal(t, exp.Instance, got.Instance)
+	require.Equal(t, exp.RegionId, got.RegionId)
+}
+
+func assertRegionTelemetryData(t *testing.T, exp, got *sm.RegionTelemetry) {
+	t.Helper()
+	require.Equal(t, len(exp.Telemetry), len(got.Telemetry))
+	// Because the message is built in the pusher by iterating a map, the
+	// order is not deterministic, therefore we have to find each element
+LOOP:
+	for _, expTenantTele := range exp.Telemetry {
+		for j, gotTenantTele := range got.Telemetry {
+			if expTenantTele.TenantId == gotTenantTele.TenantId {
+				assertTenantTelemetryData(t, expTenantTele, gotTenantTele)
+				got.Telemetry = append(got.Telemetry[:j], got.Telemetry[j+1:]...)
+				continue LOOP
+			}
+		}
+		t.Fatalf("telemetry not found: %v", expTenantTele)
+	}
+}
+
+func assertTenantTelemetryData(t *testing.T, exp, got *sm.TenantTelemetry) {
+	t.Helper()
+	require.Equal(t, len(exp.Telemetry), len(got.Telemetry))
+LOOP:
+	for _, expTele := range exp.Telemetry {
+		for j, gotTele := range got.Telemetry {
+			if reflect.DeepEqual(expTele, gotTele) {
+				got.Telemetry = append(got.Telemetry[:j], got.Telemetry[j+1:]...)
+				continue LOOP
+			}
+		}
+		t.Fatalf("telemetry not found: %v", expTele)
+	}
+}

--- a/internal/telemetry/telemeter.go
+++ b/internal/telemetry/telemeter.go
@@ -89,7 +89,7 @@ func (t *Telemeter) AddExecution(e Execution) {
 	// If we do not have a pusher for this region, create it
 	l := t.logger.With().
 		Str("component", "region-pusher").
-		Str("instance", t.instance).
+		Str("agent_instance", t.instance).
 		Int32("regionId", e.RegionID).
 		Logger()
 	labels := prom.Labels{
@@ -117,7 +117,7 @@ func (t *Telemeter) registerMetrics(registerer prom.Registerer) {
 		Subsystem:   "telemetry",
 		Name:        "push_requests_active",
 		Help:        "Active push telemetry requests",
-		ConstLabels: prom.Labels{"instance": t.instance},
+		ConstLabels: prom.Labels{"agent_instance": t.instance},
 	}, []string{"region_id"})
 	t.metrics.pushRequestsDuration = prom.NewHistogramVec(prom.HistogramOpts{
 		Namespace:   "sm_agent",
@@ -125,21 +125,21 @@ func (t *Telemeter) registerMetrics(registerer prom.Registerer) {
 		Name:        "push_requests_duration_seconds",
 		Help:        "Duration of push telemetry requests",
 		Buckets:     prom.ExponentialBucketsRange(0.01, 2.0, 10),
-		ConstLabels: prom.Labels{"instance": t.instance},
+		ConstLabels: prom.Labels{"agent_instance": t.instance},
 	}, []string{"region_id"})
 	t.metrics.pushRequestsTotal = prom.NewCounterVec(prom.CounterOpts{
 		Namespace:   "sm_agent",
 		Subsystem:   "telemetry",
 		Name:        "push_requests_total",
 		Help:        "Total count of push telemetry requests",
-		ConstLabels: prom.Labels{"instance": t.instance},
+		ConstLabels: prom.Labels{"agent_instance": t.instance},
 	}, []string{"region_id"})
 	t.metrics.pushRequestsError = prom.NewCounterVec(prom.CounterOpts{
 		Namespace:   "sm_agent",
 		Subsystem:   "telemetry",
 		Name:        "push_requests_errors_total",
 		Help:        "Total count of errored push telemetry requests",
-		ConstLabels: prom.Labels{"instance": t.instance},
+		ConstLabels: prom.Labels{"agent_instance": t.instance},
 	}, []string{"region_id"})
 
 	t.metrics.addExecutionDuration = prom.NewHistogramVec(prom.HistogramOpts{
@@ -151,7 +151,7 @@ func (t *Telemeter) registerMetrics(registerer prom.Registerer) {
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: time.Hour,
-		ConstLabels:                     prom.Labels{"instance": t.instance},
+		ConstLabels:                     prom.Labels{"agent_instance": t.instance},
 	}, []string{"region_id"})
 
 	registerer.MustRegister(t.metrics.pushRequestsActive)

--- a/internal/telemetry/telemeter.go
+++ b/internal/telemetry/telemeter.go
@@ -1,0 +1,75 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/rs/zerolog"
+)
+
+// Telemeter maintains the telemetry data for all the tenants running checks
+// in the agent instance, organized by region.
+type Telemeter struct {
+	ctx    context.Context
+	client sm.TelemetryClient
+	logger zerolog.Logger
+
+	instance     string
+	pushTimeSpan time.Duration
+
+	pushers   map[int32]*RegionPusher // Indexed by region ID
+	pushersMu sync.RWMutex
+}
+
+// Execution represents the telemetry for a check execution.
+type Execution struct {
+	LocalTenantID int64
+	RegionID      int32
+	CheckClass    sm.CheckClass
+	Duration      time.Duration
+}
+
+// NewTelemeter creates a new Telemeter component.
+func NewTelemeter(
+	ctx context.Context, instance string, pushTimeSpan time.Duration, client sm.TelemetryClient, logger zerolog.Logger,
+) *Telemeter {
+	t := &Telemeter{
+		ctx:          ctx,
+		client:       client,
+		logger:       logger,
+		instance:     instance,
+		pushTimeSpan: pushTimeSpan,
+		pushers:      make(map[int32]*RegionPusher),
+	}
+
+	return t
+}
+
+// AddExecution adds a new execution to the agent's telemetry.
+func (t *Telemeter) AddExecution(e Execution) {
+	t.pushersMu.RLock()
+	if p, ok := t.pushers[e.RegionID]; ok {
+		p.AddExecution(e)
+		t.pushersMu.RUnlock()
+		return
+	}
+	t.pushersMu.RUnlock()
+
+	// If we do not have a pusher for this region, create it
+	l := t.logger.With().
+		Str("component", "region-pusher").
+		Str("instance", t.instance).
+		Int32("regionId", e.RegionID).
+		Logger()
+	p := NewRegionPusher(
+		t.ctx, t.pushTimeSpan,
+		t.client, l, t.instance, e.RegionID,
+	)
+	p.AddExecution(e)
+
+	t.pushersMu.Lock()
+	defer t.pushersMu.Unlock()
+	t.pushers[e.RegionID] = p
+}

--- a/internal/telemetry/telemeter_test.go
+++ b/internal/telemetry/telemeter_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
@@ -53,9 +54,10 @@ func TestTelemeterAddExecution(t *testing.T) {
 		ctx        = context.Background()
 		timeSpan   = 1 * time.Hour
 		testClient = &testTelemetryClient{}
+		registerer = prom.NewPedanticRegistry()
 	)
 
-	tele := NewTelemeter(ctx, instance, timeSpan, testClient, zerolog.Nop())
+	tele := NewTelemeter(ctx, instance, timeSpan, testClient, zerolog.Nop(), registerer)
 
 	t.Run("should init with no region pushers", func(t *testing.T) {
 		verifyTelemeter(t, tele, 0)

--- a/internal/telemetry/telemeter_test.go
+++ b/internal/telemetry/telemeter_test.go
@@ -1,0 +1,91 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTelemeterAddExecution(t *testing.T) {
+	verifyTelemeter := func(t *testing.T, tele *Telemeter, nRegionPushers int) {
+		t.Helper()
+		require.Equal(t, len(tele.pushers), nRegionPushers)
+	}
+
+	verifyRegionPusher := func(t *testing.T, tele *Telemeter, regionID int32, ee ...Execution) {
+		t.Helper()
+		p, ok := tele.pushers[regionID]
+		require.True(t, ok)
+
+		// sum expected executions data
+		regionTele := make(map[int64]map[sm.CheckClass]*sm.CheckClassTelemetry)
+		for _, e := range ee {
+			tenantTele, ok := regionTele[e.LocalTenantID]
+			if !ok {
+				tenantTele = make(map[sm.CheckClass]*sm.CheckClassTelemetry)
+				regionTele[e.LocalTenantID] = tenantTele
+			}
+			if _, ok := tenantTele[e.CheckClass]; !ok {
+				tenantTele[e.CheckClass] = &sm.CheckClassTelemetry{CheckClass: e.CheckClass}
+			}
+			tenantTele[e.CheckClass].Executions++
+			tenantTele[e.CheckClass].Duration += float32(e.Duration.Seconds())
+		}
+
+		// verify
+		for tenantID, expTTele := range regionTele {
+			gotTTele, ok := p.telemetry[tenantID]
+			require.True(t, ok, "telemetry not found for tenant")
+			for _, expCCTele := range expTTele {
+				gotCCTele, ok := gotTTele[expCCTele.CheckClass]
+				require.True(t, ok, "telemetry not found for check class")
+				require.Equal(t, expCCTele.Executions, gotCCTele.Executions)
+				require.Equal(t, expCCTele.Duration, gotCCTele.Duration)
+			}
+		}
+	}
+
+	var (
+		ctx        = context.Background()
+		timeSpan   = 1 * time.Hour
+		testClient = &testTelemetryClient{}
+	)
+
+	tele := NewTelemeter(ctx, instance, timeSpan, testClient, zerolog.Nop())
+
+	t.Run("should init with no region pushers", func(t *testing.T) {
+		verifyTelemeter(t, tele, 0)
+	})
+
+	t.Run("should create a new region pusher", func(t *testing.T) {
+		tele.AddExecution(ee[0])
+		verifyTelemeter(t, tele, 1)
+		verifyRegionPusher(t, tele, ee[0].RegionID, ee[0])
+	})
+
+	t.Run("should add telemetry to current region pusher", func(t *testing.T) {
+		tele.AddExecution(ee[1])
+		tele.AddExecution(ee[2])
+		verifyTelemeter(t, tele, 1)
+		verifyRegionPusher(t, tele, ee[0].RegionID, ee[:2]...)
+	})
+
+	t.Run("should add another region pusher", func(t *testing.T) {
+		e := ee[2]
+		e.RegionID = 1
+		tele.AddExecution(e)
+		e = ee[3]
+		e.RegionID = 1
+		tele.AddExecution(e)
+		verifyTelemeter(t, tele, 2)
+		verifyRegionPusher(t, tele, e.RegionID, ee[2:4]...)
+	})
+
+	t.Run("initial region pusher data should be intact", func(t *testing.T) {
+		verifyRegionPusher(t, tele, ee[0].RegionID, ee[:2]...)
+	})
+}

--- a/internal/telemetry/ticker.go
+++ b/internal/telemetry/ticker.go
@@ -1,0 +1,40 @@
+package telemetry
+
+import (
+	"math/rand"
+	"time"
+)
+
+const (
+	jitterUpperBound = 60 // s
+)
+
+// ticker represents a ticker interface that
+// can be mocked for more reliable tests.
+type ticker interface {
+	C() <-chan time.Time
+}
+
+func newStdTicker(d time.Duration) *stdTicker {
+	return &stdTicker{
+		Ticker: time.NewTicker(withJitter(d)),
+	}
+}
+
+// stdTicker is a wrapper around the standard
+// library time ticker.
+type stdTicker struct {
+	*time.Ticker
+}
+
+func (t *stdTicker) C() <-chan time.Time {
+	return t.Ticker.C
+}
+
+// withJitter sums a random jitter of [0, 59)s to the given duration.
+// This will randomize the tenant pushers push time to avoid many overlapping
+// requests to the API and instead distribute them more evenly.
+func withJitter(d time.Duration) time.Duration {
+	jitter := time.Duration(rand.Intn(jitterUpperBound)) * time.Second
+	return d + jitter
+}

--- a/internal/telemetry/ticker.go
+++ b/internal/telemetry/ticker.go
@@ -13,6 +13,7 @@ const (
 // can be mocked for more reliable tests.
 type ticker interface {
 	C() <-chan time.Time
+	Stop()
 }
 
 func newStdTicker(d time.Duration) *stdTicker {
@@ -29,6 +30,10 @@ type stdTicker struct {
 
 func (t *stdTicker) C() <-chan time.Time {
 	return t.Ticker.C
+}
+
+func (t *stdTicker) Stop() {
+	t.Ticker.Stop()
 }
 
 // withJitter sums a random jitter of [0, 59)s to the given duration.

--- a/internal/telemetry/ticker_test.go
+++ b/internal/telemetry/ticker_test.go
@@ -1,0 +1,47 @@
+package telemetry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithJitter(t *testing.T) {
+	testCases := []struct {
+		d      time.Duration
+		minExp time.Duration
+		maxExp time.Duration
+	}{
+		{
+			d:      1 * time.Minute,
+			minExp: 1 * time.Minute,
+			maxExp: 1*time.Minute + jitterUpperBound*time.Second,
+		},
+		{
+			d:      5 * time.Minute,
+			minExp: 5 * time.Minute,
+			maxExp: 5*time.Minute + jitterUpperBound*time.Second,
+		},
+		{
+			d:      60 * time.Second,
+			minExp: 60 * time.Second,
+			maxExp: 60*time.Second + jitterUpperBound*time.Second,
+		},
+		{
+			d:      5 * time.Second,
+			minExp: 5 * time.Second,
+			maxExp: 5*time.Second + jitterUpperBound*time.Second,
+		},
+		{
+			d:      0 * time.Second,
+			minExp: 0 * time.Second,
+			maxExp: 0*time.Second + jitterUpperBound*time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		require.GreaterOrEqual(t, withJitter(tc.d), tc.minExp)
+		require.Less(t, withJitter(tc.d), tc.maxExp)
+	}
+}


### PR DESCRIPTION
This PR adds a telemetry subsystem responsible to collect telemetry data for check executions in the agent.

Currently the telemetry data covers executions and executions duration, and is organized per region, tenant and check class. Each region has an independent goroutine which periodically (by default every 5 min) sends the accumulated telemetry data to the proxy/API.

Updates: grafana/synthetic-monitoring#13