### PR TITLE
Add header to ease tracking HTTP requests

### DIFF
--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -139,7 +139,7 @@ func NewHandler(opts HandlerOpts) (*Handler, error) {
 		tenantCh:                     opts.TenantCh,
 		runnerFactory:                opts.runnerFactory,
 		grpcAdhocChecksClientFactory: opts.grpcAdhocChecksClientFactory,
-		proberFactory:                prober.NewProberFactory(opts.K6Runner),
+		proberFactory:                prober.NewProberFactory(opts.K6Runner, ""),
 		api: apiInfo{
 			conn: opts.Conn,
 		},

--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -139,7 +139,7 @@ func NewHandler(opts HandlerOpts) (*Handler, error) {
 		tenantCh:                     opts.TenantCh,
 		runnerFactory:                opts.runnerFactory,
 		grpcAdhocChecksClientFactory: opts.grpcAdhocChecksClientFactory,
-		proberFactory:                prober.NewProberFactory(opts.K6Runner, ""),
+		proberFactory:                prober.NewProberFactory(opts.K6Runner, 0),
 		api: apiInfo{
 			conn: opts.Conn,
 		},

--- a/internal/prober/http/http.go
+++ b/internal/prober/http/http.go
@@ -264,7 +264,7 @@ func augmentHttpHeaders(check *sm.Check, reservedHeaders http.Header) {
 	for _, header := range check.Settings.Http.Headers {
 		name, _ := strToHeaderNameValue(header)
 
-		_, present := reservedHeaders[strings.ToLower(name)]
+		_, present := reservedHeaders[http.CanonicalHeaderKey(name)]
 		if present {
 			continue // users can't override reserved headers with their own values
 		}
@@ -272,8 +272,15 @@ func augmentHttpHeaders(check *sm.Check, reservedHeaders http.Header) {
 		headers = append(headers, header)
 	}
 
-	for header, values := range reservedHeaders {
-		headers = append(headers, fmt.Sprintf("%s:%s", header, strings.Join(values, ",")))
+	for key, values := range reservedHeaders {
+		var b strings.Builder
+		for _, value := range values {
+			b.Reset()
+			b.WriteString(key)
+			b.WriteRune(':')
+			b.WriteString(value)
+			headers = append(headers, b.String())
+		}
 	}
 
 	check.Settings.Http.Headers = headers

--- a/internal/prober/http/http.go
+++ b/internal/prober/http/http.go
@@ -263,7 +263,7 @@ func convertOAuth2Config(ctx context.Context, cfg *sm.OAuth2Config, logger zerol
 // Overrides any user-provided headers with our own augmented values
 // for 'reserved' headers.
 func augmentHttpHeaders(check *sm.Check, additionalHeaders []string) {
-	filteredHeaders := []string{}
+	headers := []string{}
 	for _, header := range check.Settings.Http.Headers {
 		name, _ := strToHeaderNameValue(header)
 
@@ -271,11 +271,12 @@ func augmentHttpHeaders(check *sm.Check, additionalHeaders []string) {
 			continue // users can't override this header with their own value.
 		}
 
-		filteredHeaders = append(filteredHeaders, header)
+		headers = append(headers, header)
 	}
+	headers = append(headers, additionalHeaders...)
 
 	httpHeaders := &check.Settings.Http.Headers
-	*httpHeaders = append(filteredHeaders, additionalHeaders...)
+	*httpHeaders = headers
 }
 
 func buildHttpHeaders(headers []string) map[string]string {

--- a/internal/prober/http/http_test.go
+++ b/internal/prober/http/http_test.go
@@ -46,7 +46,7 @@ func TestNewProber(t *testing.T) {
 			},
 			expected: Prober{
 				config: getDefaultModule().
-					addHttpHeader("x-sm-id", "3-3"). // is checkId twice since probeId is unavailable here
+					addHttpHeader("X-Sm-Id", "3-3"). // is checkId twice since probeId is unavailable here
 					getConfigModule(),
 			},
 			ExpectError: false,
@@ -80,7 +80,7 @@ func TestNewProber(t *testing.T) {
 				config: getDefaultModule().
 					addHttpHeader("uSeR-aGeNt", "test-user-agent").
 					addHttpHeader("some-header", "some-value").
-					addHttpHeader("x-sm-id", "5-5").
+					addHttpHeader("X-Sm-Id", "5-5").
 					getConfigModule(),
 			},
 			ExpectError: false,
@@ -94,7 +94,7 @@ func TestNewProber(t *testing.T) {
 			// origin identifier for http requests is checkId-probeId; testing with checkId twice in the absence of probeId
 			checkId := testcase.input.Id
 			reservedHeaders := http.Header{}
-			reservedHeaders["x-sm-id"] = []string{fmt.Sprintf("%d-%d", checkId, checkId)}
+			reservedHeaders.Add("x-sm-id", fmt.Sprintf("%d-%d", checkId, checkId))
 
 			actual, err := NewProber(ctx, testcase.input, logger, reservedHeaders)
 			require.Equal(t, &testcase.expected, &actual)

--- a/internal/prober/http/http_test.go
+++ b/internal/prober/http/http_test.go
@@ -219,7 +219,7 @@ func TestProbe(t *testing.T) {
 			zl := zerolog.Logger{}
 			kl := log.NewLogfmtLogger(io.Discard)
 
-			prober, err := NewProber(ctx, check, zl, "1-1")
+			prober, err := NewProber(ctx, check, zl, "")
 			require.NoError(t, err)
 			require.Equal(t, tc.expectFailure, !prober.Probe(ctx, check.Target, registry, kl))
 

--- a/internal/prober/http/http_test.go
+++ b/internal/prober/http/http_test.go
@@ -36,7 +36,11 @@ func TestNewProber(t *testing.T) {
 				Id:     3,
 				Target: "www.grafana.com",
 				Settings: sm.CheckSettings{
-					Http: &sm.HttpSettings{},
+					Http: &sm.HttpSettings{
+						Headers: []string{
+							"X-SM-ID: 9880-98",
+						},
+					},
 				},
 			},
 			expected: Prober{
@@ -66,6 +70,7 @@ func TestNewProber(t *testing.T) {
 						Headers: []string{
 							"uSeR-aGeNt: test-user-agent",
 							"some-header: some-value",
+							"x-SM-iD: 3232-32",
 						},
 					},
 				},

--- a/internal/prober/http/http_test.go
+++ b/internal/prober/http/http_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"testing"
@@ -92,7 +93,8 @@ func TestNewProber(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// origin identifier for http requests is checkId-probeId; testing with checkId twice in the absence of probeId
 			checkId := testcase.input.Id
-			reservedHeaders := []sm.HttpHeader{{Name: "x-sm-id", Value: fmt.Sprintf("%d-%d", checkId, checkId)}}
+			reservedHeaders := http.Header{}
+			reservedHeaders["x-sm-id"] = []string{fmt.Sprintf("%d-%d", checkId, checkId)}
 
 			actual, err := NewProber(ctx, testcase.input, logger, reservedHeaders)
 			require.Equal(t, &testcase.expected, &actual)
@@ -227,7 +229,7 @@ func TestProbe(t *testing.T) {
 			zl := zerolog.Logger{}
 			kl := log.NewLogfmtLogger(io.Discard)
 
-			prober, err := NewProber(ctx, check, zl, []sm.HttpHeader{})
+			prober, err := NewProber(ctx, check, zl, http.Header{})
 			require.NoError(t, err)
 			require.Equal(t, tc.expectFailure, !prober.Probe(ctx, check.Target, registry, kl))
 

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -105,7 +105,7 @@ func augmentHttpHeaders(check *sm.Check, reservedHeaders http.Header) {
 	for _, entry := range check.Settings.Multihttp.Entries {
 		heads := entry.Request.Headers
 		for _, headerPtr := range heads {
-			_, present := reservedHeaders[strings.ToLower(headerPtr.Name)]
+			_, present := reservedHeaders[http.CanonicalHeaderKey(headerPtr.Name)]
 
 			if present {
 				continue // users can't override reserved headers with their own values

--- a/internal/prober/multihttp/multihttp_test.go
+++ b/internal/prober/multihttp/multihttp_test.go
@@ -3,6 +3,7 @@ package multihttp
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 	"time"
 
@@ -114,10 +115,8 @@ func TestNewProber(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var runner noopRunner
 			checkId := tc.check.Id
-			reservedHeaders := []sm.HttpHeader{{
-				Name:  "x-sm-id",
-				Value: fmt.Sprintf("%d-%d", checkId, checkId),
-			}}
+			reservedHeaders := http.Header{}
+			reservedHeaders["x-sm-id"] = []string{fmt.Sprintf("%d-%d", checkId, checkId)}
 
 			p, err := NewProber(ctx, tc.check, logger, runner, reservedHeaders)
 			if tc.expectFailure {

--- a/internal/prober/multihttp/multihttp_test.go
+++ b/internal/prober/multihttp/multihttp_test.go
@@ -116,7 +116,7 @@ func TestNewProber(t *testing.T) {
 			var runner noopRunner
 			checkId := tc.check.Id
 			reservedHeaders := http.Header{}
-			reservedHeaders["x-sm-id"] = []string{fmt.Sprintf("%d-%d", checkId, checkId)}
+			reservedHeaders.Add("x-sm-id", fmt.Sprintf("%d-%d", checkId, checkId))
 
 			p, err := NewProber(ctx, tc.check, logger, runner, reservedHeaders)
 			if tc.expectFailure {
@@ -127,7 +127,7 @@ func TestNewProber(t *testing.T) {
 			requestHeaders := tc.check.Settings.Multihttp.Entries[0].Request.Headers
 			require.Equal(t, len(requestHeaders), 1) // reserved header is present
 
-			require.Equal(t, requestHeaders[0].Name, "x-sm-id")
+			require.Equal(t, requestHeaders[0].Name, "X-Sm-Id")
 			require.Equal(t, requestHeaders[0].Value, fmt.Sprintf("%d-%d", checkId, checkId))
 
 			require.NoError(t, err)

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -812,7 +812,7 @@ func TestSettingsToScript(t *testing.T) {
 	k6path := filepath.Join(testhelper.ModuleDir(t), "dist", "k6")
 	runner := k6runner.New(k6path)
 
-	prober, err := NewProber(ctx, check, logger, runner)
+	prober, err := NewProber(ctx, check, logger, runner, []sm.HttpHeader{})
 	require.NoError(t, err)
 
 	reg := prometheus.NewPedanticRegistry()

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -3,6 +3,7 @@ package multihttp
 import (
 	"bytes"
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
@@ -812,7 +813,7 @@ func TestSettingsToScript(t *testing.T) {
 	k6path := filepath.Join(testhelper.ModuleDir(t), "dist", "k6")
 	runner := k6runner.New(k6path)
 
-	prober, err := NewProber(ctx, check, logger, runner, []sm.HttpHeader{})
+	prober, err := NewProber(ctx, check, logger, runner, http.Header{})
 	require.NoError(t, err)
 
 	reg := prometheus.NewPedanticRegistry()

--- a/internal/prober/prober.go
+++ b/internal/prober/prober.go
@@ -34,12 +34,14 @@ type ProberFactory interface {
 }
 
 type proberFactory struct {
-	runner k6runner.Runner
+	runner               k6runner.Runner
+	checkProbeIdentifier string
 }
 
-func NewProberFactory(runner k6runner.Runner) ProberFactory {
+func NewProberFactory(runner k6runner.Runner, checkProbeIdentifier string) ProberFactory {
 	return proberFactory{
-		runner: runner,
+		runner:               runner,
+		checkProbeIdentifier: checkProbeIdentifier,
 	}
 }
 
@@ -56,7 +58,7 @@ func (f proberFactory) New(ctx context.Context, logger zerolog.Logger, check mod
 		target = check.Target
 
 	case sm.CheckTypeHttp:
-		p, err = http.NewProber(ctx, check.Check, logger)
+		p, err = http.NewProber(ctx, check.Check, logger, f.checkProbeIdentifier)
 		target = check.Target
 
 	case sm.CheckTypeDns:

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -114,14 +114,13 @@ func (d *probeData) Tenant() model.GlobalID {
 func New(ctx context.Context, check model.Check, publisher pusher.Publisher, probe sm.Probe, logger zerolog.Logger,
 	scrapeCounter Incrementer, errorCounter IncrementerVec, k6runner k6runner.Runner, labelsLimiter LabelsLimiter,
 ) (*Scraper, error) {
-	checkProbeIdentifier := fmt.Sprintf("%d-%d", check.Id, probe.Id)
 	return NewWithOpts(ctx, check, ScraperOpts{
 		Probe:         probe,
 		Publisher:     publisher,
 		Logger:        logger,
 		ScrapeCounter: scrapeCounter,
 		ErrorCounter:  errorCounter,
-		ProbeFactory:  prober.NewProberFactory(k6runner, checkProbeIdentifier),
+		ProbeFactory:  prober.NewProberFactory(k6runner, probe.Id),
 		LabelsLimiter: labelsLimiter,
 	})
 }

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -114,13 +114,14 @@ func (d *probeData) Tenant() model.GlobalID {
 func New(ctx context.Context, check model.Check, publisher pusher.Publisher, probe sm.Probe, logger zerolog.Logger,
 	scrapeCounter Incrementer, errorCounter IncrementerVec, k6runner k6runner.Runner, labelsLimiter LabelsLimiter,
 ) (*Scraper, error) {
+	checkProbeIdentifier := fmt.Sprintf("%d-%d", check.Id, probe.Id)
 	return NewWithOpts(ctx, check, ScraperOpts{
 		Probe:         probe,
 		Publisher:     publisher,
 		Logger:        logger,
 		ScrapeCounter: scrapeCounter,
 		ErrorCounter:  errorCounter,
-		ProbeFactory:  prober.NewProberFactory(k6runner),
+		ProbeFactory:  prober.NewProberFactory(k6runner, checkProbeIdentifier),
 		LabelsLimiter: labelsLimiter,
 	})
 }

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -111,6 +111,7 @@ func TestValidateMetrics(t *testing.T) {
 					ctx,
 					check,
 					zerolog.New(io.Discard),
+					"",
 				)
 				if err != nil {
 					t.Fatalf("cannot create HTTP prober: %s", err)
@@ -144,6 +145,7 @@ func TestValidateMetrics(t *testing.T) {
 					ctx,
 					check,
 					zerolog.New(io.Discard),
+					"",
 				)
 				if err != nil {
 					t.Fatalf("cannot create HTTP prober: %s", err)

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -111,7 +111,7 @@ func TestValidateMetrics(t *testing.T) {
 					ctx,
 					check,
 					zerolog.New(io.Discard),
-					[]sm.HttpHeader{},
+					http.Header{},
 				)
 				if err != nil {
 					t.Fatalf("cannot create HTTP prober: %s", err)
@@ -145,7 +145,7 @@ func TestValidateMetrics(t *testing.T) {
 					ctx,
 					check,
 					zerolog.New(io.Discard),
-					[]sm.HttpHeader{},
+					http.Header{},
 				)
 				if err != nil {
 					t.Fatalf("cannot create HTTP prober: %s", err)
@@ -342,7 +342,7 @@ func TestValidateMetrics(t *testing.T) {
 					check,
 					zerolog.New(zerolog.NewTestWriter(t)),
 					runner,
-					[]sm.HttpHeader{},
+					http.Header{},
 				)
 				if err != nil {
 					t.Fatalf("cannot create MultiHTTP prober: %s", err)

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -111,7 +111,7 @@ func TestValidateMetrics(t *testing.T) {
 					ctx,
 					check,
 					zerolog.New(io.Discard),
-					"",
+					[]sm.HttpHeader{},
 				)
 				if err != nil {
 					t.Fatalf("cannot create HTTP prober: %s", err)
@@ -145,7 +145,7 @@ func TestValidateMetrics(t *testing.T) {
 					ctx,
 					check,
 					zerolog.New(io.Discard),
-					"",
+					[]sm.HttpHeader{},
 				)
 				if err != nil {
 					t.Fatalf("cannot create HTTP prober: %s", err)
@@ -342,6 +342,7 @@ func TestValidateMetrics(t *testing.T) {
 					check,
 					zerolog.New(zerolog.NewTestWriter(t)),
 					runner,
+					[]sm.HttpHeader{},
 				)
 				if err != nil {
 					t.Fatalf("cannot create MultiHTTP prober: %s", err)


### PR DESCRIPTION
Addressing https://github.com/grafana/synthetic-monitoring-agent/issues/325.

The goal is to add a header `x-sm-id` with a value `checkId-probeId` so we can identify the owner of a check for anti-abuse purposes. This header gets added to`http.Prober.config`.

Happy to hear any suggestions on how to test this Go code better - testing `NewProber()` from `http_test.go` works to assert the resulting http config directly. but it'd be nicer to have a test server or something so I can add an HTTP check to a test `Updater` and validate the request headers sent.