### PR TITLE
Send adhoc check done logs to Loki without --verbose

### DIFF
--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -3,14 +3,11 @@ package adhoc
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"time"
 
-	kitlog "github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/rs/zerolog"
@@ -486,25 +483,17 @@ func (r *runner) Run(ctx context.Context, tenantId model.GlobalID, publisher pus
 	mfs, err := registry.Gather()
 
 	buf := &bytes.Buffer{}
-	bl := kitlog.NewJSONLogger(buf)
+	targetLogger := zerolog.New(buf)
 
-	entriesBytes, _ := json.Marshal(logger.entries)
-	mfsBytes, _ := json.Marshal(mfs)
-
-	entriesJson := string(entriesBytes)
-	mfsJson := string(mfsBytes)
-
-	logLabelPairs := []interface{}{
-		"error", err,
-		"id", r.id,
-		"target", r.target,
-		"probe", r.probe,
-		"check_name", r.prober.Name(),
-		"logs", entriesJson,
-		"timeseries", mfsJson,
-	}
-	sl := kitlog.With(bl, logLabelPairs...)
-	level.Info(sl).Log("msg", "ad-hoc check done")
+	targetLogger.Warn().
+		AnErr("error", err).
+		Str("id", r.id).
+		Str("target", r.target).
+		Str("probe", r.probe).
+		Str("check_name", r.prober.Name()).
+		Interface("logs", logger.entries).
+		Interface("timeseries", mfs).
+		Msg("ad-hoc check done")
 
 	r.logger.Debug().
 		Str("id", r.id).

--- a/internal/adhoc/adhoc_test.go
+++ b/internal/adhoc/adhoc_test.go
@@ -59,6 +59,7 @@ func TestHandlerRun(t *testing.T) {
 	}
 
 	publishCh := make(chan pusher.Payload)
+	zerolog.SetGlobalLevel(zerolog.WarnLevel) // default log level.
 
 	opts := HandlerOpts{
 		Logger:         logger,
@@ -92,6 +93,9 @@ func TestHandlerRun(t *testing.T) {
 	payload := <-publishCh
 	require.Len(t, payload.Metrics(), 0)
 	require.Len(t, payload.Streams(), 1)
+
+	logBody := payload.Streams()[0].Entries[0].Line
+	require.Contains(t, logBody, "ad-hoc check done") // log must publish even when verbose is disabled for check tests
 }
 
 type channelPublisher chan pusher.Payload


### PR DESCRIPTION
Addresses https://github.com/grafana/synthetic-monitoring-agent/issues/586.

Because it looks like we use `zerolog` for system logging on-instance vs `kitlog` for logs we intend to write to Loki for SM checks, ~~I opt to use `kitlog` here to write the `ad-hoc check done` message for test runs on private probes.~~

Update:
The `go-kit/log`'s JSONLogger is annoying to configure the format for the marshalled JSON on. I see we use it for the `logfmt` format on our Loki publishes - maybe we can find a better logger package that does both well.

Mitigating this issue for now by raising the log level to `warn` so it publishes without `--verbose`, but want to circle back later to change the logger impl and bring it down to `info` again.