### PR TITLE
Configure blacklist ip range for k6 runner

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -54,7 +54,7 @@ func run(args []string, stdout io.Writer) error {
 		enablePProf          = flags.Bool("enable-pprof", false, "exposes profiling data via HTTP /debug/pprof/ endpoint")
 		httpListenAddr       = flags.String("listen-address", "localhost:4050", "listen address")
 		k6URI                = flags.String("k6-uri", "k6", "how to run k6 (path or URL)")
-		k6BlacklistedIP      = flags.String("blocked-nets", "10.0.0.0/8", "blacklisted CIDR IP for k6 requests")
+		k6BlacklistedIP      = flags.String("blocked-nets", "10.0.0.0/8", "IP networks to block in CIDR notation, disabled if empty")
 		selectedPublisher    = flags.String("publisher", pusherV1.Name, "publisher type (EXPERIMENTAL)")
 	)
 

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -41,22 +41,23 @@ func New(opts RunnerOpts) Runner {
 			logger: &logger,
 		}
 	} else {
-		var blacklistIP string
-		if opts.BlacklistedIP != "" {
-			blacklistIP = opts.BlacklistedIP
-		} else {
-			blacklistIP = "10.0.0.0/8"
-		}
-
 		r = &LocalRunner{
 			k6path:        opts.Uri,
 			logger:        &logger,
 			fs:            afero.NewOsFs(),
-			blacklistedIP: blacklistIP,
+			blacklistedIP: "10.0.0.0/8",
 		}
+
+		r.(*LocalRunner).withOpts(opts)
 	}
 
 	return r
+}
+
+func (r *LocalRunner) withOpts(opts RunnerOpts) {
+	if opts.BlacklistedIP != "" {
+		r.blacklistedIP = opts.BlacklistedIP
+	}
 }
 
 type Script struct {

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -26,20 +26,33 @@ type Runner interface {
 	Run(ctx context.Context, script []byte) (*RunResponse, error)
 }
 
-func New(uri string) Runner {
+type RunnerOpts struct {
+	Uri           string
+	BlacklistedIP string
+}
+
+func New(opts RunnerOpts) Runner {
 	var r Runner
 	logger := zerolog.Nop()
 
-	if strings.HasPrefix(uri, "http") {
+	if strings.HasPrefix(opts.Uri, "http") {
 		r = &HttpRunner{
-			url:    uri,
+			url:    opts.Uri,
 			logger: &logger,
 		}
 	} else {
+		var blacklistIP string
+		if opts.BlacklistedIP != "" {
+			blacklistIP = opts.BlacklistedIP
+		} else {
+			blacklistIP = "10.0.0.0/8"
+		}
+
 		r = &LocalRunner{
-			k6path: uri,
-			logger: &logger,
-			fs:     afero.NewOsFs(),
+			k6path:        opts.Uri,
+			logger:        &logger,
+			fs:            afero.NewOsFs(),
+			blacklistedIP: blacklistIP,
 		}
 	}
 
@@ -338,9 +351,10 @@ func (r HttpRunner) Run(ctx context.Context, script []byte) (*RunResponse, error
 }
 
 type LocalRunner struct {
-	k6path string
-	logger *zerolog.Logger
-	fs     afero.Fs
+	k6path        string
+	logger        *zerolog.Logger
+	fs            afero.Fs
+	blacklistedIP string
 }
 
 func (r LocalRunner) WithLogger(logger *zerolog.Logger) Runner {
@@ -406,7 +420,7 @@ func (r LocalRunner) Run(ctx context.Context, script []byte) (*RunResponse, erro
 		"--batch", "10",
 		"--batch-per-host", "4",
 		"--no-connection-reuse",
-		"--blacklist-ip", "10.0.0.0/8", // TODO(mem): make this configurable
+		"--blacklist-ip", r.blacklistedIP,
 		"--block-hostnames", "*.cluster.local", // TODO(mem): make this configurable
 		"--summary-time-unit", "s",
 		// "--discard-response-bodies",                        // TODO(mem): make this configurable

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -23,20 +23,20 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	r1 := new("k6", "")
+	r1 := New(RunnerOpts{Uri: "k6"})
 	require.IsType(t, &LocalRunner{}, r1)
 	require.Equal(t, "10.0.0.0/8", r1.(*LocalRunner).blacklistedIP)
-	r2 := new("/usr/bin/k6", "192.168.4.0/24")
+	r2 := New(RunnerOpts{Uri: "/usr/bin/k6", BlacklistedIP: "192.168.4.0/24"})
 	require.IsType(t, &LocalRunner{}, r2)
 	require.Equal(t, "192.168.4.0/24", r2.(*LocalRunner).blacklistedIP)
-	r3 := new("http://localhost:6565", "")
+	r3 := New(RunnerOpts{Uri: "http://localhost:6565"})
 	require.IsType(t, &HttpRunner{}, r3)
-	r4 := new("https://localhost:6565", "")
+	r4 := New(RunnerOpts{Uri: "https://localhost:6565"})
 	require.IsType(t, &HttpRunner{}, r4)
 }
 
 func TestNewScript(t *testing.T) {
-	runner := new("k6", "")
+	runner := New(RunnerOpts{Uri: "k6"})
 	src := []byte("test")
 	script, err := NewScript(src, runner)
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestHttpRunnerRun(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	runner := new(srv.URL+"/run", "")
+	runner := New(RunnerOpts{Uri: srv.URL + "/run"})
 	require.IsType(t, &HttpRunner{}, runner)
 
 	ctx := context.Background()
@@ -154,7 +154,7 @@ func TestHttpRunnerRunError(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	runner := new(srv.URL+"/run", "")
+	runner := New(RunnerOpts{Uri: srv.URL + "/run"})
 	require.IsType(t, &HttpRunner{}, runner)
 
 	ctx, cancel := testhelper.Context(context.Background(), t)
@@ -260,10 +260,6 @@ func TestK6LogsToLogger(t *testing.T) {
 
 	err := k6LogsToLogger(data, &logger)
 	require.NoError(t, err)
-}
-
-func new(uri string, blacklistedIp string) Runner {
-	return New(RunnerOpts{Uri: uri, BlacklistedIP: blacklistedIp})
 }
 
 type testLogger struct {

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -811,7 +811,7 @@ func TestSettingsToScript(t *testing.T) {
 	// logger := zerolog.New(zerolog.NewTestWriter(t))
 	logger := zerolog.Nop()
 	k6path := filepath.Join(testhelper.ModuleDir(t), "dist", "k6")
-	runner := k6runner.New(k6path)
+	runner := k6runner.New(k6runner.RunnerOpts{Uri: k6path})
 
 	prober, err := NewProber(ctx, check, logger, runner, http.Header{})
 	require.NoError(t, err)

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -280,7 +280,7 @@ func TestValidateMetrics(t *testing.T) {
 				var runner k6runner.Runner
 
 				if k6Path := os.Getenv("K6_PATH"); k6Path != "" {
-					runner = k6runner.New(k6Path)
+					runner = k6runner.New(k6runner.RunnerOpts{Uri: k6Path})
 				} else {
 					runner = &testRunner{
 						metrics: testhelper.MustReadFile(t, "testdata/k6.dat"),
@@ -329,7 +329,7 @@ func TestValidateMetrics(t *testing.T) {
 				var runner k6runner.Runner
 
 				if k6Path := os.Getenv("K6_PATH"); k6Path != "" {
-					runner = k6runner.New(k6Path)
+					runner = k6runner.New(k6runner.RunnerOpts{Uri: k6Path})
 				} else {
 					runner = &testRunner{
 						metrics: testhelper.MustReadFile(t, "testdata/multihttp.dat"),


### PR DESCRIPTION
Addresses https://github.com/grafana/synthetic-monitoring-agent/issues/587: makes the blacklist IP range for the K6 runner configurable by flag.