### PR TITLE
Fix: CheckSettings JSON unmarshal after k6 settings rename

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -2029,3 +2029,44 @@ func TestMultiHttpSettingsValidate(t *testing.T) {
 		},
 	})
 }
+
+func TestCheckSettingsUnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		jsn string
+		exp CheckSettings
+	}{
+		{
+			jsn: `{
+				"k6": {
+					"script": []
+				}
+			}`,
+			exp: CheckSettings{
+				Scripted: &ScriptedSettings{
+					Script: []byte{},
+				},
+			},
+		},
+		{
+			jsn: `{
+				"scripted": {
+					"script": []
+				}
+			}`,
+			exp: CheckSettings{
+				Scripted: &ScriptedSettings{
+					Script: []byte{},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var cs CheckSettings
+		if err := json.Unmarshal([]byte(tc.jsn), &cs); err != nil {
+			t.Fatalf("unexpected error unmarshalling CheckSettings: %v", err)
+		}
+
+		require.Equal(t, tc.exp, cs)
+	}
+}


### PR DESCRIPTION
Due to the CheckSettings K6 field renaming to Scripted, previous JSON representations of CheckSettings are incorrectly decoded. This commit overloads the UnmarshalJSON method for CheckSettings in order to transparently translate previous representations that might contain data for the K6 field to the new Scripted field.