### PR TITLE
Experimental: increase max frequency to 1 hour

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -2029,3 +2029,23 @@ func TestMultiHttpSettingsValidate(t *testing.T) {
 		},
 	})
 }
+
+func TestInClosedRange(t *testing.T) {
+	testcases := map[string]struct {
+		value    int64
+		lower    int64
+		upper    int64
+		expected bool
+	}{
+		"too low":     {value: 0, lower: 1, upper: 5, expected: false},
+		"lower bound": {value: 1, lower: 1, upper: 5, expected: true},
+		"in range":    {value: 3, lower: 1, upper: 5, expected: true},
+		"upper bound": {value: 5, lower: 1, upper: 5, expected: true},
+		"too high":    {value: 6, lower: 1, upper: 5, expected: false},
+	}
+
+	for name, tc := range testcases {
+		actual := inClosedRange(tc.value, tc.lower, tc.upper)
+		require.Equalf(t, tc.expected, actual, `%s`, name)
+	}
+}


### PR DESCRIPTION
Allow the maximum interval between successive check runs to be up to 1 hour. This will break some dashboards, because there are built-in assumptions about the maximum value being 2 minutes. In particular, it's going to be necessary to adjust the value we use for ranges, which is hard-coded to 5 minutes. If we change the queries, we still need to adjust values in Grafana, to prevent sampling values at intervals less than the frequency. This is going to be particularly visible in queries that use `increase`, `rate` and similar functions. Because of that, this is mostly about adding backend support for [issue #318](https://github.com/grafana/synthetic-monitoring-app/issues/318).