### PR TITLE
Pass a scraper factory from main

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
 	pusherV1 "github.com/grafana/synthetic-monitoring-agent/internal/pusher/v1"
 	pusherV2 "github.com/grafana/synthetic-monitoring-agent/internal/pusher/v2"
+	"github.com/grafana/synthetic-monitoring-agent/internal/scraper"
 	"github.com/grafana/synthetic-monitoring-agent/internal/telemetry"
 	"github.com/grafana/synthetic-monitoring-agent/internal/tenants"
 	"github.com/grafana/synthetic-monitoring-agent/internal/version"
@@ -256,6 +257,7 @@ func run(args []string, stdout io.Writer) error {
 		PromRegisterer: promRegisterer,
 		Features:       features,
 		K6Runner:       k6Runner,
+		ScraperFactory: scraper.New,
 		TenantLimits:   limits,
 		Telemeter:      telemetry,
 	})


### PR DESCRIPTION
This is a no-op, because this is the default behavior of the checks updater if no scraper factory is provided.

The intention here is to be able to pass alternative scraper factories that modify the behavior of the of the scraper based on e.g. program arguments.