### PR TITLE
Release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 ## [Unreleased]
 
 
+<a name="v0.22.0"></a>
+## [v0.22.0] - 2024-03-11
+### Feature
+- allow checks to run less often ([#611](https://github.com/grafana/synthetic-monitoring-agent/issues/611))
+
+### Fix
+- telemetry region label ([#638](https://github.com/grafana/synthetic-monitoring-agent/issues/638))
+
+
 <a name="v0.21.0"></a>
 ## [v0.21.0] - 2024-02-26
 ### Feature
@@ -554,7 +563,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.22.0...HEAD
+[v0.22.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.21.0...v0.22.0
 [v0.21.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.20.1...v0.21.0
 [v0.20.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.6...v0.20.1
 [v0.19.6]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.5...v0.19.6


### PR DESCRIPTION
* Send adhoc check done logs to Loki without --verbose (#631)
* Chore(deps): Bump github.com/prometheus/prometheus from 0.50.0 to 0.50.1
* Configure blacklist ip range for k6 runner (#633)
* Add telemetry (#621)
* Fix: telemetry region label (#638)
* Chore(deps): Bump github.com/stretchr/testify from 1.8.4 to 1.9.0 (#640)
* Chore(deps): Bump google.golang.org/grpc from 1.61.1 to 1.62.0 (#628)
* Chore(deps): Bump golang.org/x/net from 0.21.0 to 0.22.0 (#642)
* Chore(deps): Bump github.com/prometheus/common from 0.47.0 to 0.49.0
* use expfmt.NewFormat instead of now-private formats directly
* Feature: allow checks to run less often (#611)
* Upgrade to grafana-build-tools v0.6.1 (#646)
* Fix telemetry error handling (#650)
* Use github.com/grafana/loki/pkg/pusher instead of logproto (#648)
* Pass a scraper factory from main (#649)
* Chore(deps): Bump google.golang.org/grpc from 1.62.0 to 1.62.1
* Chore(deps): Bump github.com/prometheus/common from 0.49.0 to 0.50.0
* Add telemetry sampled executions (#653)