### PR TITLE
Feature: switch to pusher v2 by default

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -61,7 +61,7 @@ func run(args []string, stdout io.Writer) error {
 		httpListenAddr       = flags.String("listen-address", "localhost:4050", "listen address")
 		k6URI                = flags.String("k6-uri", "k6", "how to run k6 (path or URL)")
 		k6BlacklistedIP      = flags.String("blocked-nets", "10.0.0.0/8", "IP networks to block in CIDR notation, disabled if empty")
-		selectedPublisher    = flags.String("publisher", pusherV1.Name, "publisher type (EXPERIMENTAL)")
+		selectedPublisher    = flags.String("publisher", pusherV2.Name, "publisher type")
 		telemetryTimeSpan    = flags.Int("telemetry-time-span", defTelemetryTimeSpan, "time span between telemetry push executions per tenant")
 	)
 


### PR DESCRIPTION
We have been running with v2 for a long time now, and it seems like it's doing what it was designed to do. Switch the default to v2, while still keeping v1 around. We will retire v1 at some point in the future.