### PR TITLE
Remove static max check labels verification

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -42,7 +42,6 @@ var (
 	ErrInvalidCheckFrequency  = errors.New("invalid check frequency")
 	ErrInvalidCheckTimeout    = errors.New("invalid check timeout")
 	ErrInvalidCheckLabelName  = errors.New("invalid check label name")
-	ErrTooManyCheckLabels     = errors.New("too many check labels")
 	ErrInvalidCheckLabelValue = errors.New("invalid check label value")
 	ErrInvalidLabelName       = errors.New("invalid label name")
 	ErrInvalidLabelValue      = errors.New("invalid label value")
@@ -131,7 +130,6 @@ const (
 const (
 	MaxMetricLabels          = 20   // Prometheus allows for 32 labels, but limit to 20.
 	MaxLogLabels             = 15   // Loki allows a maximum of 15 labels.
-	MaxCheckLabels           = 10   // Allow 10 user labels for checks,
 	MaxProbeLabels           = 3    // 3 for probes, leaving 7 for internal use.
 	maxValidLabelValueLength = 2048 // This is the actual max label value length.
 	MaxLabelValueLength      = 128  // Keep this number low so that the UI remains usable.
@@ -376,10 +374,6 @@ func (c Check) validateTimeout() error {
 }
 
 func validateLabels(labels []Label) error {
-	if len(labels) > MaxCheckLabels {
-		return ErrTooManyCheckLabels
-	}
-
 	seenLabels := make(map[string]struct{})
 
 	for _, label := range labels {


### PR DESCRIPTION
This is a cherry-pick from #606 in order to delay the static labels limit verification removal until this mechanism is in place in the API. Once this static verification is removed from the agent, the limit will be checked in the API in relation with the specific tenant limit.