### PR TITLE
dependabot: group prometheus updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       - "dependencies"
     schedule:
       interval: "daily"
+    groups:
+      prometheus-go:
+        patterns:
+          - "github.com/prometheus/*"


### PR DESCRIPTION
Dependabot is currently creating separate bumps for packages that often get updated in steplock, such as
https://github.com/grafana/synthetic-monitoring-agent/pull/662 and https://github.com/grafana/synthetic-monitoring-agent/pull/663. This should instruct dependabot to create a single PR for them.