### PR TITLE
Release v0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 ## [Unreleased]
 
 
+<a name="v0.23.2"></a>
+## [v0.23.2] - 2024-04-08
+### Dependabot
+- group prometheus updates ([#664](https://github.com/grafana/synthetic-monitoring-agent/issues/664))
+
+
 <a name="v0.23.1"></a>
 ## [v0.23.1] - 2024-03-18
 
@@ -575,7 +581,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.1...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.2...HEAD
+[v0.23.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.1...v0.23.2
 [v0.23.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.0...v0.23.1
 [v0.23.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.22.0...v0.23.0
 [v0.22.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.21.0...v0.22.0


### PR DESCRIPTION
* dependabot: group prometheus updates (#664)
* Chore(deps): Bump the prometheus-go group with 2 updates (#668)
* Allow returning stale data from tenants cache (#665)
* Chore(deps): Bump the prometheus-go group with 2 updates (#669)
* Chore(deps): Bump golang.org/x/net from 0.22.0 to 0.23.0 (#670)
* Chore(deps): Bump golang.org/x/net from 0.23.0 to 0.24.0 (#672)
* Chore(deps): Bump golang.org/x/sync from 0.6.0 to 0.7.0 (#673)
* Update grafana-build-tools to v0.10.0 (#676)