### PR TITLE
Terminate agent if capabilities not supported

### DIFF
--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -47,7 +47,7 @@ const (
 	errTransportClosing    = TransientError("transport closing")
 	errProbeUnregistered   = TransientError("probe no longer registered")
 	errIncompatibleApi     = Error("API does not support required features")
-	errCapabilityK6Missing = Error("K6 is required for scripted check support")
+	errCapabilityK6Missing = Error("k6 is required for scripted check support")
 )
 
 // Backoffer defines an interface to provide backoff durations.
@@ -297,6 +297,14 @@ func (c *Updater) Run(ctx context.Context) error {
 				Err(err).
 				Str("connection_state", c.api.conn.GetState().String()).
 				Msg("cannot connect, bailing out")
+			return err
+
+		case errors.Is(err, errCapabilityK6Missing):
+			// probe missing k6 to support capability
+			c.logger.Error().
+				Err(err).
+				Str("connection_state", c.api.conn.GetState().String()).
+				Msg("k6 requirement missing, bailing out")
 			return err
 
 		case errors.Is(err, context.Canceled):

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -38,16 +38,26 @@ type Error string
 
 func (e Error) Error() string { return string(e) }
 
+// TransientError is an error that can be recovered.
 type TransientError Error
 
 func (e TransientError) Error() string { return string(e) }
 
+var _ error = TransientError("")
+
+// FatalError is an error that causes the program to terminate.
+type FatalError Error
+
+func (e FatalError) Error() string { return string(e) }
+
+var _ error = FatalError("")
+
 const (
-	errNotAuthorized       = Error("probe not authorized")
-	errTransportClosing    = TransientError("transport closing")
+	errCapabilityK6Missing = FatalError("k6 is required for scripted check support")
+	errIncompatibleApi     = FatalError("API does not support required features")
+	errNotAuthorized       = FatalError("probe not authorized")
 	errProbeUnregistered   = TransientError("probe no longer registered")
-	errIncompatibleApi     = Error("API does not support required features")
-	errCapabilityK6Missing = Error("k6 is required for scripted check support")
+	errTransportClosing    = TransientError("transport closing")
 )
 
 // Backoffer defines an interface to provide backoff durations.
@@ -253,82 +263,74 @@ func (c *Updater) Run(ctx context.Context) error {
 	c.backoff.Reset()
 
 	for {
-		var transientErr *TransientError
-
 		wasConnected, err := c.loop(ctx)
 
-		c.logger.Info().
-			Err(err).
-			Bool("was_connected", wasConnected).
-			Str("connection_state", c.api.conn.GetState().String()).
-			Msg("broke out of loop")
+		logger := c.logger.With().Str("connection_state", c.api.conn.GetState().String()).Logger()
 
-		switch {
-		case err == nil:
-			return nil
+		logger.Info().Err(err).Bool("was_connected", wasConnected).Msg("broke out of loop")
 
-		case errors.As(err, &transientErr):
-			c.logger.Warn().
-				Err(err).
-				Str("connection_state", c.api.conn.GetState().String()).
-				Msg("transient error, trying to reconnect")
+		done, err := handleError(ctx, logger, c.backoff, wasConnected, err)
 
-			if err := sleepCtx(ctx, c.backoff.Duration()); err != nil {
-				return err
-			}
-
-			if wasConnected {
-				c.backoff.Reset()
-			}
-
-			continue
-
-		case errors.Is(err, errNotAuthorized):
-			// our token is invalid, bail out?
-			c.logger.Error().
-				Err(err).
-				Str("connection_state", c.api.conn.GetState().String()).
-				Msg("cannot connect, bailing out")
+		if done {
 			return err
-
-		case errors.Is(err, errIncompatibleApi):
-			// API server doesn't support required features.
-			c.logger.Error().
-				Err(err).
-				Str("connection_state", c.api.conn.GetState().String()).
-				Msg("cannot connect, bailing out")
-			return err
-
-		case errors.Is(err, errCapabilityK6Missing):
-			// probe missing k6 to support capability
-			c.logger.Error().
-				Err(err).
-				Str("connection_state", c.api.conn.GetState().String()).
-				Msg("k6 requirement missing, bailing out")
-			return err
-
-		case errors.Is(err, context.Canceled):
-			// context was cancelled, clean up
-			c.logger.Error().
-				Err(err).
-				Str("connection_state", c.api.conn.GetState().String()).
-				Msg("context cancelled, closing updater")
-			return nil
-
-		default:
-			c.logger.Warn().
-				Err(err).
-				Str("connection_state", c.api.conn.GetState().String()).
-				Msg("handling check changes")
-
-			// TODO(mem): this might be a transient error (e.g. bad connection). We probably need to
-			// fine-tune GRPPC's backoff parameters. We might also need to keep count of the reconnects, and
-			// give up if they hit some threshold?
-			if err := sleepCtx(ctx, c.backoff.Duration()); err != nil {
-				return err
-			}
 		}
 	}
+}
+
+// handleError takes care of handling errors that occur during the execution of
+// the updater loop. It returns a boolean indicating whether the updater should
+// stop and an error that should be returned to the caller of this function.
+// That error might be nil.
+//
+// TODO(mem): `wasConnected` is passed to preserve the previous behavior of the
+// updater. It might be possible to remove it and handle this in the caller.
+func handleError(ctx context.Context, logger zerolog.Logger, backoff Backoffer, wasConnected bool, err error) (bool, error) {
+	var (
+		transientErr TransientError
+		fatalError   FatalError
+	)
+
+	switch {
+	case err == nil:
+		return true, nil
+
+	case errors.As(err, &transientErr):
+		logger.Warn().Err(err).Msg("transient error, trying to reconnect")
+
+		if err := sleepCtx(ctx, backoff.Duration()); err != nil {
+			return true, err
+		}
+
+		if wasConnected {
+			backoff.Reset()
+		}
+
+		return false, nil
+
+	case errors.As(err, &fatalError):
+		logger.Error().Err(err).Msg("fatal error, bailing out")
+		return true, err
+
+	case errors.Is(err, context.Canceled):
+		// context was cancelled, clean up
+		logger.Error().
+			Err(err).
+			Msg("context cancelled, closing updater")
+		return true, nil
+
+	default:
+		logger.Warn().
+			Msg("handling check changes")
+
+		// TODO(mem): this might be a transient error (e.g. bad connection). We probably need to
+		// fine-tune GRPPC's backoff parameters. We might also need to keep count of the reconnects, and
+		// give up if they hit some threshold?
+		if err := sleepCtx(ctx, backoff.Duration()); err != nil {
+			return true, err
+		}
+	}
+
+	return false, nil
 }
 
 func (c *Updater) loop(ctx context.Context) (bool, error) {

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -332,7 +332,6 @@ func TestCheckHandlerProbeValidation(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
-
 }
 
 type testProber struct{}

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -21,6 +22,7 @@ import (
 	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
 	"github.com/grafana/synthetic-monitoring-agent/internal/scraper"
 	"github.com/grafana/synthetic-monitoring-agent/internal/telemetry"
+	"github.com/grafana/synthetic-monitoring-agent/internal/testhelper"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
@@ -396,4 +398,106 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 
 func (noopRunner) Run(ctx context.Context, script []byte) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
+}
+
+type testBackoff time.Duration
+
+func (b *testBackoff) Reset() {
+	*b = 0
+}
+
+func (b testBackoff) Duration() time.Duration {
+	return time.Duration(b)
+}
+
+// TestHandleError tests the handleError function. It considers the errors that
+// might be returned from the loop method.
+func TestHandleError(t *testing.T) {
+	ctx, cancel := testhelper.Context(context.Background(), t)
+	defer cancel()
+
+	logger := zerolog.Nop()
+
+	t.Run("no error", func(t *testing.T) {
+		backoff := testBackoff(1)
+		done, err := handleError(ctx, logger, &backoff, false, nil)
+		require.True(t, done)
+		require.NoError(t, err)
+		require.NotZero(t, backoff)
+	})
+
+	t.Run("context cancelled", func(t *testing.T) {
+		backoff := testBackoff(1)
+		done, err := handleError(ctx, logger, &backoff, false, fmt.Errorf("wrapped: %w", context.Canceled))
+		require.True(t, done)
+		require.NoError(t, err)
+		require.NotZero(t, backoff)
+	})
+
+	t.Run("k6 capability missing", func(t *testing.T) {
+		backoff := testBackoff(1)
+		done, err := handleError(ctx, logger, &backoff, false, errCapabilityK6Missing)
+		require.True(t, done)
+		require.ErrorIs(t, err, errCapabilityK6Missing)
+		require.NotZero(t, backoff)
+	})
+
+	t.Run("incompatible API", func(t *testing.T) {
+		backoff := testBackoff(1)
+		done, err := handleError(ctx, logger, &backoff, false, errIncompatibleApi)
+		require.True(t, done)
+		require.ErrorIs(t, err, errIncompatibleApi)
+		require.NotZero(t, backoff)
+	})
+
+	t.Run("not authorized", func(t *testing.T) {
+		backoff := testBackoff(1)
+		done, err := handleError(ctx, logger, &backoff, false, errNotAuthorized)
+		require.True(t, done)
+		require.ErrorIs(t, err, errNotAuthorized)
+		require.NotZero(t, backoff)
+	})
+
+	t.Run("transport closing - not connected", func(t *testing.T) {
+		backoff := testBackoff(1)
+		done, err := handleError(ctx, logger, &backoff, false, errTransportClosing)
+		require.False(t, done)
+		require.NoError(t, err)
+		require.NotZero(t, backoff)
+	})
+
+	t.Run("transport closing - not connected - cancelled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		backoff := testBackoff(100)
+		done, err := handleError(ctx, logger, &backoff, false, errTransportClosing)
+		require.True(t, done)
+		require.ErrorIs(t, err, context.Canceled)
+		require.NotZero(t, backoff)
+	})
+
+	t.Run("transport closing - connected", func(t *testing.T) {
+		backoff := testBackoff(1)
+		done, err := handleError(ctx, logger, &backoff, true, errTransportClosing)
+		require.False(t, done)
+		require.NoError(t, err)
+		require.Zero(t, backoff)
+	})
+
+	t.Run("probe unregistered - not connected", func(t *testing.T) {
+		backoff := testBackoff(1)
+		done, err := handleError(ctx, logger, &backoff, false, errProbeUnregistered)
+		require.False(t, done)
+		require.NoError(t, err)
+		require.NotZero(t, backoff)
+	})
+
+	t.Run("probe unregistered - connected", func(t *testing.T) {
+		backoff := testBackoff(1)
+		done, err := handleError(ctx, logger, &backoff, true, errProbeUnregistered)
+		require.False(t, done)
+		require.NoError(t, err)
+		require.Zero(t, backoff)
+	})
 }


### PR DESCRIPTION
Part of the new capabilities framework, probes must support features that are expected of them upon connection or else will terminate with an error verbose enough to diagnose the issue.

Un-drafting this, but should merge after the [API changes](https://github.com/grafana/synthetic-monitoring-api/pull/815).