### PR TITLE
Log configuration at start up

### DIFF
--- a/cmd/synthetic-monitoring-agent/secret.go
+++ b/cmd/synthetic-monitoring-agent/secret.go
@@ -1,0 +1,25 @@
+package main
+
+// Secret represents a string that shouldn't be logged.
+type Secret string
+
+// String returns a redacted version of the secret.
+func (s Secret) String() string {
+	return "<redacted>"
+}
+
+// Set sets the value of the secret.
+func (s *Secret) Set(value string) error {
+	*s = Secret(value)
+	return nil
+}
+
+// MarshalText returns a text representation of the redacted version of the
+// secret.
+//
+// This method implements the necessary interface to use Secret in the
+// encoding/text and encoding/json packages, which are used by zerolog to
+// control the output of the log messages.
+func (s Secret) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}

--- a/cmd/synthetic-monitoring-agent/secret_test.go
+++ b/cmd/synthetic-monitoring-agent/secret_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecret(t *testing.T) {
+	testcases := map[string]struct {
+		input string
+	}{
+		"empty":  {input: ""},
+		"secret": {input: "secret"},
+		"blank":  {input: " "},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			var s Secret
+
+			require.NoError(t, s.Set(tc.input))
+
+			require.Equal(t, tc.input, string(s))
+
+			require.Equal(t, "<redacted>", s.String())
+
+			text, err := s.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, []byte("<redacted>"), text)
+
+			buf, err := json.Marshal(s)
+			require.NoError(t, err)
+			require.Equal(t, []byte(`"\u003credacted\u003e"`), buf)
+		})
+	}
+}


### PR DESCRIPTION
When the program is starting up, log the configuration parameters. This helps with debugging and support.

Be careful not to log the API secret.

This is a no-op change, but it's a little noisy becuase of the introduction of the config struct.