### PR TITLE
Make k6 capability validation nil-safe

### DIFF
--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -481,7 +481,10 @@ func (c *Updater) loop(ctx context.Context) (bool, error) {
 }
 
 func (c *Updater) validateProbeCapabilities(capabilities *sm.Probe_Capabilities) error {
-	if !capabilities.DisableScriptedChecks && c.k6Runner == nil {
+	// k6 is only not required on this probe if explicitly disabled
+	requireK6 := capabilities == nil || !capabilities.DisableScriptedChecks
+
+	if requireK6 && c.k6Runner == nil {
 		return errCapabilityK6Missing
 	}
 

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -320,6 +320,29 @@ func TestCheckHandlerProbeValidation(t *testing.T) {
 			},
 			probe: sm.Probe{Id: 100, Name: "test-probe", Capabilities: &sm.Probe_Capabilities{DisableScriptedChecks: true}},
 		},
+		"missing K6 when required by default": {
+			expectedError: errCapabilityK6Missing,
+			opts: UpdaterOptions{
+				Conn:           new(grpc.ClientConn),
+				PromRegisterer: prometheus.NewPedanticRegistry(),
+				Publisher:      channelPublisher(make(chan pusher.Payload)),
+				TenantCh:       make(chan<- sm.Tenant),
+				Logger:         zerolog.Nop(),
+			},
+			probe: sm.Probe{Id: 100, Name: "test-probe"},
+		},
+		"has K6 when required by default": {
+			expectedError: nil,
+			opts: UpdaterOptions{
+				Conn:           new(grpc.ClientConn),
+				PromRegisterer: prometheus.NewPedanticRegistry(),
+				Publisher:      channelPublisher(make(chan pusher.Payload)),
+				TenantCh:       make(chan<- sm.Tenant),
+				Logger:         zerolog.Nop(),
+				K6Runner:       noopRunner{},
+			},
+			probe: sm.Probe{Id: 100, Name: "test-probe"},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
The proxy release was outdated, causing it to not propagate the `Probe.Capabilities` field to the agents.

This revealed a miss on checking that the field is present in the agent before validating that the K6 config matches the `Capabilities` requirement. This PR updates the requirement to make sure the field is set or else require K6 by default.