### PR TITLE
Release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,22 @@
 ## [Unreleased]
 
 
+<a name="v0.24.0"></a>
+## [v0.24.0] - 2024-04-30
+### Feature
+- automatically set up GOMEMLIMIT ([#691](https://github.com/grafana/synthetic-monitoring-agent/issues/691))
+
+### Fix
+- use uniform timeout validation logic ([#693](https://github.com/grafana/synthetic-monitoring-agent/issues/693))
+- TestTickWithOffset sometimes if offset is 0 ([#686](https://github.com/grafana/synthetic-monitoring-agent/issues/686))
+
+### K6runner
+- inspect errors and propagate unexpected ones to the probe
+- handle errors reported by http runners
+
+
 <a name="v0.23.4"></a>
-## [v0.23.4] - 2024-04-16
+## [v0.23.4] - 2024-04-17
 ### Feature
 - upgrade k6 to v0.50.0 ([#681](https://github.com/grafana/synthetic-monitoring-agent/issues/681))
 
@@ -585,7 +599,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.4...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.0...HEAD
+[v0.24.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.4...v0.24.0
 [v0.23.4]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.3...v0.23.4
 [v0.23.3]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.2...v0.23.3
 [v0.23.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.1...v0.23.2


### PR DESCRIPTION
* Feature: upgrade k6 to v0.50.0 (#681)
* Chore(deps): Bump github.com/prometheus/blackbox_exporter
* skip interpolating multihttp variables into the metric names (#683)
* proto fields for scripted check enablement (#674)
* Switch to using buf to manage protobuf code (#641)
* Release v0.23.4 (#685)
* Fix: TestTickWithOffset sometimes if offset is 0 (#686)
* Chore(deps): Bump the prometheus-go group with 2 updates
* Chore(deps): Bump github.com/miekg/dns from 1.1.58 to 1.1.59
* Log configuration at start up (#689)
* Feature: automatically set up GOMEMLIMIT (#691)
* Terminate agent if capabilities not supported (#684)
* Make k6 capability validation nil-safe (#692)
* Fix: use uniform timeout validation logic (#693)
* k6runner: handle errors reported by http runners
* k6runner/test: add test for RunResponse error handling
* k6runner: inspect errors and propagate unexpected ones to the probe