### PR TITLE
Fix: report duration from script

### DIFF
--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -906,9 +906,10 @@ func TestValidateLabels(t *testing.T) {
 				},
 			}
 
-			data, err := s.collectData(context.Background(), time.Unix(int64(3141000)/1000, 0))
+			data, duration, err := s.collectData(context.Background(), time.Unix(int64(3141000)/1000, 0))
 			require.NoError(t, err)
 			require.NotNil(t, data)
+			require.NotZero(t, duration)
 
 			metricLabels := maxProbeMetricLabels(t, data.Metrics())
 			logLabels := maxProbeLogLabels(t, data.Streams())
@@ -1529,9 +1530,10 @@ func TestScraperCollectData(t *testing.T) {
 				},
 			}
 
-			data, err := s.collectData(context.Background(), time.Unix(sampleTsMs/1000, 0))
+			data, duration, err := s.collectData(context.Background(), time.Unix(sampleTsMs/1000, 0))
 			require.NoError(t, err)
 			require.NotNil(t, data)
+			require.NotZero(t, duration)
 
 			for _, ts := range data.Metrics() {
 				validateMetrics(t, ts, tc)


### PR DESCRIPTION
Right now we are reporting the time it takes to run a script, including the time it takes for k6 to actually start running the script, plus all other kinds of overhead.

Modify the sm extension to report the script duration, and report that number as probe_duration_seconds. We are still reporting probe_script_duration_seconds as well. This will get fixed in a future change.