### PR TITLE
Bump Go to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/synthetic-monitoring-agent
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-kit/kit v0.13.0

--- a/scripts/go/go.mod
+++ b/scripts/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/synthetic-monitoring-agent/scripts/go
 
-go 1.21
+go 1.22
 
 require (
 	github.com/dmarkham/enumer v1.5.9


### PR DESCRIPTION
This has no effect on the released images because those are already using Go 1.21, but it's nice to keep stuff in sync.