### PR TITLE
Remove adhoc and traceroute feature flags

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -181,8 +181,6 @@ func run(args []string, stdout io.Writer) error {
 		Interface("config", config).
 		Msg("starting")
 
-	notifyAboutDeprecatedFeatureFlags(features, zl)
-
 	if features.IsSet(feature.K6) {
 		newUri, err := validateK6URI(config.K6URI)
 		if err != nil {
@@ -406,14 +404,6 @@ func validateK6URI(uri string) (string, error) {
 	}
 
 	return uri, nil
-}
-
-func notifyAboutDeprecatedFeatureFlags(features feature.Collection, zl zerolog.Logger) {
-	for _, ff := range []string{feature.AdHoc, feature.Traceroute} {
-		if features.IsSet(ff) {
-			zl.Info().Msgf("the `%s` feature is now permanently enabled in the agent, you can remove it from the --feature flag without loss of functionality", ff)
-		}
-	}
 }
 
 func setupGoMemLimit(ratio float64) error {

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -9,11 +9,7 @@ import (
 )
 
 // TODO: this doesn't seem like the right place for this
-const (
-	Traceroute = "traceroute"
-	AdHoc      = "adhoc"
-	K6         = "k6"
-)
+const K6 = "k6"
 
 // ErrInvalidCollection is returned when you try to set a flag in an
 // invalid collection.


### PR DESCRIPTION
Resolves https://github.com/grafana/synthetic-monitoring-agent/issues/556.

We could also consider the issue handled by https://github.com/grafana/synthetic-monitoring-agent/pull/615, but I'm not sure we need to keep these around to let operators know they're obsolete - when would we remove these then?