### PR TITLE
checks/test: make timer big enough for context cancel to be picked up

### DIFF
--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -493,7 +493,7 @@ func TestHandleError(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		backoff := testBackoff(100)
+		backoff := testBackoff(time.Second)
 		done, err := handleError(ctx, logger, &backoff, false, errTransportClosing)
 		require.True(t, done)
 		require.ErrorIs(t, err, context.Canceled)


### PR DESCRIPTION
I cannot reproduce the flaky test locally, so let's try things and see what sticks.

---

I think this was it: The 100 nanosecond timer was probably long enough for context cancellation to be picked up before the timer expired in our beefy machines, but not in the handicapped CI runners.