### PR TITLE
Fix: Interpolate variables into MultiHTTP request bodies

### DIFF
--- a/internal/prober/multihttp/script.go
+++ b/internal/prober/multihttp/script.go
@@ -3,7 +3,6 @@ package multihttp
 import (
 	"bytes"
 	"embed"
-	"encoding/base64"
 	"fmt"
 	"regexp"
 	"strings"
@@ -96,11 +95,8 @@ func buildBody(body *sm.HttpRequestBody) string {
 
 	default:
 		var buf strings.Builder
-
-		buf.WriteString(`encoding.b64decode("`)
-		buf.WriteString(base64.RawStdEncoding.EncodeToString(body.Payload))
-		buf.WriteString(`", 'rawstd', "b")`)
-
+		bodyString := string(body.Payload)
+		buf.WriteString(performVariableExpansion(bodyString))
 		return buf.String()
 	}
 }

--- a/internal/prober/multihttp/script.go
+++ b/internal/prober/multihttp/script.go
@@ -3,6 +3,7 @@ package multihttp
 import (
 	"bytes"
 	"embed"
+	"encoding/base64"
 	"fmt"
 	"regexp"
 	"strings"
@@ -95,9 +96,50 @@ func buildBody(body *sm.HttpRequestBody) string {
 
 	default:
 		var buf strings.Builder
-		bodyString := string(body.Payload)
-		buf.WriteString(performVariableExpansion(bodyString))
+
+		buf.WriteString(`encoding.b64decode("`)
+		buf.WriteString(base64.RawStdEncoding.EncodeToString(body.Payload))
+		buf.WriteString(`", 'rawstd', "b")`)
+
 		return buf.String()
+	}
+}
+
+func interpolateBodyVariables(bodyVarName string, body *sm.HttpRequestBody) []string {
+	switch {
+	case body == nil || len(body.Payload) == 0:
+		return nil
+
+	default:
+		var buf strings.Builder
+
+		matches := userVariables.FindAllString(string(body.Payload), -1)
+		parsedMatches := make(map[string]struct{})
+		out := make([]string, 0, len(matches))
+
+		// For every instance of ${variable} in the body,
+		// this block returns {bodyVarName}.replace('${variable}', vars['variable'])
+		for _, m := range matches {
+			if _, found := parsedMatches[m]; found {
+				continue
+			}
+
+			buf.Reset()
+			buf.WriteString(bodyVarName)
+			buf.WriteString(".replace('")
+			buf.WriteString(m)
+			buf.WriteString("', vars['")
+			// writing the variable name from between ${ and }
+			for i := 2; i < len(m)-1; i++ {
+				buf.WriteByte(m[i])
+			}
+			buf.WriteString("'])")
+			out = append(out, buf.String())
+
+			parsedMatches[m] = struct{}{}
+		}
+
+		return out
 	}
 }
 
@@ -383,12 +425,13 @@ func settingsToScript(settings *sm.MultiHttpSettings) ([]byte, error) {
 	tmpl, err := template.
 		New("").
 		Funcs(template.FuncMap{
-			"buildBody":        buildBody,
-			"buildChecks":      buildChecks,
-			"buildHeaders":     buildHeaders,
-			"buildUrl":         performVariableExpansion,
-			"buildQueryParams": buildQueryParams,
-			"buildVars":        buildVars,
+			"buildBody":           buildBody,
+			"buildChecks":         buildChecks,
+			"buildHeaders":        buildHeaders,
+			"buildUrl":            performVariableExpansion,
+			"buildQueryParams":    buildQueryParams,
+			"buildVars":           buildVars,
+			"interpolateBodyVars": interpolateBodyVariables,
 		}).
 		ParseFS(templateFS, "*.tmpl")
 	if err != nil {

--- a/internal/prober/multihttp/script.tmpl
+++ b/internal/prober/multihttp/script.tmpl
@@ -69,6 +69,7 @@ function assertHeader(headers, name, matcher) {
 
 export default function() {
 	let response;
+	let body;
 	let url;
 	let currentCheck;
 	let match;
@@ -87,9 +88,14 @@ export default function() {
 	{{ range $queries }}{{ . }};
 	{{ end -}}
 	{{- $method := .Request.Method.String }}
-	{{- $body := buildBody .Request.Body }}
+	
+	body = {{ buildBody .Request.Body }};
+	{{- $bodyVars := interpolateBodyVars "body" .Request.Body }}
+	{{ range $bodyVars }}{{ . }};
+	{{ end -}}
+
 	{{- $headers := buildHeaders .Request.Headers .Request.Body }}
-	response = http.request('{{ $method }}', url.toString(), {{ $body }}, {
+	response = http.request('{{ $method }}', url.toString(), body, {
 		// TODO(mem): build params out of options for the check
 		tags: {
 		  name: '{{ $idx }}', // TODO(mem): give the user some control over this?

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -343,6 +343,8 @@ func TestBuildBody(t *testing.T) {
 }
 
 func TestInterpolateBodyVariables(t *testing.T) {
+	t.Parallel()
+
 	type input struct {
 		body *sm.HttpRequestBody
 	}
@@ -372,6 +374,7 @@ func TestInterpolateBodyVariables(t *testing.T) {
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			actual := interpolateBodyVariables("body", tc.input.body)
 			require.Equal(t, tc.expected, actual)
 		})

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -320,9 +320,17 @@ func TestBuildBody(t *testing.T) {
 		input    input
 		expected string
 	}{
+		"variable in body is interpolated correctly": {
+			input:    input{body: &sm.HttpRequestBody{Payload: []byte("test ${testVar} works")}},
+			expected: "'test '+vars['testVar']+' works'", // 'test '+vars['testVar']+' works'
+		},
+		"body starting with variable is interpolated correctly": {
+			input:    input{body: &sm.HttpRequestBody{Payload: []byte("${testVar} test")}},
+			expected: "vars['testVar']+' test'", // vars['testVar']+' test'
+		},
 		"not empty": {
 			input:    input{body: &sm.HttpRequestBody{Payload: []byte("test")}},
-			expected: `encoding.b64decode("dGVzdA", 'rawstd', "b")`,
+			expected: "'test'", // 'test'
 		},
 		"nil": {
 			input:    input{body: nil},


### PR DESCRIPTION
Addresses https://github.com/grafana/synthetic-monitoring-agent/issues/637.
Writing `encoding.b64decode(<BODY>)` into the template doesn't let us catch where the user is referencing variables.

We should either:
1. Write the whole string expression (`"literal " +vars['var1']+ " more text " +vars['var2']`) directly into the template, or
2. Add a functional block in the template to take the b64-decoded `$body` and replace any interpolated variables in the template code itself.

For option 1, `buildBody` could likely just return the result of `performVariableExpansion` on the body payload.

Option 2 is probably better practice as the user input won't escape the string; however users who are trying to execute arbitrary code _could_ just leverage scripted checks.