### PR TITLE
k6runner: use check context for http request

### DIFF
--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -350,9 +350,9 @@ func (r HttpRunner) Run(ctx context.Context, script []byte) (*RunResponse, error
 	}
 
 	// The context above carries the check timeout, which will be eventually passed to k6 by the runner at the other end
-	// of this request. To account for network overhead, we add a second of grace time to the script timeout to form
-	// the timeout of this request.
-	reqCtx, cancel := context.WithTimeout(ctx, k6Timeout+time.Second)
+	// of this request. To account for network overhead, we create a different context with an extra second of timeout,
+	// which adds some grace time to account for the network/system latency of the http request.
+	reqCtx, cancel := context.WithTimeout(context.Background(), k6Timeout+time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, r.url, bytes.NewReader(reqBody))


### PR DESCRIPTION
This PR instructs the HTTP-backed k6 runner (Grafana Cloud) to use the context carrying the script timeout as the request context for HTTP requests made to that k6 runner. An extra second of grace time is added to account for network latency is added to the check timeout.

This fixes a potential deadlock where the agent would wait for the HTTP request to complete forever, even longer than the maximum time the script is allowed to run. This does not occur frequently, but could happen on certain scenarios such as when GC runners are abruptly terminated.

Note that this is a stopgap measure to prevent deadlocks in the agent. Ideally, we should have a separate settings for the time we wait for the runner to respond, and the time that the runner allows k6 to wait for. See details about the long-term proposal here: https://docs.google.com/document/d/1kq5xC4izHyJ9WOonS308J8sE3uDG48c6gj4ZPHsWIx4/edit.