### PR TITLE
Implement retries for remote k6 runners

### DIFF
--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -37,6 +37,9 @@ type Settings struct {
 	Timeout int64 `json:"timeout"`
 }
 
+// ErrNoTimeout is returned by [Runner] implementations if the supplied script has a timeout of zero.
+var ErrNoTimeout = errors.New("check has no timeout")
+
 type Runner interface {
 	WithLogger(logger *zerolog.Logger) Runner
 	Run(ctx context.Context, script Script) (*RunResponse, error)
@@ -351,7 +354,10 @@ func (r HttpRunner) WithLogger(logger *zerolog.Logger) Runner {
 var ErrUnexpectedStatus = errors.New("unexpected status code")
 
 func (r HttpRunner) Run(ctx context.Context, script Script) (*RunResponse, error) {
-	k6Timeout := time.Duration(script.Settings.Timeout) * time.Millisecond
+	checkTimeout := time.Duration(script.Settings.Timeout) * time.Millisecond
+	if checkTimeout == 0 {
+		return nil, ErrNoTimeout
+	}
 
 	reqBody, err := json.Marshal(script)
 	if err != nil {
@@ -361,7 +367,7 @@ func (r HttpRunner) Run(ctx context.Context, script Script) (*RunResponse, error
 	// The context above carries the check timeout, which will be eventually passed to k6 by the runner at the other end
 	// of this request. To account for network overhead, we create a different context with an extra second of timeout,
 	// which adds some grace time to account for the network/system latency of the http request.
-	reqCtx, cancel := context.WithTimeout(context.Background(), k6Timeout+time.Second)
+	reqCtx, cancel := context.WithTimeout(context.Background(), checkTimeout+time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, r.url, bytes.NewReader(reqBody))

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -345,10 +345,9 @@ type RunResponse struct {
 }
 
 func (r HttpRunner) WithLogger(logger *zerolog.Logger) Runner {
-	return HttpRunner{
-		url:    r.url,
-		logger: logger,
-	}
+	r.logger = logger
+
+	return r
 }
 
 var ErrUnexpectedStatus = errors.New("unexpected status code")

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"os/exec"
 	"strings"
@@ -56,8 +57,10 @@ func New(opts RunnerOpts) Runner {
 
 	if strings.HasPrefix(opts.Uri, "http") {
 		r = &HttpRunner{
-			url:    opts.Uri,
-			logger: &logger,
+			url:       opts.Uri,
+			logger:    &logger,
+			graceTime: defaultGraceTime,
+			backoff:   defaultBackoff,
 		}
 	} else {
 		r = LocalRunner{
@@ -324,7 +327,17 @@ NEXT_RECORD:
 type HttpRunner struct {
 	url    string
 	logger *zerolog.Logger
+	// backoff sets the minimum amount of time to wait before retrying a request. nth attempt waits n times this value,
+	// plus some jitter.
+	backoff time.Duration
+	// graceTime tells the HttpRunner how much time to add to the script timeout to form the request timeout.
+	graceTime time.Duration
 }
+
+const (
+	defaultBackoff   = 10 * time.Second
+	defaultGraceTime = 20 * time.Second
+)
 
 type requestError struct {
 	Err     string `json:"error"`
@@ -353,23 +366,90 @@ func (r HttpRunner) WithLogger(logger *zerolog.Logger) Runner {
 var ErrUnexpectedStatus = errors.New("unexpected status code")
 
 func (r HttpRunner) Run(ctx context.Context, script Script) (*RunResponse, error) {
+	if r.backoff == 0 {
+		panic("zero backoff, runner is misconfigured, refusing to DoS")
+	}
+
+	if deadline, hasDeadline := ctx.Deadline(); !hasDeadline {
+		defaultAllRetriesTimeout := time.Duration(script.Settings.Timeout) * time.Millisecond * 2
+		r.logger.Error().
+			Dur("allRetriesTimeout", defaultAllRetriesTimeout).
+			Msg("k6 runner does not have a deadline for all retries. This is a bug. Defaulting to twice the timeout to avoid retrying forever")
+
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultAllRetriesTimeout)
+		defer cancel()
+	} else if tud := time.Until(deadline); tud < time.Duration(script.Settings.Timeout)*time.Millisecond*2 {
+		r.logger.Debug().
+			Str("timeUntilNext", tud.String()).
+			Str("timeout", (time.Duration(script.Settings.Timeout) * time.Millisecond).String()).
+			Msg("time until next execution is too close to script timeout, there might not be room for retries")
+	}
+
+	wait := r.backoff
+	var response *RunResponse
+	for {
+		start := time.Now()
+
+		var err error
+		response, err = r.request(ctx, script)
+		if err == nil {
+			r.logger.Debug().Bytes("metrics", response.Metrics).Bytes("logs", response.Logs).Msg("script result")
+			return response, nil
+		}
+
+		if !errors.Is(err, errRetryable) {
+			return nil, err
+		}
+
+		// Wait, but subtract the amount of time we've already waited as part of the request timeout.
+		// We do this because these requests have huge timeouts, and by the nature of the system running these request,
+		// we expect the most common error to be a timeout, so we avoid waiting even more on top of an already large
+		// value.
+		waitRemaining := max(0, wait-time.Since(start))
+		r.logger.Debug().Err(err).Dur("after", waitRemaining).Msg("retrying retryable error")
+
+		waitTimer := time.NewTimer(waitRemaining)
+		select {
+		case <-ctx.Done():
+			waitTimer.Stop()
+			return nil, fmt.Errorf("cannot retry further: %w", errors.Join(err, ctx.Err()))
+		case <-waitTimer.C:
+		}
+
+		// Backoff linearly, adding some jitter.
+		wait += r.backoff + time.Duration(rand.Intn(int(r.backoff)))
+	}
+}
+
+// errRetryable indicates that an error is retryable. It is typically joined with another error.
+var errRetryable = errors.New("retryable")
+
+func (r HttpRunner) request(ctx context.Context, script Script) (*RunResponse, error) {
 	checkTimeout := time.Duration(script.Settings.Timeout) * time.Millisecond
 	if checkTimeout == 0 {
 		return nil, ErrNoTimeout
 	}
+
+	// requestTimeout should be noticeably larger than [Script.Settings.Timeout], to account for added latencies in the
+	// system such as network, i/o, seralization, queue wait time, etc. that take place after and before the script is
+	// ran.
+	//  t0                 t1                                      t2               t3
+	//  |--- Queue wait ---|-------------- k6 run -----------------|--- Response ---|
+	//  checkTimeout = t2 - t1
+	//  requestTimeout = t3 - t0
+	requestTimeout := checkTimeout + r.graceTime
+	notAfter := time.Now().Add(requestTimeout)
+
+	ctx, cancel := context.WithDeadline(ctx, notAfter)
+	defer cancel()
 
 	reqBody, err := json.Marshal(script)
 	if err != nil {
 		return nil, fmt.Errorf("encoding script: %w", err)
 	}
 
-	// The context above carries the check timeout, which will be eventually passed to k6 by the runner at the other end
-	// of this request. To account for network overhead, we create a different context with an extra second of timeout,
-	// which adds some grace time to account for the network/system latency of the http request.
-	reqCtx, cancel := context.WithTimeout(context.Background(), checkTimeout+time.Second)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, r.url, bytes.NewReader(reqBody))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.url, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("building request: %w", err)
 	}
@@ -379,30 +459,43 @@ func (r HttpRunner) Run(ctx context.Context, script Script) (*RunResponse, error
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		r.logger.Error().Err(err).Msg("sending request")
-		return nil, fmt.Errorf("running script: %w", err)
+
+		// Any error making a request is retryable.
+		return nil, errors.Join(errRetryable, fmt.Errorf("making request: %w", err))
 	}
 
 	defer resp.Body.Close()
 
 	switch resp.StatusCode {
 	case http.StatusOK, http.StatusRequestTimeout, http.StatusUnprocessableEntity, http.StatusInternalServerError:
-	// These are status code that come with a machine-readable response. The response may contain an error, which is
+	// These are status code that we assume come with a machine-readable response. The response may contain an error, which is
 	// handled later.
 	// See: https://github.com/grafana/sm-k6-runner/blob/main/internal/mq/proxy.go#L215
-	default:
+
+	case http.StatusBadRequest:
+		// These are status codes that do not come with a machine readable response, and are not retryable.
+		//
+		// There might be an argument to be made to retry 500s, as they can be produced by panic recovering mechanisms which
+		// _can_ be seen as a transient error. However, it is also possible for a 500 to be returned by a script that failed
+		// and also needed a lot of time to complete. For this reason, we choose to not retry 500 for the time being.
 		return nil, fmt.Errorf("%w %d", ErrUnexpectedStatus, resp.StatusCode)
+
+	default:
+		// Statuses not returned by the proxy directly are assumed to be infrastructure (e.g. ingress, k8s) related and
+		// thus marked as retriable.
+		// Runners may also return http.StatusServiceUnavailable if the browser session manager cannot be reached. We want
+		// to retry those errors, so we let the "default" block catch them.
+		return nil, errors.Join(errRetryable, fmt.Errorf("%w %d", ErrUnexpectedStatus, resp.StatusCode))
 	}
 
-	var result RunResponse
-	err = json.NewDecoder(resp.Body).Decode(&result)
+	var response RunResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
 		r.logger.Error().Err(err).Msg("decoding script result")
 		return nil, fmt.Errorf("decoding script result: %w", err)
 	}
 
-	r.logger.Debug().Bytes("metrics", result.Metrics).Bytes("logs", result.Logs).Msg("script result")
-
-	return &result, nil
+	return &response, nil
 }
 
 type LocalRunner struct {
@@ -419,6 +512,11 @@ func (r LocalRunner) WithLogger(logger *zerolog.Logger) Runner {
 
 func (r LocalRunner) Run(ctx context.Context, script Script) (*RunResponse, error) {
 	afs := afero.Afero{Fs: r.fs}
+
+	checkTimeout := time.Duration(script.Settings.Timeout) * time.Millisecond
+	if checkTimeout == 0 {
+		return nil, ErrNoTimeout
+	}
 
 	workdir, err := afs.TempDir("", "k6-runner")
 	if err != nil {
@@ -455,7 +553,9 @@ func (r LocalRunner) Run(ctx context.Context, script Script) (*RunResponse, erro
 		return nil, fmt.Errorf("cannot find k6 executable: %w", err)
 	}
 
-	timeout := time.Duration(script.Settings.Timeout) * time.Millisecond
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, checkTimeout)
+	defer cancel()
 
 	// #nosec G204 -- the variables are not user-controlled
 	cmd := exec.CommandContext(
@@ -467,7 +567,6 @@ func (r LocalRunner) Run(ctx context.Context, script Script) (*RunResponse, erro
 		"--log-output", "file="+logsFn,
 		"--vus", "1",
 		"--iterations", "1",
-		"--duration", timeout.String(),
 		"--max-redirects", "10",
 		"--batch", "10",
 		"--batch-per-host", "4",

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -7,10 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -173,11 +177,15 @@ func TestHttpRunnerRunError(t *testing.T) {
 	runner := New(RunnerOpts{Uri: srv.URL + "/run"})
 	require.IsType(t, &HttpRunner{}, runner)
 
-	ctx, cancel := testhelper.Context(context.Background(), t)
+	// HTTPRunner will retry until the context deadline is met, so we set a short one.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	ctx, cancel = testhelper.Context(ctx, t)
 	t.Cleanup(cancel)
 
 	_, err := runner.Run(ctx, script)
-	require.Error(t, err)
+	require.ErrorIs(t, err, ErrUnexpectedStatus)
 }
 
 // TestScriptHTTPRun tests that Script reports what it should depending on the status code and responses of the HTTP
@@ -327,7 +335,7 @@ func TestScriptHTTPRun(t *testing.T) {
 				Metrics: testMetrics,
 				Logs:    testLogs,
 			},
-			delay:         2 * time.Second,
+			delay:         3 * time.Second, // Beyond timeout + graceTime.
 			statusCode:    http.StatusInternalServerError,
 			expectSuccess: false,
 			expectError:   context.DeadlineExceeded,
@@ -348,7 +356,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			srv := httptest.NewServer(mux)
 			t.Cleanup(srv.Close)
 
-			runner := New(RunnerOpts{Uri: srv.URL + "/run"})
+			runner := HttpRunner{url: srv.URL + "/run", graceTime: time.Second, backoff: time.Second}
 			script, err := NewProcessor(Script{
 				Script: []byte("tee-hee"),
 				Settings: Settings{
@@ -357,7 +365,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			}, runner)
 			require.NoError(t, err)
 
-			baseCtx, baseCancel := context.WithTimeout(context.Background(), time.Second)
+			baseCtx, baseCancel := context.WithTimeout(context.Background(), 4*time.Second)
 			t.Cleanup(baseCancel)
 			ctx, cancel := testhelper.Context(baseCtx, t)
 			t.Cleanup(cancel)
@@ -379,6 +387,223 @@ func TestScriptHTTPRun(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHTTPProcessorRetries(t *testing.T) {
+	t.Parallel()
+
+	t.Run("status codes", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range []struct {
+			name           string
+			handler        http.Handler
+			scriptTimeout  time.Duration
+			graceTime      time.Duration
+			globalTimeout  time.Duration
+			expectRequests int64
+			expectError    error
+		}{
+			{
+				name:          "no retries needed",
+				handler:       emptyJSON(http.StatusOK),
+				scriptTimeout: time.Second, graceTime: time.Second, globalTimeout: 5 * time.Second,
+				expectRequests: 1,
+				expectError:    nil,
+			},
+			{
+				name:          "does not retry 400",
+				handler:       emptyJSON(http.StatusBadRequest),
+				scriptTimeout: time.Second, graceTime: time.Second, globalTimeout: 5 * time.Second,
+				expectRequests: 1,
+				expectError:    ErrUnexpectedStatus,
+			},
+			{
+				name:          "does not retry 422",
+				handler:       emptyJSON(http.StatusUnprocessableEntity),
+				scriptTimeout: time.Second, graceTime: time.Second, globalTimeout: 5 * time.Second,
+				expectRequests: 1,
+				expectError:    nil,
+			},
+			{
+				name:          "does not retry 428",
+				handler:       emptyJSON(http.StatusRequestTimeout),
+				scriptTimeout: time.Second, graceTime: time.Second, globalTimeout: 5 * time.Second,
+				expectRequests: 1,
+				expectError:    nil,
+			},
+			{
+				name:          "does not retry 500",
+				handler:       emptyJSON(http.StatusInternalServerError),
+				scriptTimeout: time.Second, graceTime: time.Second, globalTimeout: 5 * time.Second,
+				expectRequests: 1,
+				expectError:    nil,
+			},
+			{
+				name:          "retries 503",
+				handler:       afterAttempts(emptyJSON(http.StatusServiceUnavailable), 1, emptyJSON(http.StatusOK)),
+				scriptTimeout: time.Second, graceTime: time.Second, globalTimeout: 5 * time.Second,
+				expectRequests: 2,
+				expectError:    nil,
+			},
+			{
+				name:          "retries 504",
+				handler:       afterAttempts(emptyJSON(http.StatusGatewayTimeout), 1, emptyJSON(http.StatusOK)),
+				scriptTimeout: time.Second, graceTime: time.Second, globalTimeout: 5 * time.Second,
+				expectRequests: 2,
+				expectError:    nil,
+			},
+			{
+				name:          "retries more than once",
+				handler:       afterAttempts(emptyJSON(http.StatusGatewayTimeout), 2, emptyJSON(http.StatusOK)),
+				scriptTimeout: time.Second, graceTime: time.Second, globalTimeout: 5 * time.Second,
+				expectRequests: 3,
+				expectError:    nil,
+			},
+			{
+				name:          "gives up eventually",
+				handler:       emptyJSON(http.StatusServiceUnavailable),
+				scriptTimeout: time.Second, graceTime: time.Second, globalTimeout: 5 * time.Second,
+				// Context is forced to timeout after 5 seconds. This means 3 requests, with delays of 0, [1-2), [2-3), as
+				// the fourth request would need to wait [3-4) seconds after [3-5) have passed, thus guaranteed to
+				// go beyond the 5s deadline.
+				expectRequests: 3,
+				expectError:    context.DeadlineExceeded,
+			},
+			{
+				name:          "gives up eventually when server hangs",
+				handler:       delay(10*time.Second, emptyJSON(http.StatusServiceUnavailable)),
+				scriptTimeout: time.Second, graceTime: time.Second, globalTimeout: 5 * time.Second,
+				// Requests have 2s timeout and 0s backoff after that (backoff includes timeout in
+				// this implementation), so that means requests are made at the 0s, 2s and 4s marks. A fourth request
+				// would happen beyond the 5s timeline.
+				expectRequests: 3,
+				expectError:    context.DeadlineExceeded,
+			},
+		} {
+			tc := tc
+
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				// Use atomic as we write to this in a handler and read from in on the test.
+				// go test -race trips if we use a regular int here.
+				var requests atomic.Int64
+
+				mux := http.NewServeMux()
+				mux.HandleFunc("/run", func(w http.ResponseWriter, r *http.Request) {
+					requests.Add(1)
+					tc.handler.ServeHTTP(w, r)
+				})
+				srv := httptest.NewServer(mux)
+				t.Cleanup(srv.Close)
+
+				runner := HttpRunner{url: srv.URL + "/run", graceTime: tc.graceTime, backoff: time.Second}
+				processor, err := NewProcessor(Script{Script: nil, Settings: Settings{tc.scriptTimeout.Milliseconds()}}, runner)
+				require.NoError(t, err)
+
+				baseCtx, baseCancel := context.WithTimeout(context.Background(), tc.globalTimeout)
+				t.Cleanup(baseCancel)
+				ctx, cancel := testhelper.Context(baseCtx, t)
+				t.Cleanup(cancel)
+
+				var (
+					registry = prometheus.NewRegistry()
+					logger   testLogger
+					zlogger  = zerolog.New(io.Discard)
+				)
+				success, err := processor.Run(ctx, registry, &logger, zlogger)
+				require.ErrorIs(t, err, tc.expectError)
+				require.Equal(t, tc.expectError == nil, success)
+				require.Equal(t, tc.expectRequests, requests.Load())
+			})
+		}
+	})
+
+	t.Run("retries network errors", func(t *testing.T) {
+		t.Parallel()
+
+		mux := http.NewServeMux()
+		mux.Handle("/run", emptyJSON(http.StatusOK))
+
+		// TODO: Hand-picking a random port instead of letting the OS allocate one is terrible practice. However,
+		// I haven't found a way to do this if we really want to know the address before something is listening on it.
+		addr := net.JoinHostPort("localhost", strconv.Itoa(30000+rand.Intn(35535)))
+		go func() {
+			time.Sleep(time.Second)
+
+			listener, err := net.Listen("tcp4", addr)
+			if err != nil {
+				t.Logf("failed to set up listener in a random port. You were really unlucky, run the test again. %v", err)
+				t.Fail()
+			}
+
+			err = http.Serve(listener, mux)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				listener.Close()
+			})
+		}()
+
+		runner := HttpRunner{url: "http://" + addr + "/run", graceTime: time.Second, backoff: time.Second}
+		processor, err := NewProcessor(Script{Script: nil, Settings: Settings{Timeout: 1000}}, runner)
+		require.NoError(t, err)
+
+		baseCtx, baseCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(baseCancel)
+		ctx, cancel := testhelper.Context(baseCtx, t)
+		t.Cleanup(cancel)
+
+		var (
+			registry = prometheus.NewRegistry()
+			logger   testLogger
+			zlogger  = zerolog.New(io.Discard)
+		)
+		success, err := processor.Run(ctx, registry, &logger, zlogger)
+		require.NoError(t, err)
+		require.True(t, success)
+	})
+}
+
+func emptyJSON(status int) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte("{}"))
+	})
+}
+
+// afterAttempts invokes the first handler if strictly less than [afterAttempts] requests have been made before to it.
+// afterAttempts(a, 0, b) always invokes b.
+// afterAttempts(a, 1, b) always invokes a for the first request, then b for the subsequent ones.
+func afterAttempts(a http.Handler, afterAttempts int, b http.Handler) http.Handler {
+	pastAttempts := 0
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if pastAttempts >= afterAttempts {
+			b.ServeHTTP(w, r)
+			return
+		}
+
+		a.ServeHTTP(w, r)
+		pastAttempts++
+	})
+}
+
+// delay calls next after some time has passed. It watches for incoming request context cancellation to avoid leaking
+// connections.
+func delay(d time.Duration, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Fully consume the request body before waiting. If we do not do this, cancelling the request context will not
+		// close the network connection, and httptest.Server will complain.
+		_, _ = io.Copy(io.Discard, r.Body)
+
+		select {
+		case <-r.Context().Done():
+			// Abort waiting if the client closes the request. Again, if we don't, httptest.Server will complain.
+		case <-time.After(d):
+			next.ServeHTTP(w, r)
+		}
+	})
 }
 
 type testRunner struct {

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -47,6 +47,9 @@ func TestNewScript(t *testing.T) {
 	runner := New(RunnerOpts{Uri: "k6"})
 	script := Script{
 		Script: []byte("test"),
+		Settings: Settings{
+			Timeout: 1000,
+		},
 	}
 
 	processor, err := NewProcessor(script, runner)
@@ -62,7 +65,12 @@ func TestScriptRun(t *testing.T) {
 		logs:    testhelper.MustReadFile(t, "testdata/test.log"),
 	}
 
-	processor, err := NewProcessor(Script{Script: testhelper.MustReadFile(t, "testdata/test.js")}, &runner)
+	processor, err := NewProcessor(Script{
+		Script: testhelper.MustReadFile(t, "testdata/test.js"),
+		Settings: Settings{
+			Timeout: 1000,
+		},
+	}, &runner)
 	require.NoError(t, err)
 	require.NotNil(t, processor)
 
@@ -341,7 +349,12 @@ func TestScriptHTTPRun(t *testing.T) {
 			t.Cleanup(srv.Close)
 
 			runner := New(RunnerOpts{Uri: srv.URL + "/run"})
-			script, err := NewProcessor(Script{Script: []byte("tee-hee")}, runner)
+			script, err := NewProcessor(Script{
+				Script: []byte("tee-hee"),
+				Settings: Settings{
+					Timeout: 1000,
+				},
+			}, runner)
 			require.NoError(t, err)
 
 			baseCtx, baseCancel := context.WithTimeout(context.Background(), time.Second)

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1561,6 +1561,11 @@ func TestScraperCollectData(t *testing.T) {
 						Created:          modifiedTs,
 						Modified:         modifiedTs,
 						Labels:           tc.checkLabels,
+						// [Check.Type] panics if all settings are nil. To work around that, we add an empty, non nil
+						// HTTP settings section.
+						Settings: sm.CheckSettings{
+							Http: &sm.HttpSettings{},
+						},
 					},
 				},
 				probe: sm.Probe{


### PR DESCRIPTION
This PR implements [agent retries for k6 checks](https://docs.google.com/document/d/1kq5xC4izHyJ9WOonS308J8sE3uDG48c6gj4ZPHsWIx4/edit), which cause the agent to retry run for k6-backed checks (MultiHTTP, Scripted and Browser) if they failed *due to infrastructural reasons*. This pr does **not** cause the agent to retry scripts that were executed but failed, for any reason.

The list of errors that will be retried are "documented in go" in the [`HttpRunner.request` function](https://github.com/grafana/synthetic-monitoring-agent/blob/982ccf9561187abbf2d89ba5c0dc7819503a9e82/internal/k6runner/k6runner.go#L414), and can be identified as when `errRetryable` is returned (joined with another error).

In short, errors that are retried are:
- Errors _making_ a request to the hosted runner: Timeout, name resolution, connection closed, etc.
- Status codes _except_: 200, 400, 408, 422, 500.

Retries are performed with linear backoff until:
- The request succeeds
- The request fails with a non-retryable error
- The next execution of the script is due, which is carried by the context deadline.

There is currently no maximum amount of retries, but backoff is reasonably high (10s, increasing linearly) so hopefully this won't DoS the hosted runners.

Loose ends, which may or may not be addressed in this PR depending on reviewer feedback:
- [ ] "E2E" test, where retries (or non retries) are tested across the stack. Test currently cover from the k6 processor downwards.
- [ ] Mechanisms to respect potential signals from the backend to stop retrying.