### PR TITLE
Fix: deprecate --features and warn user

### DIFF
--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -9,7 +9,10 @@ import (
 )
 
 // TODO: this doesn't seem like the right place for this
-const K6 = "k6"
+const (
+	Traceroute = "traceroute"
+	K6         = "k6"
+)
 
 // ErrInvalidCollection is returned when you try to set a flag in an
 // invalid collection.


### PR DESCRIPTION
Allow the `--features` flag to be present when running the agent, but keep it defunct and warn users that it's deprecated.