### PR TITLE
Create `k6runner.Script` and make probers aware of it

### DIFF
--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -419,7 +419,7 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (noopRunner) Run(ctx context.Context, script []byte) (*k6runner.RunResponse, error) {
+func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }
 

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -61,13 +61,13 @@ func (r *LocalRunner) withOpts(opts RunnerOpts) {
 	}
 }
 
-type Script struct {
+type Processor struct {
 	runner Runner
 	script []byte
 }
 
-func NewScript(script []byte, k6runner Runner) (*Script, error) {
-	r := Script{
+func NewProcessor(script []byte, k6runner Runner) (*Processor, error) {
+	r := Processor{
 		runner: k6runner,
 		script: script,
 	}
@@ -80,7 +80,7 @@ var (
 	ErrFromRunner  = errors.New("runner reported an error")
 )
 
-func (r Script) Run(ctx context.Context, registry *prometheus.Registry, logger logger.Logger, internalLogger zerolog.Logger) (bool, error) {
+func (r Processor) Run(ctx context.Context, registry *prometheus.Registry, logger logger.Logger, internalLogger zerolog.Logger) (bool, error) {
 	k6runner := r.runner.WithLogger(&internalLogger)
 
 	result, err := k6runner.Run(ctx, r.script)

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -38,7 +38,7 @@ func TestNew(t *testing.T) {
 func TestNewScript(t *testing.T) {
 	runner := New(RunnerOpts{Uri: "k6"})
 	src := []byte("test")
-	script, err := NewScript(src, runner)
+	script, err := NewProcessor(src, runner)
 	require.NoError(t, err)
 	require.NotNil(t, script)
 	require.Equal(t, src, script.script)
@@ -51,7 +51,7 @@ func TestScriptRun(t *testing.T) {
 		logs:    testhelper.MustReadFile(t, "testdata/test.log"),
 	}
 
-	script, err := NewScript(testhelper.MustReadFile(t, "testdata/test.js"), &runner)
+	script, err := NewProcessor(testhelper.MustReadFile(t, "testdata/test.js"), &runner)
 	require.NoError(t, err)
 	require.NotNil(t, script)
 
@@ -278,7 +278,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			t.Cleanup(srv.Close)
 
 			runner := New(RunnerOpts{Uri: srv.URL + "/run"})
-			script, err := NewScript([]byte("tee-hee"), runner)
+			script, err := NewProcessor([]byte("tee-hee"), runner)
 			require.NoError(t, err)
 
 			baseCtx, baseCancel := context.WithTimeout(context.Background(), time.Second)

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -26,7 +26,7 @@ type Module struct {
 type Prober struct {
 	logger zerolog.Logger
 	config Module
-	script *k6runner.Script
+	script *k6runner.Processor
 }
 
 func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runner k6runner.Runner, reservedHeaders http.Header) (Prober, error) {
@@ -53,7 +53,7 @@ func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runne
 		return p, err
 	}
 
-	k6Script, err := k6runner.NewScript(script, runner)
+	k6Script, err := k6runner.NewProcessor(script, runner)
 	if err != nil {
 		return p, err
 	}

--- a/internal/prober/multihttp/multihttp_test.go
+++ b/internal/prober/multihttp/multihttp_test.go
@@ -131,8 +131,8 @@ func TestNewProber(t *testing.T) {
 			require.Equal(t, requestHeaders[0].Value, fmt.Sprintf("%d-%d", checkId, checkId))
 
 			require.NoError(t, err)
-			require.Equal(t, proberName, p.config.Prober)
-			require.Equal(t, 10*time.Second, p.config.Timeout)
+			require.Equal(t, proberName, p.module.Prober)
+			require.Equal(t, 10*time.Second, time.Duration(p.module.Script.Settings.Timeout)*time.Millisecond)
 			// TODO: check script
 		})
 	}
@@ -145,6 +145,6 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (noopRunner) Run(ctx context.Context, script []byte) (*k6runner.RunResponse, error) {
+func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -25,7 +25,7 @@ type Module struct {
 type Prober struct {
 	logger zerolog.Logger
 	config Module
-	script *k6runner.Script
+	script *k6runner.Processor
 }
 
 func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runner k6runner.Runner) (Prober, error) {
@@ -39,7 +39,7 @@ func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runne
 	timeout := time.Duration(check.Timeout) * time.Millisecond
 	p.config.Timeout = timeout
 
-	script, err := k6runner.NewScript(check.Settings.Scripted.Script, runner)
+	script, err := k6runner.NewProcessor(check.Settings.Scripted.Script, runner)
 	if err != nil {
 		return p, err
 	}

--- a/internal/prober/scripted/scripted_test.go
+++ b/internal/prober/scripted/scripted_test.go
@@ -59,9 +59,9 @@ func TestNewProber(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.Equal(t, proberName, p.config.Prober)
-			require.Equal(t, 10*time.Second, p.config.Timeout)
-			require.Equal(t, tc.check.Settings.Scripted.Script, p.config.Script)
+			require.Equal(t, proberName, p.module.Prober)
+			require.Equal(t, 10*time.Second, time.Duration(p.module.Script.Settings.Timeout)*time.Millisecond)
+			require.Equal(t, tc.check.Settings.Scripted.Script, p.module.Script.Script)
 		})
 	}
 }
@@ -73,7 +73,7 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (noopRunner) Run(ctx context.Context, script []byte) (*k6runner.RunResponse, error) {
+func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }
 

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1685,7 +1685,7 @@ type testRunner struct {
 
 var _ k6runner.Runner = &testRunner{}
 
-func (r *testRunner) Run(ctx context.Context, script []byte) (*k6runner.RunResponse, error) {
+func (r *testRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{
 		Metrics: r.metrics,
 		Logs:    r.logs,


### PR DESCRIPTION
Before this PR, `MultiHTTP` and `Scripted` `Prober`s created k6 runners using only the raw script data (`[]byte`) as input to the runner. This have worked nicely, as until now runners only required two things to work: The raw script data, and a timeout that was encoded in the context for `Runner.Run()`.

We have seen however a couple scenarios that make me think this is not enough for the near future:
- We want to decouple the context from `Runner.Run()`, a.k.a. the request timeout, from the check timeout that is communicated to the runners. This is needed to properly implement what #715 workarounded.
- We want to make k6 runners aware of some check metadata, for troubleshooting. https://github.com/grafana/sm-k6-runner/pull/191 worked around this using a hash, but it's not ideal.
- We want to be able to implement different queues for browser and non-browser scripts (https://github.com/grafana/sm-k6-runner/issues/174). We tentatively want to do this by extracting script features (https://github.com/grafana/sm-k6-archiver/pull/22), which will eventually need to be sent to the runners.

For these three reasons, I think it is beneficial to create a richer type so that `Prober`s can feed all these details to the k6 runner, which this PR does.

Please note that this PR is not feature complete, namely how timeouts are handled does not fully makes sense. This is because I tried to keep the patchset as small as possible for reviewability. How timeouts are handled is improved in #724.