### PR TITLE
Release v0.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 ## [Unreleased]
 
 
+<a name="v0.24.2"></a>
+## [v0.24.2] - 2024-06-10
+### Fix
+- deprecate --features and warn user ([#726](https://github.com/grafana/synthetic-monitoring-agent/issues/726))
+- Interpolate variables into MultiHTTP request bodies ([#713](https://github.com/grafana/synthetic-monitoring-agent/issues/713))
+
+### K6runner
+- use check context for http request ([#715](https://github.com/grafana/synthetic-monitoring-agent/issues/715))
+
+
 <a name="v0.24.1"></a>
 ## [v0.24.1] - 2024-04-30
 ### Fix
@@ -65,11 +75,6 @@
 
 ### Fix
 - missing http check regex validations ([#612](https://github.com/grafana/synthetic-monitoring-agent/issues/612))
-
-
-<a name="v0.20.1"></a>
-## [v0.20.1] - 2024-02-12
-### Fix
 - add test for HTTP check with a long URL
 
 
@@ -610,7 +615,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.1...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.2...HEAD
+[v0.24.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.1...v0.24.2
 [v0.24.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.0...v0.24.1
 [v0.24.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.4...v0.24.0
 [v0.23.4]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.3...v0.23.4
@@ -619,8 +625,7 @@
 [v0.23.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.0...v0.23.1
 [v0.23.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.22.0...v0.23.0
 [v0.22.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.21.0...v0.22.0
-[v0.21.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.20.1...v0.21.0
-[v0.20.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.6...v0.20.1
+[v0.21.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.6...v0.21.0
 [v0.19.6]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.5...v0.19.6
 [v0.19.5]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.4...v0.19.5
 [v0.19.4]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.3...v0.19.4


### PR DESCRIPTION
* Chore(deps): Bump golang.org/x/net from 0.24.0 to 0.25.0
* Chore(deps): Bump the prometheus-go group across 1 directory with 2 updates
* Chore(deps): Bump github.com/mccutchen/go-httpbin/v2
* Update to grafana-build-tools v0.11.0 (#705)
* Remove adhoc and traceroute feature flags. (#707)
* Chore(deps): Bump github.com/KimMachineGun/automemlimit
* checks/test: make timer big enough for context cancel to be picked up
* Fix: Interpolate variables into MultiHTTP request bodies (#713)
* Chore(deps): Bump github.com/prometheus/prometheus (#716)
* Chore(deps): Bump github.com/rs/zerolog from 1.32.0 to 1.33.0
* --- updated-dependencies: - dependency-name: kernel.org/pub/linux/libs/security/libcap/cap   dependency-type: direct:production   update-type: version-update:semver-patch ...
* MultiHttp script should decode the payload as a string and replace the variable placeholders with the values. The result should be assigned to the request body. (#717)
* Build(deps): Bump golang.org/x/net from 0.25.0 to 0.26.0
* Enable K6 by default in agent deployments (#722)
* Fix: deprecate --features and warn user (#726)
* k6runner: use check context for http request (#715)