### PR TITLE
k6runner: apply empty IP denylist even if it is empty

### DIFF
--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -60,20 +60,12 @@ func New(opts RunnerOpts) Runner {
 		r = &LocalRunner{
 			k6path:        opts.Uri,
 			logger:        &logger,
+			blacklistedIP: opts.BlacklistedIP,
 			fs:            afero.NewOsFs(),
-			blacklistedIP: "10.0.0.0/8",
 		}
-
-		r.(*LocalRunner).withOpts(opts)
 	}
 
 	return r
-}
-
-func (r *LocalRunner) withOpts(opts RunnerOpts) {
-	if opts.BlacklistedIP != "" {
-		r.blacklistedIP = opts.BlacklistedIP
-	}
 }
 
 // Processor runs a script with a runner and parses the k6 output.

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -57,7 +57,7 @@ func New(opts RunnerOpts) Runner {
 			logger: &logger,
 		}
 	} else {
-		r = &LocalRunner{
+		r = LocalRunner{
 			k6path:        opts.Uri,
 			logger:        &logger,
 			blacklistedIP: opts.BlacklistedIP,

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -393,11 +393,8 @@ type LocalRunner struct {
 }
 
 func (r LocalRunner) WithLogger(logger *zerolog.Logger) Runner {
-	return LocalRunner{
-		k6path: r.k6path,
-		fs:     r.fs,
-		logger: logger,
-	}
+	r.logger = logger
+	return r
 }
 
 func (r LocalRunner) Run(ctx context.Context, script Script) (*RunResponse, error) {

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -25,7 +25,7 @@ import (
 func TestNew(t *testing.T) {
 	r1 := New(RunnerOpts{Uri: "k6"})
 	require.IsType(t, &LocalRunner{}, r1)
-	require.Equal(t, "10.0.0.0/8", r1.(*LocalRunner).blacklistedIP)
+	require.Equal(t, "", r1.(*LocalRunner).blacklistedIP)
 	r2 := New(RunnerOpts{Uri: "/usr/bin/k6", BlacklistedIP: "192.168.4.0/24"})
 	require.IsType(t, &LocalRunner{}, r2)
 	require.Equal(t, "192.168.4.0/24", r2.(*LocalRunner).blacklistedIP)

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -30,6 +30,10 @@ func TestNew(t *testing.T) {
 	r2 := New(RunnerOpts{Uri: "/usr/bin/k6", BlacklistedIP: "192.168.4.0/24"})
 	require.IsType(t, LocalRunner{}, r2)
 	require.Equal(t, "192.168.4.0/24", r2.(LocalRunner).blacklistedIP)
+	// Ensure WithLogger preserves config.
+	zl := zerolog.New(io.Discard)
+	r2 = r2.WithLogger(&zl)
+	require.Equal(t, "192.168.4.0/24", r2.(LocalRunner).blacklistedIP)
 
 	r3 := New(RunnerOpts{Uri: "http://localhost:6565"})
 	require.IsType(t, &HttpRunner{}, r3)

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -24,11 +24,13 @@ import (
 
 func TestNew(t *testing.T) {
 	r1 := New(RunnerOpts{Uri: "k6"})
-	require.IsType(t, &LocalRunner{}, r1)
-	require.Equal(t, "", r1.(*LocalRunner).blacklistedIP)
+	require.IsType(t, LocalRunner{}, r1)
+	require.Equal(t, "", r1.(LocalRunner).blacklistedIP)
+
 	r2 := New(RunnerOpts{Uri: "/usr/bin/k6", BlacklistedIP: "192.168.4.0/24"})
-	require.IsType(t, &LocalRunner{}, r2)
-	require.Equal(t, "192.168.4.0/24", r2.(*LocalRunner).blacklistedIP)
+	require.IsType(t, LocalRunner{}, r2)
+	require.Equal(t, "192.168.4.0/24", r2.(LocalRunner).blacklistedIP)
+
 	r3 := New(RunnerOpts{Uri: "http://localhost:6565"})
 	require.IsType(t, &HttpRunner{}, r3)
 	r4 := New(RunnerOpts{Uri: "https://localhost:6565"})


### PR DESCRIPTION
Before this PR, `withOpts` checked if the IP denylist at `opts.BlacklistedIP` was empty, and if it was, it didn't override the default value (`10.0.0.0/8`). Unfortunately, this effectively prevented from clearning that default, as specifying `--blocked-nets=""` would cause `opts.BlacklistedIP` to become the empty string, which will not be applied over the default.

To prevent having two defaults (cli flag and in-constructor), with the constructor one being always ignored, this PR gets rid of the constructor default.

The changes here should not cause any functional change, as `blocked-nets` defaults to `10.0.0.0/8` either way in the CLI code: https://github.com/grafana/synthetic-monitoring-agent/blob/7123e22162573d5ff1b83649aca571dd7f0479b9/cmd/synthetic-monitoring-agent/main.go#L80

Additionally, this PR fixes a bug that made this change ineffective when `WithLogger` was called on the local runner, as doing so would not copy the IP denylist.

Finally, having a mixture of pointer and non-pointer returns for LocalRunner was making testing hard. This PR also uniforms to non-pointer runners everywhere.

Related to: https://github.com/grafana/synthetic-monitoring-agent/issues/730