### PR TITLE
Release v0.24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,23 @@
 ## [Unreleased]
 
 
+<a name="v0.24.3"></a>
+## [v0.24.3] - 2024-06-18
+### K6runner
+- prevent clearing ip denylist when calling WithLogger
+- use non-pointer LocalRunner everywhere
+- apply empty IP denylist even if it is empty
+- rename Script to Processor
+
+### Prober
+- log errors returned by k6-backed probes as errors
+
+### Scraper
+- formatting
+
+
 <a name="v0.24.2"></a>
-## [v0.24.2] - 2024-06-10
+## [v0.24.2] - 2024-06-13
 ### Fix
 - deprecate --features and warn user ([#726](https://github.com/grafana/synthetic-monitoring-agent/issues/726))
 - Interpolate variables into MultiHTTP request bodies ([#713](https://github.com/grafana/synthetic-monitoring-agent/issues/713))
@@ -22,6 +37,7 @@
 ## [v0.24.0] - 2024-04-30
 ### Feature
 - automatically set up GOMEMLIMIT ([#691](https://github.com/grafana/synthetic-monitoring-agent/issues/691))
+- upgrade k6 to v0.50.0 ([#681](https://github.com/grafana/synthetic-monitoring-agent/issues/681))
 
 ### Fix
 - use uniform timeout validation logic ([#693](https://github.com/grafana/synthetic-monitoring-agent/issues/693))
@@ -30,12 +46,6 @@
 ### K6runner
 - inspect errors and propagate unexpected ones to the probe
 - handle errors reported by http runners
-
-
-<a name="v0.23.4"></a>
-## [v0.23.4] - 2024-04-17
-### Feature
-- upgrade k6 to v0.50.0 ([#681](https://github.com/grafana/synthetic-monitoring-agent/issues/681))
 
 
 <a name="v0.23.3"></a>
@@ -615,11 +625,11 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.2...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.3...HEAD
+[v0.24.3]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.2...v0.24.3
 [v0.24.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.1...v0.24.2
 [v0.24.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.0...v0.24.1
-[v0.24.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.4...v0.24.0
-[v0.23.4]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.3...v0.23.4
+[v0.24.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.3...v0.24.0
 [v0.23.3]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.2...v0.23.3
 [v0.23.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.1...v0.23.2
 [v0.23.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.0...v0.23.1


### PR DESCRIPTION
The main user-facing change for this release is a partial fix for #730

---

* Build(deps): Bump github.com/miekg/dns from 1.1.59 to 1.1.61
* k6runner: rename Script to Processor
* create k6runner.Script and make probers aware of it
* scraper: formatting
* prober: log errors returned by k6-backed probes as errors
* k6runner/test: fail if the wrong endpoint is hit
* k6runner: apply empty IP denylist even if it is empty
* k6runner: use non-pointer LocalRunner everywhere
* k6runner: prevent clearing ip denylist when calling WithLogger