### PR TITLE
bump k6 version using renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    ":semanticCommitsDisabled",
+  ],
+  "enabledManagers": ["custom.regex"], // We use renovate for things that dependabot cannot handle only.
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "grafana/k6",
+      "fileMatch": [".*\\.mk"],
+      "matchStrings": [
+        'K6_VERSION\\s+:=\\s+(?<currentValue>.+)\\s*', // Use single quotes _and_ two backslashes.
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
Doing this by hand is tiring. Renovate is configured to not bump anything else, so we keep working with dependabot as we are used to.

This yields PRs like https://github.com/roobre/grafana-synthetic-monitoring-agent/pull/3