### PR TITLE
k6runner/test: ensure logs are sent to loki when runner reports user errors

### DIFF
--- a/internal/k6runner/testdata/test.log
+++ b/internal/k6runner/testdata/test.log
@@ -44,3 +44,4 @@ time="2023-06-01T13:40:26-06:00" level=debug msg=Stopping... component=metrics-e
 time="2023-06-01T13:40:26-06:00" level=debug msg="Stopped!" component=metrics-engine-ingester
 time="2023-06-01T13:40:26-06:00" level=debug msg="Generating the end-of-test summary..."
 time="2023-06-01T13:40:26-06:00" level=debug msg="Everything has finished, exiting k6 normally!"
+time="2023-06-01T13:40:26-06:00" level=test msg="Non-debug message, for testing!"


### PR DESCRIPTION
Doesn't actually fix, but related to https://github.com/grafana/synthetic-monitoring-app/issues/835.

When running a script on a remote runner, roughly two kind of errors can occur:
1. An error occurs reaching the remote runner, meaning that the script could not be scheduled. kan example of this can be network errors reaching our infra.
2. The script was executed, and it returned an error. In this case the runner returns the k6 error log as a part of the response body.

This PR adds tests asserting that those errors in the response body (2) are sent to Loki regardless of the reported `errorCode`.