### PR TITLE
k6runner: send logs even if metrics are malformed

### DIFF
--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -99,6 +99,14 @@ func (r Processor) Run(ctx context.Context, registry *prometheus.Registry, logge
 		return false, err
 	}
 
+	// Send logs before metrics to make sure logs are submitted even if the metrics output is not parsable.
+	if err := k6LogsToLogger(result.Logs, logger); err != nil {
+		internalLogger.Debug().
+			Err(err).
+			Msg("cannot load logs to logger")
+		return false, err
+	}
+
 	var (
 		collector       sampleCollector
 		resultCollector checkResultCollector
@@ -115,13 +123,6 @@ func (r Processor) Run(ctx context.Context, registry *prometheus.Registry, logge
 		internalLogger.Error().
 			Err(err).
 			Msg("cannot register collector")
-		return false, err
-	}
-
-	if err := k6LogsToLogger(result.Logs, logger); err != nil {
-		internalLogger.Debug().
-			Err(err).
-			Msg("cannot load logs to logger")
 		return false, err
 	}
 


### PR DESCRIPTION
Another step towards https://github.com/grafana/synthetic-monitoring-app/issues/835.

When https://github.com/grafana/sm-k6-runner/pull/208 is merged, there is a theoretical possibility of the logs and/or metrics returned by the runner to be malformed, for example is k6 is killed while it is writing its output.

This PR adds tests for that case, ensuring that:
- Receiving borked metrics triggers an error
- Receiving borked metrics still causes logs to be sent, and the execution to be marked as failure.