### PR TITLE
Correct the listen address to scrape metrics to port 4050

### DIFF
--- a/scripts/package/config/systemd/synthetic-monitoring-agent.conf
+++ b/scripts/package/config/systemd/synthetic-monitoring-agent.conf
@@ -8,7 +8,7 @@ API_SERVER='synthetic-monitoring-grpc.grafana.net:443'
 API_INSECURE="false"
 
 # listen address for /metrics and /debug/pprof
-LISTEN_ADDRESS="127.0.0.1:4031"
+LISTEN_ADDRESS="127.0.0.1:4050"
 
 # verbose logging
 VERBOSE="false"


### PR DESCRIPTION
@alexwulf noticed agent installations are using port `4031` to serve `/metrics`.

Our default in the docs ([A](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/#production-deployments), [B](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/#troubleshooting-private-probes)) and the code ([ref](https://github.com/grafana/synthetic-monitoring-agent/blob/main/cmd/synthetic-monitoring-agent/main.go#L78)) is `4050`. We should align the config file to this.