### PR TITLE
Split and fix renovate config

### DIFF
--- a/.github/renovate-selfhosted.json
+++ b/.github/renovate-selfhosted.json
@@ -1,0 +1,7 @@
+{
+  "username": "GrafanaRenovateBot",
+  "platform": "github",
+  "repositories": [
+    "grafana/synthetic-monitoring-agent"
+  ]
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,7 +37,8 @@
     {
       // Update grafana-build-tools tags across the repository.
       "customType": "regex",
-      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "ghcr.io/grafana/grafana-build-tools",
+      "datasourceTemplate": "docker",
       "versioningTemplate": "semver",
       "fileMatch": [
         "^\\.github/workflows/.*\\.ya?ml$",
@@ -46,7 +47,7 @@
         ".*\\.mk$"
       ],
       "matchStrings": [
-        "\\bghcr\\.io/(?<depName>grafana/grafana-build-tools):(?<currentValue>\\S+)\\b"
+        "ghcr.io/grafana/grafana-build-tools:(?<currentValue>\\S+)"
       ]
     }
   ]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,10 +5,13 @@
     ":semanticCommitsDisabled"
   ],
 
+
   "branchPrefix": "grafanarenovatebot/",
-  "gitAuthor": "GrafanaRenovateBot <renovategrafana@grafana.com>",
   // Used when renovate runs as a github app.
   // https://docs.renovatebot.com/configuration-options/#platformcommit
+  // Setting platformCommit to `true`, as required by Grafana policy, seems to make renovate think all PRs are modified,
+  // as the dynamic author configured by github does not match the author set in `gitAuthor`. It is recommended to
+  // leave it unset: https://github.com/renovatebot/renovate/discussions/29106.
   "platformCommit": true,
   "dependencyDashboard": false,
   "forkProcessing": "disabled",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,19 +6,15 @@
   ],
 
   "branchPrefix": "grafanarenovatebot/",
-  "username": "GrafanaRenovateBot",
   "gitAuthor": "GrafanaRenovateBot <renovategrafana@grafana.com>",
+  // Used when renovate runs as a github app.
+  // https://docs.renovatebot.com/configuration-options/#platformcommit
   "platformCommit": true,
   "dependencyDashboard": false,
-  "platform": "github",
   "forkProcessing": "disabled",
 
-  "repositories": [
-    "grafana/synthetic-monitoring-agent"
-  ],
-
+  // TODO: We should be able to use the defaults if we turn dependabot off.
   "enabledManagers": ["custom.regex", "gomod"],
-
   "gomod": {
     "enabled": true
   },
@@ -29,6 +25,7 @@
 
   "customManagers": [
     {
+      // Update k6 version in Dockerfiles.
       "customType": "regex",
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "grafana/k6",
@@ -38,6 +35,7 @@
       ]
     },
     {
+      // Update grafana-build-tools tags across the repository.
       "customType": "regex",
       "datasourceTemplate": "github-tags",
       "versioningTemplate": "semver",

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -23,5 +23,5 @@ jobs:
         uses: renovatebot/github-action@21d88b0bf0183abcee15f990011cca090dfc47dd # v40.1.12
         with:
           renovate-version: 37.420.1@sha256:528f003c9aa77f6e916e3f9f5cc2fb9ae16fcf285af66f412a34325124f4a00e
-          configurationFile: .github/renovate.json
+          configurationFile: .github/renovate-selfhosted.json
           token: '${{ steps.generate-token.outputs.token }}'


### PR DESCRIPTION
When selfhosted, renovate requires a separate config file ([ref](https://docs.renovatebot.com/self-hosted-configuration/)). This PR splits out self-hosted options to a different file, and points renovate itself to it. Additionally:
- Migrates repo config to json5 (as it allows comments)
- Simplifies the regex looking for grafana-build-tools container image
- Removes `gitAuthor`, so renovate can rebase PRs created by itself with `platformCommit` (https://github.com/renovatebot/renovate/discussions/29106)