### PR TITLE
Add CheckSettings validation case for browser

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -563,6 +563,11 @@ func (s CheckSettings) Validate() error {
 		validateFn = s.Grpc.Validate
 	}
 
+	if s.Browser != nil {
+		settingsCount++
+		validateFn = s.Browser.Validate
+	}
+
 	if settingsCount != 1 {
 		return ErrInvalidCheckSettings
 	}


### PR DESCRIPTION
We were getting `invalid check settings` error message when trying to create a browser check.  I believe it's because we're missed a case in the CheckSettings validation