### PR TITLE
k6runner: log errors encountered by logfmt parser

### DIFF
--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -301,7 +301,7 @@ NEXT_RECORD:
 		_ = logger.Log(line...)
 	}
 
-	return nil
+	return dec.Err()
 }
 
 type HttpRunner struct {

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logfmt/logfmt"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
 	"github.com/grafana/synthetic-monitoring-agent/internal/testhelper"
 	"github.com/prometheus/client_golang/prometheus"
@@ -254,7 +255,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			},
 			statusCode:    http.StatusUnprocessableEntity,
 			expectSuccess: false,
-			expectError:   nil,
+			expectErrorAs: &logfmt.SyntaxError{},
 			expectLogs:    `level="error"` + "\n",
 		},
 		{
@@ -267,7 +268,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			},
 			statusCode:    http.StatusUnprocessableEntity,
 			expectSuccess: false,
-			expectErrorAs: &expfmt.ParseError{},
+			expectErrorAs: expfmt.ParseError{},
 			expectLogs:    nonDebugLogLine,
 		},
 		{

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -345,7 +345,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			if tc.expectErrorAs == nil {
 				require.ErrorIs(t, err, tc.expectError)
 			} else {
-				require.ErrorAs(t, err, tc.expectErrorAs)
+				require.ErrorAs(t, err, &tc.expectErrorAs)
 			}
 		})
 	}


### PR DESCRIPTION
Quick nit found while researching https://github.com/grafana/synthetic-monitoring/issues/55. We were not logging errors encountered while parsing log output.