### PR TITLE
Default to `sm-k6` binary instead of `k6`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH
 
 COPY dist/${HOST_DIST}/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
-COPY dist/${HOST_DIST}/k6 /usr/local/bin/k6
+COPY dist/${HOST_DIST}/k6 /usr/local/bin/sm-k6
 COPY scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -76,7 +76,7 @@ func run(args []string, stdout io.Writer) error {
 		}{
 			GrpcApiServerAddr: "localhost:4031",
 			HttpListenAddr:    "localhost:4050",
-			K6URI:             "k6",
+			K6URI:             "sm-k6",
 			K6BlacklistedIP:   "10.0.0.0/8",
 			SelectedPublisher: pusherV2.Name,
 			TelemetryTimeSpan: defTelemetryTimeSpan,
@@ -433,7 +433,6 @@ func setupGoMemLimit(ratio float64) error {
 			),
 		),
 	)
-
 	if err != nil {
 		return fmt.Errorf("failed to set GOMEMLIMIT: %w", err)
 	}


### PR DESCRIPTION
As described in: https://github.com/grafana/support-escalations/issues/11346#issuecomment-2213578649

For non-docker installations, we ship a `sm-k6` binary with the required sm extension that we must use. However, this binary is never looked up, and instead we default to a `k6` binary in the system which may not have the required extension, resulting in obscure failures with exit code 255.

This PR changes the default value to `sm-k6`, and adjusts the Dockerfile so the `k6` binary is copied inside with this name.

https://github.com/grafana/synthetic-monitoring-agent/compare/look-sm-k6-first is an alternative to this, but I'm leaning towards this impl for simplicity.