### PR TITLE
renovate: add workflow to validate config

### DIFF
--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -1,6 +1,8 @@
 name: Validate renovate config
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - '**renovate*.*'
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since we don't use neither the dependency dashboard, nor the SaaS renovate, it may become hard to know if we introduce modifications to the renovate config that do not make sense.

This PR adds a simple check that runs the `renovate-config-validator` tool to ensure the config is valid.