### PR TITLE
ci/renovate: limit gomod digest updates to once every two weeks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,6 +26,15 @@
     "gomodTidyE"
   ],
 
+  "packageRules" : [
+    {
+      // Non-versioned go modules are noisy, with almost daily updates. We throttle them a bit.
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["digest"],
+      "schedule": "on monday every 2 weeks",
+    },
+  ],
+
   "customManagers": [
     {
       // Update k6 version in Dockerfiles.


### PR DESCRIPTION
Go modules that are not versioned create PRs continuously, e.g.:
- https://github.com/grafana/synthetic-monitoring-agent/pull/781
- https://github.com/grafana/synthetic-monitoring-agent/pull/778

This PR throttles digest-type updates to go modules so they only happen one out of two Mondays.