### PR TITLE
Fix browser check class

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -267,8 +267,11 @@ func (c CheckType) Class() CheckClass {
 	case CheckTypeDns, CheckTypeHttp, CheckTypePing, CheckTypeTcp, CheckTypeTraceroute, CheckTypeGrpc:
 		return CheckClass_PROTOCOL
 
-	case CheckTypeScripted, CheckTypeMultiHttp, CheckTypeBrowser: // TODO(mem): does browser belong here?
+	case CheckTypeScripted, CheckTypeMultiHttp:
 		return CheckClass_SCRIPTED
+
+	case CheckTypeBrowser:
+		return CheckClass_BROWSER
 
 	default:
 		panic("unhandled check class")
@@ -1442,7 +1445,7 @@ func inClosedRange[T constraints.Ordered](v, lower, upper T) bool {
 }
 
 func GetCheckInstance(checkType CheckType) Check {
-	var validCheckCases = map[CheckType]Check{
+	validCheckCases := map[CheckType]Check{
 		CheckTypeDns: {
 			Id:        1,
 			TenantId:  1,

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -503,7 +503,7 @@ func TestCheckClass(t *testing.T) {
 		},
 		CheckTypeBrowser.String(): {
 			input:    GetCheckInstance(CheckTypeBrowser),
-			expected: CheckClass_SCRIPTED, // Is this correct, or does this need to be CheckClass_Browser?
+			expected: CheckClass_BROWSER,
 		},
 	}
 
@@ -612,7 +612,7 @@ func TestCheckTypeClass(t *testing.T) {
 		},
 		CheckTypeBrowser.String(): {
 			input:    CheckTypeBrowser,
-			expected: CheckClass_SCRIPTED, // TODO(mem): is this the correct value?
+			expected: CheckClass_BROWSER,
 		},
 	}
 


### PR DESCRIPTION
Addresses previous TODO comments left in #737 about the correct Check Class for browser checks. After the introduction of a specific browser check class in #787 we can address these comments and make browser checks a class on its own, that is necessary in order to distinguish telemetry from scripted checks.