### PR TITLE
Release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,27 @@
 ## [Unreleased]
 
 
+<a name="v0.25.0"></a>
+## [v0.25.0] - 2024-07-15
+### Cmd
+- default to sm-k6 binary
+
+### Dockerfile
+- copy sm-specific k6 as sm-k6 instead of just k6
+
+### Grpc
+- nolint deprecated grpc options
+
+### Http
+- rename `promconfig.Header` to `promconfig.ProxyHeader`
+
+### K6runner
+- log errors encountered by logfmt parser
+- send logs even if metrics are malformed
+
+
 <a name="v0.24.3"></a>
-## [v0.24.3] - 2024-06-18
+## [v0.24.3] - 2024-06-19
 ### K6runner
 - prevent clearing ip denylist when calling WithLogger
 - use non-pointer LocalRunner everywhere
@@ -625,7 +644,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.3...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.25.0...HEAD
+[v0.25.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.3...v0.25.0
 [v0.24.3]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.2...v0.24.3
 [v0.24.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.1...v0.24.2
 [v0.24.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.0...v0.24.1


### PR DESCRIPTION
* Chore(deps): Bump google.golang.org/grpc from 1.63.2 to 1.64.0
* grpc: nolint deprecated grpc options
* Build(deps): Bump the prometheus-go group across 1 directory with 2 updates
* http: rename `promconfig.Header` to `promconfig.ProxyHeader`
* Add the basic stuff to support a browser check type (#737)
* k6runner/test: ensure logs are sent to loki when runner reports user errors
* k6runner: send logs even if metrics are malformed
* Build(deps): Bump github.com/prometheus/common
* Bump k6 version using renovate (#745)
* Dispatch renovate workflow manually (#746)
* Update renovate (#748)
* Update dependency grafana/k6 to v0.52.0 (#749)
* Fix renovate configuration (#751)
* Update github.com/grafana/loki/pkg/push digest to 04bc3a4 (#752)
* Update module github.com/dmarkham/enumer to v1.5.10 (#754)
* Update module github.com/sirupsen/logrus to v1.9.3 (#755)
* Update module github.com/stretchr/testify to v1.9.0 (#759)
* Update dependency grafana/grafana-build-tools to v0.15.0 (#756)
* Correct the listen address to scrape metrics to port 4050. (#743)
* Build(deps): Bump google.golang.org/grpc from 1.64.0 to 1.65.0
* Update module github.com/securego/gosec to v2
* Split and fix renovate config (#767)
* Update ghcr.io/grafana/grafana-build-tools Docker tag to v0.15.1 (#770)
* add validation case for browser (#773)
* Update module gotest.tools/gotestsum to v1.12.0
* Update module go.k6.io/k6 to v0.52.0
* Update golang.org/x/exp digest to 7f521ea
* Update module golang.org/x/net to v0.27.0 (#775)
* Update module github.com/securego/gosec to v2
* Update module gotest.tools/gotestsum to v1.12.0
* Update module github.com/spf13/afero to v1.11.0 (#758)
* Update module github.com/golangci/golangci-lint to v1.59.1
* Update github.com/grafana/loki/pkg/push digest to 6da364e
* Update module github.com/securego/gosec to v2
* Route browser checks to the browser prober (#780)
* Update module google.golang.org/grpc to v1.65.0 (#761)
* ci/renovate: limit gomod digest updates to once every two weeks (#785)
* Update golang.org/x/exp digest to 46b0784 (#781)
* cmd: default to sm-k6 binary
* Dockerfile: copy sm-specific k6 as sm-k6 instead of just k6
* k6runner/test: pass address of expectErrorAs to errors.As
* k6runner: log errors encountered by logfmt parser
* Update github.com/grafana/loki/pkg/push digest to 7c86e65
* Add browser limits and class (#787)
* Update module github.com/prometheus/prometheus to v0.53.1 (#790)
* Report browser check's class as browser (#788)
* Update github.com/grafana/loki/pkg/push digest to 527510d (#793)
* Update github.com/securego/gosec/v2 digest to 4487a0c