### PR TITLE
ci/renovate: update gomod digests before 8 AM UTC

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,7 +31,7 @@
       // Non-versioned go modules are noisy, with almost daily updates. We throttle them a bit.
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["digest"],
-      "schedule": "on monday every 2 weeks",
+      "schedule": "before 8am on monday every 2 weeks",
     },
   ],
 


### PR DESCRIPTION
Follow up to #785, it seems that these digests may be updated several times per day. This PR further restricts the regex so renovate works during the night and we see the PRs already fresh in the morning.

00 - 8AM UTC should be outside working hours for both EMEA and NASA.