### PR TITLE
feat: Validate browser capability

### DIFF
--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -470,8 +470,11 @@ func (c *Updater) loop(ctx context.Context) (bool, error) {
 }
 
 func (c *Updater) validateProbeCapabilities(capabilities *sm.Probe_Capabilities) error {
-	// k6 is only not required on this probe if explicitly disabled
-	requireK6 := capabilities == nil || !capabilities.DisableScriptedChecks
+	// k6 is required by default unless it has been explicitly disabled from
+	// the API side by forbidding scripted and browser checks execution.
+	requireK6 := capabilities == nil ||
+		!capabilities.DisableScriptedChecks ||
+		!capabilities.DisableBrowserChecks
 
 	if requireK6 && c.k6Runner == nil {
 		return errCapabilityK6Missing

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -269,6 +269,8 @@ func TestHandleCheckOp(t *testing.T) {
 }
 
 func TestCheckHandlerProbeValidation(t *testing.T) {
+	t.Parallel()
+
 	testcases := map[string]struct {
 		opts          UpdaterOptions
 		probe         sm.Probe
@@ -417,6 +419,8 @@ func TestCheckHandlerProbeValidation(t *testing.T) {
 
 	for testName, tc := range testcases {
 		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
 			u, err := NewUpdater(tc.opts)
 			require.NoError(t, err)
 


### PR DESCRIPTION
k6 functionality is required in the agent by default, and is NOT required only in case both, scripted and browser checks, have been disabled for the probe from the API.

Updates: https://github.com/grafana/synthetic-monitoring/issues/116