### PR TITLE
Release v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 ## [Unreleased]
 
 
+<a name="v0.25.1"></a>
+## [v0.25.1] - 2024-07-30
+### K6runner
+- handle ErrorCodeFailed ([#791](https://github.com/grafana/synthetic-monitoring-agent/issues/791))
+
+
 <a name="v0.25.0"></a>
 ## [v0.25.0] - 2024-07-15
 ### Cmd
@@ -56,7 +62,6 @@
 ## [v0.24.0] - 2024-04-30
 ### Feature
 - automatically set up GOMEMLIMIT ([#691](https://github.com/grafana/synthetic-monitoring-agent/issues/691))
-- upgrade k6 to v0.50.0 ([#681](https://github.com/grafana/synthetic-monitoring-agent/issues/681))
 
 ### Fix
 - use uniform timeout validation logic ([#693](https://github.com/grafana/synthetic-monitoring-agent/issues/693))
@@ -65,6 +70,12 @@
 ### K6runner
 - inspect errors and propagate unexpected ones to the probe
 - handle errors reported by http runners
+
+
+<a name="v0.23.4"></a>
+## [v0.23.4] - 2024-04-17
+### Feature
+- upgrade k6 to v0.50.0 ([#681](https://github.com/grafana/synthetic-monitoring-agent/issues/681))
 
 
 <a name="v0.23.3"></a>
@@ -104,6 +115,11 @@
 
 ### Fix
 - missing http check regex validations ([#612](https://github.com/grafana/synthetic-monitoring-agent/issues/612))
+
+
+<a name="v0.20.1"></a>
+## [v0.20.1] - 2024-02-12
+### Fix
 - add test for HTTP check with a long URL
 
 
@@ -644,18 +660,21 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.25.1...HEAD
+[v0.25.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.25.0...v0.25.1
 [v0.25.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.3...v0.25.0
 [v0.24.3]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.2...v0.24.3
 [v0.24.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.1...v0.24.2
 [v0.24.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.0...v0.24.1
-[v0.24.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.3...v0.24.0
+[v0.24.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.4...v0.24.0
+[v0.23.4]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.3...v0.23.4
 [v0.23.3]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.2...v0.23.3
 [v0.23.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.1...v0.23.2
 [v0.23.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.0...v0.23.1
 [v0.23.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.22.0...v0.23.0
 [v0.22.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.21.0...v0.22.0
-[v0.21.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.6...v0.21.0
+[v0.21.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.20.1...v0.21.0
+[v0.20.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.6...v0.20.1
 [v0.19.6]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.5...v0.19.6
 [v0.19.5]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.4...v0.19.5
 [v0.19.4]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.3...v0.19.4


### PR DESCRIPTION
* ci/renovate: update gomod digests before 8 AM UTC
* Update ghcr.io/grafana/grafana-build-tools Docker tag to v0.16.0 (#800)
* Info message for -features used deprecated syntax. (#801)
* Update golang.org/x/exp digest to 8a7402a (#806)
* k6runner: handle ErrorCodeFailed (#791)
* Add retries to BBE DNS probe (#803)
* Update ghcr.io/grafana/grafana-build-tools Docker tag to v0.17.1 (#808)
* Update github.com/grafana/loki/pkg/push digest to 5a87ccb (#804)