### PR TITLE
Add with-browser Docker image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -149,7 +149,7 @@ steps:
     ref:
     - refs/tags/v*.*.*
 - commands:
-  - '{ echo latest-browser,$(./scripts/version)-browser ; } > .tags'
+  - echo "latest-browser,$(./scripts/version)-browser" > .tags
   depends_on:
   - docker publish (release)
   image: ghcr.io/grafana/grafana-build-tools:v0.23.0
@@ -350,6 +350,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 05e99e6e4a271db0a871235e54b35572269b57bf70a08364d9b26fc959309137
+hmac: d4db61b261c83fd65b96a3ea5bec1f3a1d8a5a4e7e80619c8573e6fd5dc6bbbd
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -149,7 +149,7 @@ steps:
     ref:
     - refs/tags/v*.*.*
 - commands:
-  - '{ echo latest-browser,$(eval ./scripts/version)-browser ; } > .tags'
+  - '{ echo latest-browser,$(./scripts/version)-browser ; } > .tags'
   depends_on:
   - docker publish (release)
   image: ghcr.io/grafana/grafana-build-tools:v0.22.0
@@ -350,6 +350,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 55a0c26c9860a4ebe2f1164f10e1c5957f2b7a7d790b07c6f3d5cab063d7a770
+hmac: 677c4a6f87a3ba14883f4992d74eac7ece1b3a0bddcb3cfffb626988bf48b72f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -82,7 +82,6 @@ steps:
     - TARGETPLATFORM=linux/amd64
     - TARGETOS=linux
     - TARGETARCH=amd64
-    - WITH_BROWSER=true
     dry_run: "true"
     repo: grafana/synthetic-monitoring-agent
     target: with-browser
@@ -150,7 +149,7 @@ steps:
     ref:
     - refs/tags/v*.*.*
 - commands:
-  - '{ echo latest-with-browser,$(eval ./scripts/version)-with-browser ; } > .tags'
+  - '{ echo latest-browser,$(eval ./scripts/version)-browser ; } > .tags'
   depends_on:
   - docker publish (release)
   image: ghcr.io/grafana/grafana-build-tools:v0.15.0

--- a/.drone.yml
+++ b/.drone.yml
@@ -53,6 +53,7 @@ steps:
     - TARGETARCH=amd64
     dry_run: "true"
     repo: grafana/synthetic-monitoring-agent
+    target: release
 - commands: []
   depends_on:
   - build
@@ -68,10 +69,28 @@ steps:
     - TARGETVARIANT=v8
     dry_run: "true"
     repo: grafana/synthetic-monitoring-agent
+    target: release
+- commands: []
+  depends_on:
+  - build
+  environment:
+    DOCKER_BUILDKIT: "1"
+  image: plugins/docker
+  name: docker build (with browser) (linux/amd64)
+  settings:
+    build_args:
+    - TARGETPLATFORM=linux/amd64
+    - TARGETOS=linux
+    - TARGETARCH=amd64
+    - WITH_BROWSER=true
+    dry_run: "true"
+    repo: grafana/synthetic-monitoring-agent
+    target: with-browser
 - commands:
   - "true"
   depends_on:
   - docker build (linux/amd64)
+  - docker build (with browser) (linux/amd64)
   - docker build (linux/arm64/v8)
   image: alpine
   name: docker build
@@ -127,6 +146,38 @@ steps:
   - docker publish to docker (linux/amd64)
   image: alpine
   name: docker publish (release)
+  when:
+    ref:
+    - refs/tags/v*.*.*
+- commands:
+  - '{ echo latest-with-browser,$(eval ./scripts/version)-with-browser ; } > .tags'
+  depends_on:
+  - docker publish (release)
+  image: ghcr.io/grafana/grafana-build-tools:v0.15.0
+  name: docker publish (with browser) tags
+- commands: []
+  depends_on:
+  - docker publish (with browser) tags
+  environment:
+    DOCKER_BUILDKIT: "1"
+  image: plugins/docker
+  name: docker publish (with browser) to docker (linux/amd64)
+  settings:
+    dry_run: "false"
+    password:
+      from_secret: docker_password
+    repo: grafana/synthetic-monitoring-agent
+    username:
+      from_secret: docker_username
+  when:
+    ref:
+    - refs/tags/v*.*.*
+- commands:
+  - "true"
+  depends_on:
+  - docker publish (with browser) to docker (linux/amd64)
+  image: alpine
+  name: docker publish (with browser) (release)
   when:
     ref:
     - refs/tags/v*.*.*

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,13 +13,13 @@ steps:
   - ./scripts/enforce-clean
   depends_on:
   - runner identification
-  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
   name: deps
 - commands:
   - make lint
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
   name: lint
 - commands:
   - git fetch origin --tags
@@ -30,14 +30,14 @@ steps:
   - make build
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
   name: build
 - commands:
   - make test
   depends_on:
   - lint
   - build
-  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
   name: test
 - commands: []
   depends_on:
@@ -152,7 +152,7 @@ steps:
   - '{ echo latest-browser,$(eval ./scripts/version)-browser ; } > .tags'
   depends_on:
   - docker publish (release)
-  image: ghcr.io/grafana/grafana-build-tools:v0.15.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
   name: docker publish (with browser) tags
 - commands: []
   depends_on:
@@ -253,7 +253,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
   name: write-key
 - commands:
   - make release-snapshot
@@ -261,7 +261,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
   name: test release
 - commands:
   - ./scripts/package/verify-deb-install.sh
@@ -287,7 +287,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
   name: release
   when:
     ref:
@@ -350,6 +350,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 698b37f156f33b7a50b91862c9fea26f77799ec55c1146bf8e4f16ac0c18e36d
+hmac: 55a0c26c9860a4ebe2f1164f10e1c5957f2b7a7d790b07c6f3d5cab063d7a770
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,13 +13,13 @@ steps:
   - ./scripts/enforce-clean
   depends_on:
   - runner identification
-  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
   name: deps
 - commands:
   - make lint
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
   name: lint
 - commands:
   - git fetch origin --tags
@@ -30,14 +30,14 @@ steps:
   - make build
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
   name: build
 - commands:
   - make test
   depends_on:
   - lint
   - build
-  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
   name: test
 - commands: []
   depends_on:
@@ -152,7 +152,7 @@ steps:
   - '{ echo latest-browser,$(./scripts/version)-browser ; } > .tags'
   depends_on:
   - docker publish (release)
-  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
   name: docker publish (with browser) tags
 - commands: []
   depends_on:
@@ -253,7 +253,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
   name: write-key
 - commands:
   - make release-snapshot
@@ -261,7 +261,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
   name: test release
 - commands:
   - ./scripts/package/verify-deb-install.sh
@@ -287,7 +287,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.22.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.23.0
   name: release
   when:
     ref:
@@ -350,6 +350,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 677c4a6f87a3ba14883f4992d74eac7ece1b3a0bddcb3cfffb626988bf48b72f
+hmac: 05e99e6e4a271db0a871235e54b35572269b57bf70a08364d9b26fc959309137
 
 ...

--- a/.gbt.mk
+++ b/.gbt.mk
@@ -4,4 +4,4 @@
 # and a shell script. This is achieved by using the `VAR=value` syntax, which
 # is valid in both Makefile and shell.
 
-GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v0.22.0
+GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v0.23.0

--- a/.gbt.mk
+++ b/.gbt.mk
@@ -4,4 +4,4 @@
 # and a shell script. This is achieved by using the `VAR=value` syntax, which
 # is valid in both Makefile and shell.
 
-GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v0.23.0
+GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v0.22.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,17 @@ ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
 # third stage with alpine base for better access to chromium
 FROM alpine:3.18 as with-browser
 
+RUN apk --no-cache add tini
 RUN apk --no-cache add chromium-swiftshader
-
-ENV SM_CHROME_BIN=/usr/bin/chromium-browser
-ENV SM_CHROME_PATH=/usr/lib/chromium/
+RUN adduser -D -u 12345 -g 12345 sm
 
 COPY --from=release /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release /usr/local/bin/sm-k6 /usr/local/bin/sm-k6
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
+USER sm
+ENV SM_CHROME_BIN=/usr/bin/chromium-browser
+ENV SM_CHROME_PATH=/usr/lib/chromium/
+
+ENTRYPOINT ["tini", "--", "/usr/local/bin/synthetic-monitoring-agent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get -y install ca-certificates
 
 ARG TARGETPLATFORM
 
-FROM --platform=$TARGETPLATFORM debian:stable-slim
+FROM --platform=$TARGETPLATFORM debian:stable-slim as release
 ARG TARGETOS
 ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH
@@ -16,5 +16,20 @@ COPY dist/${HOST_DIST}/synthetic-monitoring-agent /usr/local/bin/synthetic-monit
 COPY dist/${HOST_DIST}/k6 /usr/local/bin/sm-k6
 COPY scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
+
+# third stage with alpine base for better access to chromium
+FROM alpine:3.18 as with-browser
+
+RUN apk --no-cache add chromium-swiftshader
+
+ENV SM_CHROME_BIN=/usr/bin/chromium-browser
+ENV SM_CHROME_PATH=/usr/lib/chromium/
+
+COPY --from=release /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
+COPY --from=release /usr/local/bin/sm-k6 /usr/local/bin/sm-k6
+COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
+COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,15 +24,12 @@ FROM alpine:3.18 as with-browser
 
 RUN apk --no-cache add tini
 RUN apk --no-cache add chromium-swiftshader
-RUN adduser -D -u 12345 -g 12345 sm
 
 COPY --from=release /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release /usr/local/bin/sm-k6 /usr/local/bin/sm-k6
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-USER sm
-ENV SM_CHROME_BIN=/usr/bin/chromium-browser
-ENV SM_CHROME_PATH=/usr/lib/chromium/
+ENV K6_BROWSER_ARGS=no-sandbox,disable-dev-shm-usage
 
 ENTRYPOINT ["tini", "--", "/usr/local/bin/synthetic-monitoring-agent"]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Please refer to [Private Probe docs](https://grafana.com/docs/grafana-cloud/synt
 
 See [examples/kubernetes](./examples/kubernetes) for the documentation and example yaml files
 
+
+Docker Images
+-------------
+We release 2 versions of the [Docker image](https://hub.docker.com/r/grafana/synthetic-monitoring-agent) for the agent, depending on whether or not Chromium is installed in the environment for use in browser checks.
+
+Variants with the browser installed are tagged with the suffix `*-browser`. These images are substantially larger and shouldn't be used unless you need the browser functionality to keep memory requirements minimal.
+
+These are built using the same multi-stage Dockerfile, so be aware that `Docker build` scripts failing to specify a build target will produce the larger image every time.
+* Without chromium: `docker build --target release .`
+* With chromium: `docker build .` or `docker build --target with-browser .`
+
+
 Signals
 -------
 

--- a/scripts/configs/drone/main.jsonnet
+++ b/scripts/configs/drone/main.jsonnet
@@ -1,4 +1,4 @@
-local go_tools_image = 'ghcr.io/grafana/grafana-build-tools:v0.23.0';
+local go_tools_image = 'ghcr.io/grafana/grafana-build-tools:v0.22.0';
 
 local step(name, commands, image=go_tools_image) = {
   name: name,

--- a/scripts/configs/drone/main.jsonnet
+++ b/scripts/configs/drone/main.jsonnet
@@ -191,7 +191,7 @@ local docker_publish(repo, auth, tag, os, arch, version='') =
     step(
       'docker publish (with browser) tags',
       [
-        '{ echo latest-browser,$(eval ./scripts/version)-browser ; } > .tags',  // use with-browser tags for docker plugin
+        '{ echo latest-browser,$(./scripts/version)-browser ; } > .tags',  // use with-browser tags for docker plugin
       ],
       go_tools_image,
     )

--- a/scripts/configs/drone/main.jsonnet
+++ b/scripts/configs/drone/main.jsonnet
@@ -1,4 +1,4 @@
-local go_tools_image = 'ghcr.io/grafana/grafana-build-tools:v0.22.0';
+local go_tools_image = 'ghcr.io/grafana/grafana-build-tools:v0.23.0';
 
 local step(name, commands, image=go_tools_image) = {
   name: name,

--- a/scripts/configs/drone/main.jsonnet
+++ b/scripts/configs/drone/main.jsonnet
@@ -94,19 +94,16 @@ local docker_step(tag, os, arch, version='', with_browser=false) =
         'TARGETARCH=' + arch,
       ] + if std.length(version) > 0 then [
         'TARGETVARIANT=' + version,
-      ] else []
-       + if with_browser then [
-        'WITH_BROWSER=true',
       ] else [],
     },
   };
 
 local docker_build(os, arch, version='', with_browser=false) =
-  local tag = if with_browser then
+  local step = if with_browser then
       'docker build (with browser)'
         else
       'docker build';
-  docker_step(tag, os, arch, version, with_browser)
+  docker_step(step, os, arch, version, with_browser)
   + dependsOn([ 'build' ]);
 
 local docker_publish(repo, auth, tag, os, arch, version='') =
@@ -194,7 +191,7 @@ local docker_publish(repo, auth, tag, os, arch, version='') =
     step(
       'docker publish (with browser) tags',
       [
-        '{ echo latest-with-browser,$(eval ./scripts/version)-with-browser ; } > .tags',  // use with-browser tags for docker plugin
+        '{ echo latest-browser,$(eval ./scripts/version)-browser ; } > .tags',  // use with-browser tags for docker plugin
       ],
       go_tools_image,
     )

--- a/scripts/configs/drone/main.jsonnet
+++ b/scripts/configs/drone/main.jsonnet
@@ -191,7 +191,7 @@ local docker_publish(repo, auth, tag, os, arch, version='') =
     step(
       'docker publish (with browser) tags',
       [
-        '{ echo latest-browser,$(./scripts/version)-browser ; } > .tags',  // use with-browser tags for docker plugin
+        'echo "latest-browser,$(./scripts/version)-browser" > .tags',  // use with-browser tags for docker plugin
       ],
       go_tools_image,
     )


### PR DESCRIPTION
Issue: https://github.com/grafana/synthetic-monitoring/issues/71
Adds a 3rd stage to the Dockerfile to build the sm-agent image from an Alpine base, installing `chromium-switshader`.

The Drone CI pipeline is also updated to publish new image versions (tagged `*-with-browser`) corresponding to the new build target:
* `latest-with-browser`
* `<semver-long>-with-browser`

We should probably prevent this from publishing until we have some logic in the agent that can leverage it.