### PR TITLE
renovate: fix grafana-build-tools dependency regex

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,7 +59,7 @@
         ".*\\.mk$"
       ],
       "matchStrings": [
-        "ghcr.io/grafana/grafana-build-tools:(?<currentValue>\\S+)"
+        "ghcr.io/grafana/grafana-build-tools:(?<currentValue>[\\w-+.]+)"
       ]
     }
   ]


### PR DESCRIPTION
`\S+` is too wide of a match. For a line like this:

```
local go_tools_image = 'ghcr.io/grafana/grafana-build-tools:v0.15.0';
```

It would match `v0.15.0';`, which is not a valid version. `[\w-+.]` matches all characters allowed in semver.