### PR TITLE
multihttp/script: fix conditional rendering of `redirects` param

### DIFF
--- a/internal/prober/multihttp/script.tmpl
+++ b/internal/prober/multihttp/script.tmpl
@@ -88,7 +88,7 @@ export default function() {
 	{{ range $queries }}{{ . }};
 	{{ end -}}
 	{{- $method := .Request.Method.String }}
-	
+
 	body = {{ buildBody .Request.Body }};
 	{{- $bodyVars := interpolateBodyVars "body" .Request.Body }}
 	{{ range $bodyVars }}{{ . }};
@@ -101,8 +101,10 @@ export default function() {
 		  name: '{{ $idx }}', // TODO(mem): give the user some control over this?
 		  __raw_url__: '{{ .Request.Url }}',
 		},
-		redirects: 0{{ if gt (len $headers) 0 }},
-		headers: {{ $headers }}{{ end }}
+		{{- if gt ($headers | len) 0 }}
+		redirects: 0,
+		headers: {{ $headers }}
+		{{- end }}
 	});
 	console.log("Response received from {{ .Request.Url }}, status", response.status);
 	if(logResponse) {


### PR DESCRIPTION
Prior to this pr, the `redirects` param to k6's `http/request` function was always rendered. This PR fixes the template so the param is only emitted when no headers are specified, in which case the number of redirects to follow will be the default value of 10.

If headers are specified, the `redirect` param is rendered and thus no redirects will be performed.

Related: https://github.com/grafana/synthetic-monitoring-app/issues/919