### PR TITLE
Output unadorned version tag for releases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
   - git status --porcelain --untracked-files=no
   - git diff --no-ext-diff --quiet
   - ./scripts/version
-  - '{ echo -n latest, ; ./scripts/version ; } > .tags'
+  - ./scripts/generate-tags > .tags
   - make build
   depends_on:
   - deps
@@ -149,7 +149,7 @@ steps:
     ref:
     - refs/tags/v*.*.*
 - commands:
-  - echo "latest-browser,$(./scripts/version)-browser" > .tags
+  - ./scripts/generate-tags browser > .tags
   depends_on:
   - docker publish (release)
   image: ghcr.io/grafana/grafana-build-tools:v0.23.0
@@ -350,6 +350,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: d4db61b261c83fd65b96a3ea5bec1f3a1d8a5a4e7e80619c8573e6fd5dc6bbbd
+hmac: f6c6e83ee34a0f724b7e3e0ca4fad4e202fee749da8997dc30aeaddae3ec9a9e
 
 ...

--- a/scripts/configs/drone/main.jsonnet
+++ b/scripts/configs/drone/main.jsonnet
@@ -100,9 +100,9 @@ local docker_step(tag, os, arch, version='', with_browser=false) =
 
 local docker_build(os, arch, version='', with_browser=false) =
   local step = if with_browser then
-      'docker build (with browser)'
-        else
-      'docker build';
+    'docker build (with browser)'
+  else
+    'docker build';
   docker_step(step, os, arch, version, with_browser)
   + dependsOn([ 'build' ]);
 
@@ -111,10 +111,10 @@ local docker_publish(repo, auth, tag, os, arch, version='') =
   + { settings: { repo: repo, dry_run: 'false' } + auth }
   + dependsOn([ 'test', 'docker build' ]);
 
-  local docker_publish_with_browser(repo, auth, tag, os, arch) =
+local docker_publish_with_browser(repo, auth, tag, os, arch) =
   docker_step('docker publish (with browser) to ' + tag, os, arch, '', true)
   + { settings: { repo: repo, dry_run: 'false' } + auth }
-  + dependsOn([ 'docker publish (with browser) tags' ]); // step to update .tags file with browser-specific image tags
+  + dependsOn([ 'docker publish (with browser) tags' ]);  // step to update .tags file with browser-specific image tags
 
 [
   pipeline('build', [
@@ -138,7 +138,7 @@ local docker_publish(repo, auth, tag, os, arch, version='') =
         'git status --porcelain --untracked-files=no',
         'git diff --no-ext-diff --quiet',  // fail if the workspace has modified files
         './scripts/version',
-        '{ echo -n latest, ; ./scripts/version ; } > .tags',  // save version in special file for docker plugin
+        './scripts/generate-tags > .tags',  // save version in special file for docker plugin
         'make build',
       ],
       go_tools_image,
@@ -191,7 +191,7 @@ local docker_publish(repo, auth, tag, os, arch, version='') =
     step(
       'docker publish (with browser) tags',
       [
-        'echo "latest-browser,$(./scripts/version)-browser" > .tags',  // use with-browser tags for docker plugin
+        './scripts/generate-tags browser > .tags',
       ],
       go_tools_image,
     )

--- a/scripts/generate-tags
+++ b/scripts/generate-tags
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+set -u
+
+# If an optional suffix is provided, append it to all the tags as `-suffix`.
+# Note that this breaks the semver format, because appending -foobar means it's
+# a pre-release version, not a "flavor" as some people claim. The more
+# appropriate way to express this would be to use `+suffix`, but we'll defer
+# that until we have fixed the different places where this might be used.
+suffix=${1:+-}${1:-}
+
+rootdir=$(git rev-parse --show-toplevel)
+version=$("${rootdir}/scripts/version")
+
+version_base=$(echo "${version}" | cut -d- -f1)
+version_seq=$(echo "${version}" | cut -d- -f2)
+
+printf "%s," "latest${suffix}"
+printf "%s" "${version}${suffix}"
+if [ "${version_seq}" = "0" ]; then
+  # Strip the additional -0-* suffix to generate a additional tag that looks like vX.Y.Z
+  printf ",%s" "${version_base}${suffix}"
+fi


### PR DESCRIPTION
There's stuff out there with pretty weird ideas as to what constitutes a "correct" version number. We have been trying to solve this problem of "incorrect versioning" for over 30 years with no success. You have to wonder why that is.

For the specific case of releases, in addition to using vX.Y.Z-0-sha, also output a vX.Y.Z tag. That allows stuff to be happy about seeing something that matches its expectations in terms of version numbers. We still need to output something else in the n != 0 case, because we need to be able to differentiate between intermediate builds. It's incorrect in semver terms, because those are prereleases that sort _before_ vX.Y.Z, not after it. To do it correctly, we would have to transform vX.Y.Z to vX.Y.(Z+1) and append the prerelease bit to that. Since that would become confusing really fast (in the face of existing practice), let's not do that. As long as nothing tries to "upgrade" vX.Y.Z-n-sha to vX.Y.Z, we shoud be OK.