### PR TITLE
Release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 ## [Unreleased]
 
 
+<a name="v0.26.0"></a>
+## [v0.26.0] - 2024-09-02
+### Dependabot
+- remove
+
+### Dockerfile
+- pin hash of debian:stable-slim image ([#828](https://github.com/grafana/synthetic-monitoring-agent/issues/828))
+
+### Drone
+- regenerate pipelines
+
+### Feat
+- Validate browser capability ([#809](https://github.com/grafana/synthetic-monitoring-agent/issues/809))
+
+### Go
+- upgrade to 1.23 ([#838](https://github.com/grafana/synthetic-monitoring-agent/issues/838))
+
+### K6runner
+- always log error code and string to user's logger
+
+### Renovate
+- add `dependencies` label to PRs
+- enable default managers
+- group prometheus-go updates
+- fix grafana-build-tools dependency regex
+
+
 <a name="v0.25.2"></a>
 ## [v0.25.2] - 2024-07-31
 
@@ -658,7 +685,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.25.2...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.26.0...HEAD
+[v0.26.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.25.2...v0.26.0
 [v0.25.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.25.1...v0.25.2
 [v0.25.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.25.0...v0.25.1
 [v0.25.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.24.3...v0.25.0


### PR DESCRIPTION
* k6runner: always log error code and string to user's logger
* Update module golang.org/x/sync to v0.8.0 (#812)
* Update module golang.org/x/net to v0.28.0 (#813)
* Build(deps): Bump the prometheus-go group across 1 directory with 2 updates (#827)
* Update ghcr.io/grafana/grafana-build-tools Docker tag to v0.22.0 (#817)
* Update module go.k6.io/k6 to v0.53.0 (#823)
* Update dependency grafana/k6 to v0.53.0
* Update module github.com/miekg/dns to v1.1.62
* Update github.com/grafana/loki/pkg/push digest to 9315b3d
* Update golang.org/x/exp digest to 9b4947d
* Update github.com/securego/gosec/v2 digest to ab3f6c1
* Update github.com/grafana/loki/pkg/push digest to 246a1df
* Update ghcr.io/grafana/grafana-build-tools Docker tag to v0.23.0
* Build(deps): Bump github.com/prometheus/client_golang
* Update module github.com/securego/gosec to v2
* renovate: fix grafana-build-tools dependency regex
* Update ghcr.io/grafana/grafana-build-tools Docker tag to v0.23.0
* drone: regenerate pipelines
* Add with-browser Docker image (#829)
* Update module github.com/prometheus/prometheus to v0.54.1 (#843)
* Update module github.com/prometheus/common to v0.56.0 (#849)
* Build(deps): Bump google.golang.org/grpc from 1.65.0 to 1.66.0
* Build(deps): Bump github.com/prometheus/common
* renovate: group prometheus-go updates
* renovate: enable default managers
* renovate: add `dependencies` label to PRs
* dependabot: remove
* Update renovatebot/github-action action to v40.2.7 (#859)
* go: upgrade to 1.23 (#838)
* Update module github.com/golangci/golangci-lint to v1.60.0 (#825)
* Update alpine Docker tag to v3.20 (#858)
* Update actions/checkout action to v4.1.7 (#857)
* Dockerfile: pin hash of debian:stable-slim image (#828)
* Update module github.com/mccutchen/go-httpbin/v2 to v2.14.1 (#860)
* Update module github.com/securego/gosec to v2 (#861)
* feat: Validate browser capability (#809)