### PR TITLE
Migrate base image from Debian to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # First stage obtains the list of certificates.
-FROM --platform=$BUILDPLATFORM debian:stable-slim@sha256:64bc71feaa7ec2ac758a6a3a37c0f0d6ebccf0a45e3f5af1f1d3b5d4cb316b29 AS build
-RUN apt-get update && apt-get -y install ca-certificates
+FROM --platform=$BUILDPLATFORM alpine:3.20.3 AS build
+RUN apk --no-cache add ca-certificates-bundle
 
 # Second stage copies the binaries, configuration and also the
 # certificates from the first stage.
 
 ARG TARGETPLATFORM
 
-FROM --platform=$TARGETPLATFORM alpine:3.20.3 as release
+FROM --platform=$TARGETPLATFORM alpine:3.20.3 AS release
 ARG TARGETOS
 ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH
@@ -21,7 +21,7 @@ ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
 
 # Third stage copies the setup from the base agent and
 # additionally installs Chromium to support browser checks.
-FROM alpine:3.20.3 as with-browser
+FROM --platform=$TARGETPLATFORM alpine:3.20.3 AS with-browser
 
 RUN apk --no-cache add tini
 RUN apk --no-cache add chromium-swiftshader

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # First stage copies the binaries, configuration and installs the
 # certificates for the base agent.
-
 ARG TARGETPLATFORM
 
 FROM --platform=$TARGETPLATFORM alpine:3.20.3 as release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-# First stage obtains the list of certificates.
-FROM --platform=$BUILDPLATFORM alpine:3.20 AS build
-RUN apk --no-cache add ca-certificates
-
-# Second stage copies the binaries, configuration and also the
-# certificates from the first stage.
+# First stage copies the binaries, configuration and installs the
+# certificates for the base agent.
 
 ARG TARGETPLATFORM
 
-FROM --platform=$TARGETPLATFORM alpine:3.20 as release
+FROM --platform=$TARGETPLATFORM alpine:3.20.3 as release
+RUN apk --no-cache add ca-certificates
+
 ARG TARGETOS
 ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH
@@ -15,12 +13,12 @@ ARG HOST_DIST=$TARGETOS-$TARGETARCH
 COPY dist/${HOST_DIST}/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY dist/${HOST_DIST}/k6 /usr/local/bin/sm-k6
 COPY scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
 
-# third stage with alpine base for better access to chromium
-FROM alpine:3.20@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d as with-browser
+# Second stage copies the setup from the base agent and
+# additionally installs Chromium to support browser checks.
+FROM alpine:3.20.3 as with-browser
 
 RUN apk --no-cache add tini
 RUN apk --no-cache add chromium-swiftshader

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # First stage obtains the list of certificates.
-FROM --platform=$BUILDPLATFORM debian:stable-slim@sha256:64bc71feaa7ec2ac758a6a3a37c0f0d6ebccf0a45e3f5af1f1d3b5d4cb316b29 AS build
-RUN apt-get update && apt-get -y install ca-certificates
+FROM --platform=$BUILDPLATFORM alpine:3.20 AS build
+RUN apk --no-cache add ca-certificates
 
 # Second stage copies the binaries, configuration and also the
 # certificates from the first stage.
 
 ARG TARGETPLATFORM
 
-FROM --platform=$TARGETPLATFORM debian:stable-slim@sha256:64bc71feaa7ec2ac758a6a3a37c0f0d6ebccf0a45e3f5af1f1d3b5d4cb316b29 as release
+FROM --platform=$TARGETPLATFORM alpine:3.20 as release
 ARG TARGETOS
 ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH


### PR DESCRIPTION
Issue: https://github.com/grafana/synthetic-monitoring-agent/issues/845

We've expanded the Dockerfile into a multi-stage build to include chromium for a browser-enabled agent on Alpine. This PR migrates the base release to Alpine as well.

Tested locally on Colima using a linux/amd64 VM.