### PR TITLE
renovate: update pinned alpine packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,6 +61,34 @@
       "matchStrings": [
         "ghcr.io/grafana/grafana-build-tools:(?<currentValue>[\\w-+.]+)"
       ]
-    }
-  ]
+    },
+    {
+      // Update pinned alpine packages in Dockerfile.
+      "customType": "regex",
+      "fileMatch": [ "Dockerfile" ],
+      "matchStrings": [
+        // Lines that loosely look like "apk add --repository community something=version".
+        // To keep this regex simple, only one package per "apk add" is supported.
+        "apk.+?add.+?(--repository|-X)[= ](?<alpineRepo>[a-z]+).+?(?<depName>[a-z0-9-]+)=(?<currentValue>[a-z0-9-.]+)"
+      ],
+      "versioningTemplate": "loose", // The most lenient versioning renovate supports.
+      // We use two different datasources for main and community, as alpine serves them in different URLs.
+      "datasourceTemplate": "custom.alpine-{{alpineRepo}}",
+      // Extracted "versions" include the package name, so here we strip that prefix using a regex.
+      "extractVersionTemplate": "{{depName}}-(?<version>.+).apk",
+    },
+  ],
+
+  "customDatasources": {
+    // Use alpine HTML mirror page as a repository. When using `html` format, renovate produces version strings from
+    // all links present in the page. The version is extracted from that using extractVersionTemplate above.
+    "alpine-main": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main/x86_64/",
+      "format": "html",
+    },
+    "alpine-community": {
+      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/",
+      "format": "html",
+    },
+  },
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -69,7 +69,7 @@
       "matchStrings": [
         // Lines that loosely look like "apk add --repository community something=version".
         // To keep this regex simple, only one package per "apk add" is supported.
-        "apk.+?add.+?(--repository|-X)[= ](?<alpineRepo>[a-z]+).+?(?<depName>[a-z0-9-]+)=(?<currentValue>[a-z0-9-.]+)"
+        "\\bapk\\b.+?\\badd\\b.+?(--repository|-X)[ =\\t]+(?<alpineRepo>[a-z]+)\\s+(?<depName>[-\\w]+?)=(?<currentValue>[-.\\w]+)"
       ],
       "versioningTemplate": "loose", // The most lenient versioning renovate supports.
       // We use two different datasources for main and community, as alpine serves them in different URLs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,11 @@ ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
 # additionally installs Chromium to support browser checks.
 FROM --platform=$TARGETPLATFORM alpine:3.20.3 AS with-browser
 
-RUN apk --no-cache add tini
-RUN apk --no-cache add chromium-swiftshader
+# Renovate updates the pinned packages below.
+# The --repository arg is required for renovate to know which alpine repo it should look for updates in.
+# To keep the renovate regex simple, only keep one package installation per line.
+RUN apk --no-cache add --repository community tini=0.19.0-r3 && \
+  apk --no-cache add --repository community chromium-swiftshader=128.0.6613.119-r0
 
 COPY --from=release /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release /usr/local/bin/sm-k6 /usr/local/bin/sm-k6


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-agent/issues/846.

Duplicates what @roobre's done to add a regex manager and a custom datasource, so renovate can update pinned alpine packages.