### PR TITLE
Feature: add retries to ICMP prober

### DIFF
--- a/internal/prober/icmp/icmp.go
+++ b/internal/prober/icmp/icmp.go
@@ -16,11 +16,13 @@ import (
 var errUnsupportedCheck = errors.New("unsupported check")
 
 type Module struct {
-	Prober      string
-	Timeout     time.Duration
-	PacketCount int64
-	ICMP        config.ICMPProbe
-	Privileged  bool
+	Prober            string
+	Timeout           time.Duration
+	PacketCount       int64
+	ReqSuccessCount   int64
+	MaxResolveRetries int64
+	ICMP              config.ICMPProbe
+	Privileged        bool
 }
 
 type Prober struct {
@@ -62,11 +64,16 @@ func settingsToModule(settings *sm.PingSettings) Module {
 
 	m.ICMP.DontFragment = settings.DontFragment
 
-	if settings.PacketCount <= 1 {
-		m.PacketCount = 1
+	if settings.PacketCount == 0 {
+		m.PacketCount = 3
+		m.ReqSuccessCount = 1
 	} else {
 		m.PacketCount = settings.PacketCount
+		m.ReqSuccessCount = settings.PacketCount // TODO(mem): expose this setting
 	}
+
+	// TODO(mem): add a setting for this
+	m.MaxResolveRetries = 3
 
 	return m
 }

--- a/internal/prober/icmp/icmp_test.go
+++ b/internal/prober/icmp/icmp_test.go
@@ -34,10 +34,62 @@ func TestNewProber(t *testing.T) {
 			},
 			expected: Prober{
 				config: Module{
-					Prober:      "ping",
-					Timeout:     0,
-					PacketCount: 1,
-					Privileged:  isPrivilegedRequired(),
+					Prober:            "ping",
+					Timeout:           0,
+					PacketCount:       3,
+					ReqSuccessCount:   1,
+					MaxResolveRetries: 3,
+					Privileged:        isPrivilegedRequired(),
+					ICMP: config.ICMPProbe{
+						IPProtocol:         "ip6",
+						IPProtocolFallback: true,
+					},
+				},
+			},
+			ExpectError: false,
+		},
+		"1 packet": {
+			input: sm.Check{
+				Target: "www.grafana.com",
+				Settings: sm.CheckSettings{
+					Ping: &sm.PingSettings{
+						PacketCount: 1,
+					},
+				},
+			},
+			expected: Prober{
+				config: Module{
+					Prober:            "ping",
+					Timeout:           0,
+					PacketCount:       1,
+					ReqSuccessCount:   1,
+					MaxResolveRetries: 3,
+					Privileged:        isPrivilegedRequired(),
+					ICMP: config.ICMPProbe{
+						IPProtocol:         "ip6",
+						IPProtocolFallback: true,
+					},
+				},
+			},
+			ExpectError: false,
+		},
+		"2 packets": {
+			input: sm.Check{
+				Target: "www.grafana.com",
+				Settings: sm.CheckSettings{
+					Ping: &sm.PingSettings{
+						PacketCount: 2,
+					},
+				},
+			},
+			expected: Prober{
+				config: Module{
+					Prober:            "ping",
+					Timeout:           0,
+					PacketCount:       2,
+					ReqSuccessCount:   2,
+					MaxResolveRetries: 3,
+					Privileged:        isPrivilegedRequired(),
 					ICMP: config.ICMPProbe{
 						IPProtocol:         "ip6",
 						IPProtocolFallback: true,
@@ -50,7 +102,7 @@ func TestNewProber(t *testing.T) {
 			input: sm.Check{
 				Target: "www.grafana.com",
 				Settings: sm.CheckSettings{
-					Http: nil,
+					Ping: nil,
 				},
 			},
 			expected:    Prober{},
@@ -79,9 +131,11 @@ func TestSettingsToModule(t *testing.T) {
 		"default": {
 			input: sm.PingSettings{},
 			expected: Module{
-				Prober:      "ping",
-				Timeout:     0,
-				PacketCount: 1,
+				Prober:            "ping",
+				Timeout:           0,
+				PacketCount:       3,
+				ReqSuccessCount:   1,
+				MaxResolveRetries: 3,
 				ICMP: config.ICMPProbe{
 					IPProtocol:         "ip6",
 					IPProtocolFallback: true,
@@ -94,9 +148,11 @@ func TestSettingsToModule(t *testing.T) {
 				SourceIpAddress: "0.0.0.0",
 			},
 			expected: Module{
-				Prober:      "ping",
-				Timeout:     0,
-				PacketCount: 1,
+				Prober:            "ping",
+				Timeout:           0,
+				PacketCount:       3,
+				ReqSuccessCount:   1,
+				MaxResolveRetries: 3,
 				ICMP: config.ICMPProbe{
 					IPProtocol:         "ip4",
 					IPProtocolFallback: false,
@@ -110,9 +166,11 @@ func TestSettingsToModule(t *testing.T) {
 				PacketCount: 1,
 			},
 			expected: Module{
-				Prober:      "ping",
-				Timeout:     0,
-				PacketCount: 1,
+				Prober:            "ping",
+				Timeout:           0,
+				PacketCount:       1,
+				ReqSuccessCount:   1,
+				MaxResolveRetries: 3,
 				ICMP: config.ICMPProbe{
 					IPProtocol:         "ip4",
 					IPProtocolFallback: false,
@@ -125,9 +183,11 @@ func TestSettingsToModule(t *testing.T) {
 				PacketCount: 2,
 			},
 			expected: Module{
-				Prober:      "ping",
-				Timeout:     0,
-				PacketCount: 2,
+				Prober:            "ping",
+				Timeout:           0,
+				PacketCount:       2,
+				ReqSuccessCount:   2,
+				MaxResolveRetries: 3,
 				ICMP: config.ICMPProbe{
 					IPProtocol:         "ip4",
 					IPProtocolFallback: false,


### PR DESCRIPTION
Add a retry mechanism to the ICMP prober. If the packet count is not set, use 3 packets instead of 1, and require that at least 1 of them gets a response. This should cover most reasonable scenarios where retries are needed.

Note that this will send out 3 packets regardless of whether 1 is already received, so this has an impact on the probe_duration_seconds metric (because the probe takes longer to run).

If the time for an individual packet is important, use `sum(probe_icmp_duration_seconds)` instead. That metric is split by phases, and the `rtt` phase is the average round-trip-time for all the received packets. The other two phases, `setup` and `resolve` only run once.

The resolve part of this also retries, in the event that the DNS server fails to produce a response and there's an indication that the request should be retried (e.g. if the response is "not found", that is not retried).