### PR TITLE
Release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 ## [Unreleased]
 
 
+<a name="v0.27.0"></a>
+## [v0.27.0] - 2024-09-19
+### K6runner
+- promote log messages surfacing errors to warning level
+- error if script timeout is not set
+
+### Scraper
+- use check frequency as the context deadline for k6 checks
+
+### Scripts
+- update go to 1.23
+
+
 <a name="v0.26.0"></a>
 ## [v0.26.0] - 2024-09-02
 ### Dependabot
@@ -140,11 +153,6 @@
 
 ### Fix
 - missing http check regex validations ([#612](https://github.com/grafana/synthetic-monitoring-agent/issues/612))
-
-
-<a name="v0.20.1"></a>
-## [v0.20.1] - 2024-02-12
-### Fix
 - add test for HTTP check with a long URL
 
 
@@ -685,7 +693,8 @@
 <a name="v0.0.1"></a>
 ## v0.0.1 - 2020-06-24
 
-[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.27.0...HEAD
+[v0.27.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.26.0...v0.27.0
 [v0.26.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.25.2...v0.26.0
 [v0.25.2]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.25.1...v0.25.2
 [v0.25.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.25.0...v0.25.1
@@ -699,8 +708,7 @@
 [v0.23.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.23.0...v0.23.1
 [v0.23.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.22.0...v0.23.0
 [v0.22.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.21.0...v0.22.0
-[v0.21.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.20.1...v0.21.0
-[v0.20.1]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.6...v0.20.1
+[v0.21.0]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.6...v0.21.0
 [v0.19.6]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.5...v0.19.6
 [v0.19.5]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.4...v0.19.5
 [v0.19.4]: https://github.com/grafana/synthetic-monitoring-agent/compare/v0.19.3...v0.19.4


### PR DESCRIPTION
* Update module github.com/prometheus/common to v0.58.0
* Output unadorned version tag for releases (#862)
* Update debian:stable-slim Docker digest to 64bc71f (#867)
* Update module github.com/prometheus/client_golang to v1.20.3 (#869)
* Update module github.com/prometheus/common to v0.59.1 (#870)
* Update module golang.org/x/net to v0.29.0
* Update alpine:3.20 Docker digest to beefdbd (#874)
* Update github.com/grafana/loki/pkg/push digest to 0780456 (#876)
* Update golang.org/x/exp digest to e7e105d (#877)
* Update renovatebot/github-action action to v40.2.8
* scripts: update go to 1.23
* Update module google.golang.org/grpc to v1.66.1 (#884)
* Update module google.golang.org/grpc to v1.66.2 (#885)
* Move browser Docker build into separate Dockerfile (#886)
* Stop publishing browser image to GCR (#888)
* Update grafana-build-tools to 0.23.1 (#889)
* Migrate base image from Debian to Alpine (#875)
* k6runner: error if script timeout is not set
* scraper: use check frequency as the context deadline for k6 checks
* scraper/test: work around panic if all settings are nil in test
* k6runner/http: override only logger in WithLogger
* k6runner/http: retry requests
* k6runner: promote log messages surfacing errors to warning level
* Update renovatebot/github-action action to v40.2.10 (#891)
* Update module github.com/prometheus/client_golang to v1.20.4 (#893)
* scripts/go: update gosec to v2 proper
* Update module github.com/mccutchen/go-httpbin/v2 to v2.15.0