### PR TITLE
Fix: allow probers to provide a duration value

### DIFF
--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -472,13 +472,19 @@ func (r *runner) Run(ctx context.Context, tenantId model.GlobalID, publisher pus
 	rCtx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
 
-	if r.prober.Probe(rCtx, r.target, registry, logger) {
+	success, duration := r.prober.Probe(rCtx, r.target, registry, logger)
+
+	if success {
 		successGauge.Set(1)
 	} else {
 		successGauge.Set(0)
 	}
 
-	durationGauge.Set(float64(time.Since(start).Microseconds()) / 1e6)
+	if duration != 0 {
+		durationGauge.Set(duration)
+	} else {
+		durationGauge.Set(float64(time.Since(start).Microseconds()) / 1e6)
+	}
 
 	mfs, err := registry.Gather()
 

--- a/internal/adhoc/adhoc_test.go
+++ b/internal/adhoc/adhoc_test.go
@@ -337,7 +337,7 @@ func (p *testProber) Name() string {
 	return "test"
 }
 
-func (p *testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+func (p *testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	p.logger.Info().Str("func", "Probe").Caller(0).Send()
 	g := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "test",
@@ -345,5 +345,5 @@ func (p *testProber) Probe(ctx context.Context, target string, registry *prometh
 	g.Set(1)
 	registry.MustRegister(g)
 	_ = logger.Log("msg", "test")
-	return true
+	return true, 1
 }

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -441,8 +441,8 @@ func (testProber) Name() string {
 	return "test-prober"
 }
 
-func (testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
-	return false
+func (testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+	return false, 0
 }
 
 type testProbeFactory struct{}

--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -59,12 +59,13 @@ func (p Prober) Name() string {
 	return proberName
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	success, err := p.processor.Run(ctx, registry, logger, p.logger)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
-		return false
+		return false, 0
 	}
 
-	return success
+	// TODO(mem): implement custom duration extraction.
+	return success, 0
 }

--- a/internal/prober/dns/dns.go
+++ b/internal/prober/dns/dns.go
@@ -50,7 +50,7 @@ func (p Prober) Name() string {
 	return "dns"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	cfg := p.config
 
 	if p.experimental {
@@ -78,7 +78,7 @@ func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.R
 	// pass the server as the target parameter, and ignore the
 	// _target_ paramater that is passed to this function.
 
-	return bbeprober.ProbeDNS(ctx, p.target, cfg, registry, logger)
+	return bbeprober.ProbeDNS(ctx, p.target, cfg, registry, logger), 0
 }
 
 func settingsToModule(settings *sm.DnsSettings, target string) config.Module {

--- a/internal/prober/dns/dns_test.go
+++ b/internal/prober/dns/dns_test.go
@@ -252,9 +252,10 @@ func TestProberRetries(t *testing.T) {
 	logger := log.NewLogfmtLogger(&buf)
 
 	t0 := time.Now()
-	success := p.Probe(ctx, p.target, registry, logger)
+	success, duration := p.Probe(ctx, p.target, registry, logger)
 	t.Log(success, time.Since(t0))
 	require.True(t, success)
+	require.Equal(t, 0, duration)
 
 	mfs, err := registry.Gather()
 	require.NoError(t, err)

--- a/internal/prober/grpc/grpc.go
+++ b/internal/prober/grpc/grpc.go
@@ -41,8 +41,8 @@ func (p Prober) Name() string {
 	return "grpc"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
-	return bbeprober.ProbeGRPC(ctx, target, p.config, registry, logger)
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+	return bbeprober.ProbeGRPC(ctx, target, p.config, registry, logger), 0
 }
 
 func settingsToModule(ctx context.Context, settings *sm.GrpcSettings, logger zerolog.Logger) (config.Module, error) {

--- a/internal/prober/http/http.go
+++ b/internal/prober/http/http.go
@@ -55,13 +55,13 @@ func (p Prober) Name() string {
 	return "http"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	if p.cacheBustingQueryParamName != "" {
 		// FIXME(mem): the second target argument should be the probe's name
 		target = addCacheBustParam(target, p.cacheBustingQueryParamName, target)
 	}
 
-	return bbeprober.ProbeHTTP(ctx, target, p.config, registry, logger)
+	return bbeprober.ProbeHTTP(ctx, target, p.config, registry, logger), 0
 }
 
 func settingsToModule(ctx context.Context, settings *sm.HttpSettings, logger zerolog.Logger) (config.Module, error) {

--- a/internal/prober/http/http_test.go
+++ b/internal/prober/http/http_test.go
@@ -231,7 +231,10 @@ func TestProbe(t *testing.T) {
 
 			prober, err := NewProber(ctx, check, zl, http.Header{})
 			require.NoError(t, err)
-			require.Equal(t, tc.expectFailure, !prober.Probe(ctx, check.Target, registry, kl))
+
+			success, duration := prober.Probe(ctx, check.Target, registry, kl)
+			require.Equal(t, tc.expectFailure, !success)
+			require.Equal(t, float64(0), duration)
 
 			mfs, err := registry.Gather()
 			require.NoError(t, err)

--- a/internal/prober/icmp/icmp.go
+++ b/internal/prober/icmp/icmp.go
@@ -47,7 +47,7 @@ func (p Prober) Name() string {
 	return "ping"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	return probeICMP(ctx, target, p.config, registry, logger)
 }
 
@@ -108,7 +108,7 @@ func isPrivilegedRequired() bool {
 		}
 	)
 
-	success := probeICMP(ctx, target, config, registry, logger)
+	success, _ := probeICMP(ctx, target, config, registry, logger)
 
 	privilegedRequired = !success
 	privilegedCheckDone = true

--- a/internal/prober/icmp/icmp_test.go
+++ b/internal/prober/icmp/icmp_test.go
@@ -233,8 +233,9 @@ func TestProber(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stdout)
 	require.NotNil(t, logger)
 
-	success := prober.Probe(ctx, "127.0.0.1", registry, logger)
+	success, duration := prober.Probe(ctx, "127.0.0.1", registry, logger)
 	require.True(t, success)
+	require.Greater(t, duration, float64(0))
 }
 
 func TestBBEProber(t *testing.T) {

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -82,14 +82,15 @@ func (p Prober) Name() string {
 	return proberName
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	success, err := p.processor.Run(ctx, registry, logger, p.logger)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
-		return false
+		return false, 0
 	}
 
-	return success
+	// TODO(mem): implement custom duration extraction.
+	return success, 0
 }
 
 // Overrides any user-provided headers with our own augmented values

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -862,11 +862,12 @@ func TestSettingsToScript(t *testing.T) {
 	userLogger := level.NewFilter(kitlog.NewLogfmtLogger(&buf), level.AllowInfo(), level.SquelchNoLevel(false))
 	require.NotNil(t, userLogger)
 
-	success := prober.Probe(ctx, check.Target, reg, userLogger)
+	success, duration := prober.Probe(ctx, check.Target, reg, userLogger)
 
 	t.Log("Log entries:\n" + buf.String())
 
 	require.True(t, success)
+	require.Equal(t, float64(0), duration)
 }
 
 func TestReplaceVariablesInString(t *testing.T) {

--- a/internal/prober/prober.go
+++ b/internal/prober/prober.go
@@ -28,10 +28,10 @@ const unsupportedCheckType = error_types.BasicError("unsupported check type")
 
 type Prober interface {
 	Name() string
-	Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool
+	Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64)
 }
 
-func Run(ctx context.Context, p Prober, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+func Run(ctx context.Context, p Prober, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	return p.Probe(ctx, target, registry, logger)
 }
 

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -59,12 +59,13 @@ func (p Prober) Name() string {
 	return proberName
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	success, err := p.processor.Run(ctx, registry, logger, p.logger)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
-		return false
+		return false, 0
 	}
 
-	return success
+	// TODO(mem): implement custom duration extraction.
+	return success, 0
 }

--- a/internal/prober/tcp/tcp.go
+++ b/internal/prober/tcp/tcp.go
@@ -41,8 +41,8 @@ func (p Prober) Name() string {
 	return "tcp"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
-	return bbeprober.ProbeTCP(ctx, target, p.config, registry, logger)
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+	return bbeprober.ProbeTCP(ctx, target, p.config, registry, logger), 0
 }
 
 func settingsToModule(ctx context.Context, settings *sm.TcpSettings, logger zerolog.Logger) (config.Module, error) {

--- a/internal/prober/traceroute/traceroute.go
+++ b/internal/prober/traceroute/traceroute.go
@@ -53,7 +53,7 @@ func (p Prober) Name() string {
 	return "traceroute"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	m, ch, err := mtr.NewMTR(
 		target,
 		p.config.srcAddr,
@@ -70,9 +70,9 @@ func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.R
 		logErr := logger.Log(err)
 		if logErr != nil {
 			p.logger.Error().Err(logErr).Msg("logging error")
-			return false
+			return false, 0
 		}
-		return false
+		return false, 0
 	}
 
 	go func(ch <-chan struct{}) {
@@ -130,7 +130,7 @@ func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.R
 	_, err = traceHash.Write([]byte(hostsString))
 	if err != nil {
 		p.logger.Error().Err(err).Msg("computing trace hash")
-		return false
+		return false, 0
 	}
 
 	var traceHashGauge = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -158,7 +158,7 @@ func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.R
 	overallPacketLoss := totalPacketsLost / totalPacketsSent
 	overallPacketLossGauge.Set(overallPacketLoss)
 
-	return success
+	return success, 0
 }
 
 func settingsToModule(settings *sm.TracerouteSettings) Module {

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1259,14 +1259,14 @@ func (p testProber) Name() string {
 	return "test prober"
 }
 
-func (p testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+func (p testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	counter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "test_counter",
 	})
 	registry.MustRegister(counter)
 	counter.Inc()
 
-	return true
+	return true, 1
 }
 
 type testLabelsLimiter struct {
@@ -1778,15 +1778,15 @@ func (p testProberB) Name() string {
 	return "test prober"
 }
 
-func (p *testProberB) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) bool {
+func (p *testProberB) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	p.execCount++
 
 	if p.failureCount < p.wantedFailures {
 		p.failureCount++
-		return false
+		return false, 0
 	}
 
-	return true
+	return true, 1
 }
 
 type testProbeFactory struct {


### PR DESCRIPTION
Some probers need to override the duration that is reported, mostly because we use probe_duration_seconds as the "latency" of the probe, which isn't exactly correct. `probe_duration_seconds` was meant to be used as the duration of the probe: how long did it take for this probe to run. Capture that value in the logs for debugging purposes, and use `probe_duration_seconds` as if it meant the time it takes the target to produce a response, including *some* setup, but not e.g. the overhead introduced by retries or the time it takes for external programs to spin up.

This is OK to change since these are all internal packages.