### PR TITLE
Add script metadata

### DIFF
--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -35,13 +35,7 @@ func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runne
 
 	p.module = Module{
 		Prober: sm.CheckTypeBrowser.String(),
-		Script: k6runner.Script{
-			Script: check.Settings.Browser.Script,
-			Settings: k6runner.Settings{
-				Timeout: check.Timeout,
-			},
-			// TODO: Add metadata & features here.
-		},
+		Script: k6runner.NewScript(check.Settings.Browser.Script, check),
 	}
 
 	processor, err := k6runner.NewProcessor(p.module.Script, runner)

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -50,13 +50,7 @@ func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runne
 
 	p.module = Module{
 		Prober: sm.CheckTypeMultiHttp.String(),
-		Script: k6runner.Script{
-			Script: script,
-			Settings: k6runner.Settings{
-				Timeout: check.Timeout,
-			},
-			// TODO: Add metadata & features here.
-		},
+		Script: k6runner.NewScript(script, check),
 	}
 
 	processor, err := k6runner.NewProcessor(p.module.Script, runner)

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -35,13 +35,7 @@ func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runne
 
 	p.module = Module{
 		Prober: sm.CheckTypeScripted.String(),
-		Script: k6runner.Script{
-			Script: check.Settings.Scripted.Script,
-			Settings: k6runner.Settings{
-				Timeout: check.Timeout,
-			},
-			// TODO: Add metadata & features here.
-		},
+		Script: k6runner.NewScript(check.Settings.Scripted.Script, check),
 	}
 
 	processor, err := k6runner.NewProcessor(p.module.Script, runner)


### PR DESCRIPTION
In order for the runner to know the type of the script that it's dealing with, add a "metadata" field to the JSON representation of the request, which contains a "type" field specifying that information.

Also pass check_id and tenant_id, which will allow us to identify checks causing issues.