### PR TITLE
k6runner: add a test for parsing truncated logs

### DIFF
--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -696,12 +696,33 @@ func buildId(name string, m *dto.Metric) string {
 }
 
 func TestK6LogsToLogger(t *testing.T) {
-	data := testhelper.MustReadFile(t, "testdata/test.log")
+	t.Parallel()
 
-	var logger testLogger
+	for _, tc := range []struct {
+		name     string
+		filename string
+	}{
+		{
+			name:     "Valid logs",
+			filename: "testdata/test.log",
+		},
+		{
+			name:     "truncated logs",
+			filename: "testdata/test-truncated.log",
+		},
+	} {
+		tc := tc
 
-	err := k6LogsToLogger(data, &logger)
-	require.NoError(t, err)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			data := testhelper.MustReadFile(t, tc.filename)
+
+			var logger testLogger
+
+			err := k6LogsToLogger(data, &logger)
+			require.NoError(t, err)
+		})
+	}
 }
 
 type testLogger struct{}

--- a/internal/k6runner/testdata/test-truncated.log
+++ b/internal/k6runner/testdata/test-truncated.log
@@ -1,0 +1,2 @@
+time="2023-06-01T13:40:26-06:00" level=debug msg="Logger format: TEXT"
+time="2023-06-01T13:40:26-06:00" level=debug msg="k6 version: v0.43.1 ((devel), go1.20.4,


### PR DESCRIPTION
Not a real PR, just living proof that @mem is right in https://github.com/grafana/sm-k6-runner/pull/280#pullrequestreview-2328339520