### PR TITLE
adhoc: clamp ad-hoc check timeout to at most 20s

### DIFF
--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -381,8 +381,9 @@ func defaultGrpcAdhocChecksClientFactory(conn ClientConn) (sm.AdHocChecksClient,
 func (h *Handler) defaultRunnerFactory(ctx context.Context, req *sm.AdHocRequest) (*runner, error) {
 	check := model.Check{
 		Check: sm.Check{
-			Target:   req.AdHocCheck.Target,
-			Timeout:  req.AdHocCheck.Timeout,
+			Target: req.AdHocCheck.Target,
+			// For ad-hoc checks, clamp the timeout to up to 20s.
+			Timeout:  min(req.AdHocCheck.Timeout, (20 * time.Second).Milliseconds()),
 			Settings: req.AdHocCheck.Settings,
 		},
 	}
@@ -398,7 +399,7 @@ func (h *Handler) defaultRunnerFactory(ctx context.Context, req *sm.AdHocRequest
 		id:      req.AdHocCheck.Id,
 		target:  target,
 		probe:   h.probe.Name,
-		timeout: time.Duration(req.AdHocCheck.Timeout) * time.Millisecond,
+		timeout: time.Duration(check.Timeout) * time.Millisecond,
 	}, nil
 }
 


### PR DESCRIPTION
Ad-hoc checks are run pseudo-synchronously from the UI, which does not wait indefinitely for a check to run. This PR limits the check timeout to at most 20s, which we consider already more than what an user will wait for data to show up.