### PR TITLE
k6runner: add check metadata and type to remote runner requests

### DIFF
--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/go-logfmt/logfmt"
+	smmmodel "github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
-	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -52,7 +52,7 @@ type CheckInfo struct {
 }
 
 // CheckInfoFromSM returns a CheckInfo from the information of the given SM check.
-func CheckInfoFromSM(smc sm.Check) CheckInfo {
+func CheckInfoFromSM(smc smmmodel.Check) CheckInfo {
 	ci := CheckInfo{
 		Metadata: map[string]any{},
 	}

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
 	"github.com/grafana/synthetic-monitoring-agent/internal/testhelper"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -91,6 +92,30 @@ func TestScriptRun(t *testing.T) {
 	success, err := processor.Run(ctx, registry, &logger, zlogger)
 	require.NoError(t, err)
 	require.True(t, success)
+}
+
+func TestCheckInfoFromSM(t *testing.T) {
+	t.Parallel()
+
+	check := sm.Check{
+		Id:       69,
+		TenantId: 1234,
+		Created:  1234.5,
+		Modified: 12345.6,
+		Settings: sm.CheckSettings{
+			Browser: &sm.BrowserSettings{}, // Make it non-nil so type is Browser.
+		},
+	}
+
+	ci := CheckInfoFromSM(check)
+
+	require.Equal(t, sm.CheckTypeBrowser.String(), ci.Type)
+	require.Equal(t, map[string]any{
+		"id":       check.Id,
+		"tenantID": check.TenantId,
+		"created":  check.Created,
+		"modified": check.Modified,
+	}, ci.Metadata)
 }
 
 type testRunner struct {

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
 	"github.com/grafana/synthetic-monitoring-agent/internal/testhelper"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
@@ -97,13 +98,16 @@ func TestScriptRun(t *testing.T) {
 func TestCheckInfoFromSM(t *testing.T) {
 	t.Parallel()
 
-	check := sm.Check{
-		Id:       69,
-		TenantId: 1234,
-		Created:  1234.5,
-		Modified: 12345.6,
-		Settings: sm.CheckSettings{
-			Browser: &sm.BrowserSettings{}, // Make it non-nil so type is Browser.
+	check := model.Check{
+		RegionId: 4,
+		Check: sm.Check{
+			Id:       69,
+			TenantId: 1234,
+			Created:  1234.5,
+			Modified: 12345.6,
+			Settings: sm.CheckSettings{
+				Browser: &sm.BrowserSettings{}, // Make it non-nil so type is Browser.
+			},
 		},
 	}
 
@@ -113,6 +117,7 @@ func TestCheckInfoFromSM(t *testing.T) {
 	require.Equal(t, map[string]any{
 		"id":       check.Id,
 		"tenantID": check.TenantId,
+		"regionID": check.RegionId,
 		"created":  check.Created,
 		"modified": check.Modified,
 	}, ci.Metadata)

--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,7 +27,7 @@ type Prober struct {
 	processor *k6runner.Processor
 }
 
-func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runner k6runner.Runner) (Prober, error) {
+func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner) (Prober, error) {
 	var p Prober
 
 	if check.Settings.Browser == nil {

--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -40,7 +40,7 @@ func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runne
 			Settings: k6runner.Settings{
 				Timeout: check.Timeout,
 			},
-			// TODO: Add metadata & features here.
+			CheckInfo: k6runner.CheckInfoFromSM(check),
 		},
 	}
 

--- a/internal/prober/browser/browser_test.go
+++ b/internal/prober/browser/browser_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/testhelper"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/rs/zerolog"
@@ -19,33 +20,37 @@ func TestNewProber(t *testing.T) {
 	logger := zerolog.New(zerolog.NewTestWriter(t))
 
 	testcases := map[string]struct {
-		check         sm.Check
+		check         model.Check
 		expectFailure bool
 	}{
 		"valid": {
 			expectFailure: false,
-			check: sm.Check{
-				Target:    "http://www.example.org",
-				Job:       "test",
-				Frequency: 10 * 1000,
-				Timeout:   10 * 1000,
-				Probes:    []int64{1},
-				Settings: sm.CheckSettings{
-					Browser: &sm.BrowserSettings{
-						Script: []byte("// test"),
+			check: model.Check{
+				Check: sm.Check{
+					Target:    "http://www.example.org",
+					Job:       "test",
+					Frequency: 10 * 1000,
+					Timeout:   10 * 1000,
+					Probes:    []int64{1},
+					Settings: sm.CheckSettings{
+						Browser: &sm.BrowserSettings{
+							Script: []byte("// test"),
+						},
 					},
 				},
 			},
 		},
 		"invalid": {
 			expectFailure: true,
-			check: sm.Check{
-				Target:    "http://www.example.org",
-				Job:       "test",
-				Frequency: 10 * 1000,
-				Timeout:   10 * 1000,
-				Probes:    []int64{1},
-				Settings:  sm.CheckSettings{},
+			check: model.Check{
+				Check: sm.Check{
+					Target:    "http://www.example.org",
+					Job:       "test",
+					Frequency: 10 * 1000,
+					Timeout:   10 * 1000,
+					Probes:    []int64{1},
+					Settings:  sm.CheckSettings{},
+				},
 			},
 		},
 	}

--- a/internal/prober/dns/dns.go
+++ b/internal/prober/dns/dns.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/dns/internal/bbe/config"
 	bbeprober "github.com/grafana/synthetic-monitoring-agent/internal/prober/dns/internal/bbe/prober"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
@@ -21,7 +22,7 @@ type Prober struct {
 	experimental bool
 }
 
-func NewProber(check sm.Check) (Prober, error) {
+func NewProber(check model.Check) (Prober, error) {
 	if check.Settings.Dns == nil {
 		return Prober{}, errUnsupportedCheck
 	}
@@ -35,7 +36,7 @@ func NewProber(check sm.Check) (Prober, error) {
 	}, nil
 }
 
-func NewExperimentalProber(check sm.Check) (Prober, error) {
+func NewExperimentalProber(check model.Check) (Prober, error) {
 	p, err := NewProber(check)
 	if err != nil {
 		return p, err

--- a/internal/prober/dns/dns_test.go
+++ b/internal/prober/dns/dns_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/dns/internal/bbe/config"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/miekg/dns"
@@ -27,17 +28,17 @@ func TestName(t *testing.T) {
 
 func TestNewProber(t *testing.T) {
 	testcases := map[string]struct {
-		input       sm.Check
+		input       model.Check
 		expected    Prober
 		ExpectError bool
 	}{
 		"default": {
-			input: sm.Check{
+			input: model.Check{Check: sm.Check{
 				Target: "www.grafana.com",
 				Settings: sm.CheckSettings{
 					Dns: &sm.DnsSettings{},
 				},
-			},
+			}},
 			expected: Prober{
 				config: config.Module{
 					Prober:  "dns",
@@ -55,10 +56,12 @@ func TestNewProber(t *testing.T) {
 			ExpectError: false,
 		},
 		"no-settings": {
-			input: sm.Check{
-				Target: "www.grafana.com",
-				Settings: sm.CheckSettings{
-					Dns: nil,
+			input: model.Check{
+				Check: sm.Check{
+					Target: "www.grafana.com",
+					Settings: sm.CheckSettings{
+						Dns: nil,
+					},
 				},
 			},
 			expected:    Prober{},
@@ -221,15 +224,17 @@ func TestProberRetries(t *testing.T) {
 		}
 	}()
 
-	p, err := NewExperimentalProber(sm.Check{
-		Target:  "www.grafana.com",
-		Timeout: 20000,
-		Settings: sm.CheckSettings{
-			Dns: &sm.DnsSettings{
-				Server:     l.LocalAddr().String(),
-				RecordType: sm.DnsRecordType_A,
-				Protocol:   sm.DnsProtocol_UDP,
-				IpVersion:  sm.IpVersion_V4,
+	p, err := NewExperimentalProber(model.Check{
+		Check: sm.Check{
+			Target:  "www.grafana.com",
+			Timeout: 20000,
+			Settings: sm.CheckSettings{
+				Dns: &sm.DnsSettings{
+					Server:     l.LocalAddr().String(),
+					RecordType: sm.DnsRecordType_A,
+					Protocol:   sm.DnsProtocol_UDP,
+					IpVersion:  sm.IpVersion_V4,
+				},
 			},
 		},
 	})

--- a/internal/prober/grpc/grpc.go
+++ b/internal/prober/grpc/grpc.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
 	"github.com/grafana/synthetic-monitoring-agent/internal/tls"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
@@ -20,7 +21,7 @@ type Prober struct {
 	config config.Module
 }
 
-func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger) (Prober, error) {
+func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger) (Prober, error) {
 	if check.Settings.Grpc == nil {
 		return Prober{}, errUnsupportedCheck
 	}

--- a/internal/prober/grpc/grpc_test.go
+++ b/internal/prober/grpc/grpc_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/prometheus/blackbox_exporter/config"
 	promcfg "github.com/prometheus/common/config"
@@ -19,15 +20,17 @@ func TestName(t *testing.T) {
 
 func TestNewProber(t *testing.T) {
 	testcases := map[string]struct {
-		input       sm.Check
+		input       model.Check
 		expected    Prober
 		ExpectError bool
 	}{
 		"default": {
-			input: sm.Check{
-				Target: "www.grafana.com",
-				Settings: sm.CheckSettings{
-					Grpc: &sm.GrpcSettings{},
+			input: model.Check{
+				Check: sm.Check{
+					Target: "www.grafana.com",
+					Settings: sm.CheckSettings{
+						Grpc: &sm.GrpcSettings{},
+					},
 				},
 			},
 			expected: Prober{
@@ -42,10 +45,12 @@ func TestNewProber(t *testing.T) {
 			},
 		},
 		"no-settings": {
-			input: sm.Check{
-				Target: "www.grafana.com",
-				Settings: sm.CheckSettings{
-					Grpc: nil,
+			input: model.Check{
+				Check: sm.Check{
+					Target: "www.grafana.com",
+					Settings: sm.CheckSettings{
+						Grpc: nil,
+					},
 				},
 			},
 			ExpectError: true,

--- a/internal/prober/http/http.go
+++ b/internal/prober/http/http.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
 	"github.com/grafana/synthetic-monitoring-agent/internal/tls"
 	"github.com/grafana/synthetic-monitoring-agent/internal/version"
@@ -29,13 +30,13 @@ type Prober struct {
 	cacheBustingQueryParamName string
 }
 
-func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, reservedHeaders http.Header) (Prober, error) {
+func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, reservedHeaders http.Header) (Prober, error) {
 	if check.Settings.Http == nil {
 		return Prober{}, errUnsupportedCheck
 	}
 
 	if len(reservedHeaders) > 0 {
-		augmentHttpHeaders(&check, reservedHeaders)
+		augmentHttpHeaders(&check.Check, reservedHeaders)
 	}
 
 	cfg, err := settingsToModule(ctx, check.Settings.Http, logger)

--- a/internal/prober/icmp/icmp.go
+++ b/internal/prober/icmp/icmp.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/prometheus/blackbox_exporter/config"
@@ -29,7 +30,7 @@ type Prober struct {
 	config Module
 }
 
-func NewProber(check sm.Check) (Prober, error) {
+func NewProber(check model.Check) (Prober, error) {
 	var p Prober
 
 	if check.Settings.Ping == nil {

--- a/internal/prober/icmp/icmp_test.go
+++ b/internal/prober/icmp/icmp_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/prometheus/blackbox_exporter/config"
 	bbeprober "github.com/prometheus/blackbox_exporter/prober"
@@ -21,15 +22,17 @@ func TestName(t *testing.T) {
 
 func TestNewProber(t *testing.T) {
 	testcases := map[string]struct {
-		input       sm.Check
+		input       model.Check
 		expected    Prober
 		ExpectError bool
 	}{
 		"default": {
-			input: sm.Check{
-				Target: "www.grafana.com",
-				Settings: sm.CheckSettings{
-					Ping: &sm.PingSettings{},
+			input: model.Check{
+				Check: sm.Check{
+					Target: "www.grafana.com",
+					Settings: sm.CheckSettings{
+						Ping: &sm.PingSettings{},
+					},
 				},
 			},
 			expected: Prober{
@@ -49,11 +52,13 @@ func TestNewProber(t *testing.T) {
 			ExpectError: false,
 		},
 		"1 packet": {
-			input: sm.Check{
-				Target: "www.grafana.com",
-				Settings: sm.CheckSettings{
-					Ping: &sm.PingSettings{
-						PacketCount: 1,
+			input: model.Check{
+				Check: sm.Check{
+					Target: "www.grafana.com",
+					Settings: sm.CheckSettings{
+						Ping: &sm.PingSettings{
+							PacketCount: 1,
+						},
 					},
 				},
 			},
@@ -74,11 +79,13 @@ func TestNewProber(t *testing.T) {
 			ExpectError: false,
 		},
 		"2 packets": {
-			input: sm.Check{
-				Target: "www.grafana.com",
-				Settings: sm.CheckSettings{
-					Ping: &sm.PingSettings{
-						PacketCount: 2,
+			input: model.Check{
+				Check: sm.Check{
+					Target: "www.grafana.com",
+					Settings: sm.CheckSettings{
+						Ping: &sm.PingSettings{
+							PacketCount: 2,
+						},
 					},
 				},
 			},
@@ -99,10 +106,12 @@ func TestNewProber(t *testing.T) {
 			ExpectError: false,
 		},
 		"no-settings": {
-			input: sm.Check{
-				Target: "www.grafana.com",
-				Settings: sm.CheckSettings{
-					Ping: nil,
+			input: model.Check{
+				Check: sm.Check{
+					Target: "www.grafana.com",
+					Settings: sm.CheckSettings{
+						Ping: nil,
+					},
 				},
 			},
 			expected:    Prober{},
@@ -213,13 +222,15 @@ func TestProber(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
 
-	prober, err := NewProber(sm.Check{
-		Target:  "127.0.0.1",
-		Timeout: 1000,
-		Settings: sm.CheckSettings{
-			Ping: &sm.PingSettings{
-				IpVersion:   sm.IpVersion_V4,
-				PacketCount: 1,
+	prober, err := NewProber(model.Check{
+		Check: sm.Check{
+			Target:  "127.0.0.1",
+			Timeout: 1000,
+			Settings: sm.CheckSettings{
+				Ping: &sm.PingSettings{
+					IpVersion:   sm.IpVersion_V4,
+					PacketCount: 1,
+				},
 			},
 		},
 	})

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -55,7 +55,7 @@ func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runne
 			Settings: k6runner.Settings{
 				Timeout: check.Timeout,
 			},
-			// TODO: Add metadata & features here.
+			CheckInfo: k6runner.CheckInfoFromSM(check),
 		},
 	}
 

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,7 +29,7 @@ type Prober struct {
 	processor *k6runner.Processor
 }
 
-func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runner k6runner.Runner, reservedHeaders http.Header) (Prober, error) {
+func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, reservedHeaders http.Header) (Prober, error) {
 	var p Prober
 
 	if check.Settings.Multihttp == nil {
@@ -40,7 +41,7 @@ func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runne
 	}
 
 	if len(reservedHeaders) > 0 {
-		augmentHttpHeaders(&check, reservedHeaders)
+		augmentHttpHeaders(&check.Check, reservedHeaders)
 	}
 
 	script, err := settingsToScript(check.Settings.Multihttp)

--- a/internal/prober/multihttp/multihttp_test.go
+++ b/internal/prober/multihttp/multihttp_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/testhelper"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/rs/zerolog"
@@ -21,28 +22,30 @@ func TestNewProber(t *testing.T) {
 	logger := zerolog.New(zerolog.NewTestWriter(t))
 
 	testcases := map[string]struct {
-		check         sm.Check
+		check         model.Check
 		expectFailure bool
 	}{
 		"valid": {
 			expectFailure: false,
-			check: sm.Check{
-				Id:        1,
-				Target:    "http://www.example.org",
-				Job:       "test",
-				Frequency: 10 * 1000,
-				Timeout:   10 * 1000,
-				Probes:    []int64{1},
-				Settings: sm.CheckSettings{
-					Multihttp: &sm.MultiHttpSettings{
-						Entries: []*sm.MultiHttpEntry{
-							{
-								Request: &sm.MultiHttpEntryRequest{
-									Url: "http://www.example.org",
-									QueryFields: []*sm.QueryField{
-										{
-											Name:  "q",
-											Value: "${v}",
+			check: model.Check{
+				Check: sm.Check{
+					Id:        1,
+					Target:    "http://www.example.org",
+					Job:       "test",
+					Frequency: 10 * 1000,
+					Timeout:   10 * 1000,
+					Probes:    []int64{1},
+					Settings: sm.CheckSettings{
+						Multihttp: &sm.MultiHttpSettings{
+							Entries: []*sm.MultiHttpEntry{
+								{
+									Request: &sm.MultiHttpEntryRequest{
+										Url: "http://www.example.org",
+										QueryFields: []*sm.QueryField{
+											{
+												Name:  "q",
+												Value: "${v}",
+											},
 										},
 									},
 								},
@@ -54,18 +57,20 @@ func TestNewProber(t *testing.T) {
 		},
 		"settings must be valid": {
 			expectFailure: true,
-			check: sm.Check{
-				Id:        2,
-				Target:    "http://www.example.org",
-				Job:       "test",
-				Frequency: 10 * 1000,
-				Timeout:   10 * 1000,
-				Probes:    []int64{1},
-				Settings: sm.CheckSettings{
-					Multihttp: &sm.MultiHttpSettings{
-						Entries: []*sm.MultiHttpEntry{
-							// This is invalid because the requsest does not have a URL
-							{},
+			check: model.Check{
+				Check: sm.Check{
+					Id:        2,
+					Target:    "http://www.example.org",
+					Job:       "test",
+					Frequency: 10 * 1000,
+					Timeout:   10 * 1000,
+					Probes:    []int64{1},
+					Settings: sm.CheckSettings{
+						Multihttp: &sm.MultiHttpSettings{
+							Entries: []*sm.MultiHttpEntry{
+								// This is invalid because the requsest does not have a URL
+								{},
+							},
 						},
 					},
 				},
@@ -73,35 +78,39 @@ func TestNewProber(t *testing.T) {
 		},
 		"must contain multihttp settings": {
 			expectFailure: true,
-			check: sm.Check{
-				Id:        3,
-				Target:    "http://www.example.org",
-				Job:       "test",
-				Frequency: 10 * 1000,
-				Timeout:   10 * 1000,
-				Probes:    []int64{1},
-				Settings: sm.CheckSettings{
-					// The settings are valid for ping, but not for multihttp
-					Ping: &sm.PingSettings{},
+			check: model.Check{
+				Check: sm.Check{
+					Id:        3,
+					Target:    "http://www.example.org",
+					Job:       "test",
+					Frequency: 10 * 1000,
+					Timeout:   10 * 1000,
+					Probes:    []int64{1},
+					Settings: sm.CheckSettings{
+						// The settings are valid for ping, but not for multihttp
+						Ping: &sm.PingSettings{},
+					},
 				},
 			},
 		},
 		"header overwrite protection is case-insensitive": {
 			expectFailure: false,
-			check: sm.Check{
-				Id:        4,
-				Target:    "http://www.example.org",
-				Job:       "test",
-				Frequency: 10 * 1000,
-				Timeout:   10 * 1000,
-				Probes:    []int64{1},
-				Settings: sm.CheckSettings{
-					Multihttp: &sm.MultiHttpSettings{
-						Entries: []*sm.MultiHttpEntry{
-							{
-								Request: &sm.MultiHttpEntryRequest{
-									Url:     "http://www.example.org",
-									Headers: []*sm.HttpHeader{{Name: "X-sM-Id", Value: "9880-9880"}},
+			check: model.Check{
+				Check: sm.Check{
+					Id:        4,
+					Target:    "http://www.example.org",
+					Job:       "test",
+					Frequency: 10 * 1000,
+					Timeout:   10 * 1000,
+					Probes:    []int64{1},
+					Settings: sm.CheckSettings{
+						Multihttp: &sm.MultiHttpSettings{
+							Entries: []*sm.MultiHttpEntry{
+								{
+									Request: &sm.MultiHttpEntryRequest{
+										Url:     "http://www.example.org",
+										Headers: []*sm.HttpHeader{{Name: "X-sM-Id", Value: "9880-9880"}},
+									},
 								},
 							},
 						},

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -12,6 +12,7 @@ import (
 	kitlog "github.com/go-kit/kit/log" //nolint:staticcheck // TODO(mem): replace in BBE
 	"github.com/go-kit/log/level"
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/testhelper"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/mccutchen/go-httpbin/v2/httpbin"
@@ -836,12 +837,14 @@ func TestSettingsToScript(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, actual)
 
-	check := sm.Check{
-		Target:  settings.Entries[0].Request.Url,
-		Job:     "test",
-		Timeout: 10000,
-		Settings: sm.CheckSettings{
-			Multihttp: settings,
+	check := model.Check{
+		Check: sm.Check{
+			Target:  settings.Entries[0].Request.Url,
+			Job:     "test",
+			Timeout: 10000,
+			Settings: sm.CheckSettings{
+				Multihttp: settings,
+			},
 		},
 	}
 

--- a/internal/prober/prober.go
+++ b/internal/prober/prober.go
@@ -62,33 +62,33 @@ func (f proberFactory) New(ctx context.Context, logger zerolog.Logger, check mod
 
 	switch checkType := check.Type(); checkType {
 	case sm.CheckTypePing:
-		p, err = icmp.NewProber(check.Check)
+		p, err = icmp.NewProber(check)
 		target = check.Target
 
 	case sm.CheckTypeHttp:
 		reservedHeaders := f.getReservedHeaders(&check)
-		p, err = httpProber.NewProber(ctx, check.Check, logger, reservedHeaders)
+		p, err = httpProber.NewProber(ctx, check, logger, reservedHeaders)
 		target = check.Target
 
 	case sm.CheckTypeDns:
 		if f.features.IsSet(feature.ExperimentalDnsProber) {
-			p, err = dns.NewExperimentalProber(check.Check)
+			p, err = dns.NewExperimentalProber(check)
 		} else {
-			p, err = dns.NewProber(check.Check)
+			p, err = dns.NewProber(check)
 		}
 		target = check.Settings.Dns.Server
 
 	case sm.CheckTypeTcp:
-		p, err = tcp.NewProber(ctx, check.Check, logger)
+		p, err = tcp.NewProber(ctx, check, logger)
 		target = check.Target
 
 	case sm.CheckTypeTraceroute:
-		p, err = traceroute.NewProber(check.Check, logger)
+		p, err = traceroute.NewProber(check, logger)
 		target = check.Target
 
 	case sm.CheckTypeScripted:
 		if f.runner != nil {
-			p, err = scripted.NewProber(ctx, check.Check, logger, f.runner)
+			p, err = scripted.NewProber(ctx, check, logger, f.runner)
 			target = check.Target
 		} else {
 			err = fmt.Errorf("k6 checks are not enabled")
@@ -99,7 +99,7 @@ func (f proberFactory) New(ctx context.Context, logger zerolog.Logger, check mod
 		// we know that the runner is actually able to handle browser
 		// checks.
 		if f.runner != nil {
-			p, err = browser.NewProber(ctx, check.Check, logger, f.runner)
+			p, err = browser.NewProber(ctx, check, logger, f.runner)
 			target = check.Target
 		} else {
 			err = fmt.Errorf("k6 checks are not enabled")
@@ -108,14 +108,14 @@ func (f proberFactory) New(ctx context.Context, logger zerolog.Logger, check mod
 	case sm.CheckTypeMultiHttp:
 		if f.runner != nil {
 			reservedHeaders := f.getReservedHeaders(&check)
-			p, err = multihttp.NewProber(ctx, check.Check, logger, f.runner, reservedHeaders)
+			p, err = multihttp.NewProber(ctx, check, logger, f.runner, reservedHeaders)
 			target = check.Target
 		} else {
 			err = fmt.Errorf("k6 checks are not enabled")
 		}
 
 	case sm.CheckTypeGrpc:
-		p, err = grpc.NewProber(ctx, check.Check, logger)
+		p, err = grpc.NewProber(ctx, check, logger)
 		target = check.Target
 
 	default:

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -40,7 +40,7 @@ func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runne
 			Settings: k6runner.Settings{
 				Timeout: check.Timeout,
 			},
-			// TODO: Add metadata & features here.
+			CheckInfo: k6runner.CheckInfoFromSM(check),
 		},
 	}
 

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,7 +27,7 @@ type Prober struct {
 	processor *k6runner.Processor
 }
 
-func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger, runner k6runner.Runner) (Prober, error) {
+func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner) (Prober, error) {
 	var p Prober
 
 	if check.Settings.Scripted == nil {

--- a/internal/prober/scripted/scripted_test.go
+++ b/internal/prober/scripted/scripted_test.go
@@ -6,7 +6,8 @@ import (
 	"time"
 
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
-	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
@@ -18,33 +19,37 @@ func TestNewProber(t *testing.T) {
 	logger := zerolog.New(zerolog.NewTestWriter(t))
 
 	testcases := map[string]struct {
-		check         synthetic_monitoring.Check
+		check         model.Check
 		expectFailure bool
 	}{
 		"valid": {
 			expectFailure: false,
-			check: synthetic_monitoring.Check{
-				Target:    "http://www.example.org",
-				Job:       "test",
-				Frequency: 10 * 1000,
-				Timeout:   10 * 1000,
-				Probes:    []int64{1},
-				Settings: synthetic_monitoring.CheckSettings{
-					Scripted: &synthetic_monitoring.ScriptedSettings{
-						Script: []byte("// test"),
+			check: model.Check{
+				Check: sm.Check{
+					Target:    "http://www.example.org",
+					Job:       "test",
+					Frequency: 10 * 1000,
+					Timeout:   10 * 1000,
+					Probes:    []int64{1},
+					Settings: sm.CheckSettings{
+						Scripted: &sm.ScriptedSettings{
+							Script: []byte("// test"),
+						},
 					},
 				},
 			},
 		},
 		"invalid": {
 			expectFailure: true,
-			check: synthetic_monitoring.Check{
-				Target:    "http://www.example.org",
-				Job:       "test",
-				Frequency: 10 * 1000,
-				Timeout:   10 * 1000,
-				Probes:    []int64{1},
-				Settings:  synthetic_monitoring.CheckSettings{},
+			check: model.Check{
+				Check: sm.Check{
+					Target:    "http://www.example.org",
+					Job:       "test",
+					Frequency: 10 * 1000,
+					Timeout:   10 * 1000,
+					Probes:    []int64{1},
+					Settings:  sm.CheckSettings{},
+				},
 			},
 		},
 	}

--- a/internal/prober/tcp/tcp.go
+++ b/internal/prober/tcp/tcp.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
 	"github.com/grafana/synthetic-monitoring-agent/internal/tls"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
@@ -20,7 +21,7 @@ type Prober struct {
 	config config.Module
 }
 
-func NewProber(ctx context.Context, check sm.Check, logger zerolog.Logger) (Prober, error) {
+func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger) (Prober, error) {
 	if check.Settings.Tcp == nil {
 		return Prober{}, errUnsupportedCheck
 	}

--- a/internal/prober/tcp/tcp_test.go
+++ b/internal/prober/tcp/tcp_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/prometheus/blackbox_exporter/config"
 	"github.com/rs/zerolog"
@@ -19,15 +20,17 @@ func TestName(t *testing.T) {
 
 func TestNewProber(t *testing.T) {
 	testcases := map[string]struct {
-		input       sm.Check
+		input       model.Check
 		expected    Prober
 		ExpectError bool
 	}{
 		"default": {
-			input: sm.Check{
-				Target: "www.grafana.com",
-				Settings: sm.CheckSettings{
-					Tcp: &sm.TcpSettings{},
+			input: model.Check{
+				Check: sm.Check{
+					Target: "www.grafana.com",
+					Settings: sm.CheckSettings{
+						Tcp: &sm.TcpSettings{},
+					},
 				},
 			},
 			expected: Prober{
@@ -44,10 +47,12 @@ func TestNewProber(t *testing.T) {
 			ExpectError: false,
 		},
 		"no-settings": {
-			input: sm.Check{
-				Target: "www.grafana.com",
-				Settings: sm.CheckSettings{
-					Tcp: nil,
+			input: model.Check{
+				Check: sm.Check{
+					Target: "www.grafana.com",
+					Settings: sm.CheckSettings{
+						Tcp: nil,
+					},
 				},
 			},
 			expected:    Prober{},

--- a/internal/prober/traceroute/traceroute_test.go
+++ b/internal/prober/traceroute/traceroute_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -18,15 +19,17 @@ func TestName(t *testing.T) {
 func TestNewProber(t *testing.T) {
 	logger := zerolog.New(io.Discard)
 	testcases := map[string]struct {
-		input       sm.Check
+		input       model.Check
 		expected    Prober
 		ExpectError bool
 	}{
 		"default": {
-			input: sm.Check{
-				Target: "www.grafana.com",
-				Settings: sm.CheckSettings{
-					Traceroute: &sm.TracerouteSettings{},
+			input: model.Check{
+				Check: sm.Check{
+					Target: "www.grafana.com",
+					Settings: sm.CheckSettings{
+						Traceroute: &sm.TracerouteSettings{},
+					},
 				},
 			},
 			expected: Prober{
@@ -47,10 +50,12 @@ func TestNewProber(t *testing.T) {
 			ExpectError: false,
 		},
 		"no-settings": {
-			input: sm.Check{
-				Target: "www.grafana.com",
-				Settings: sm.CheckSettings{
-					Tcp: nil,
+			input: model.Check{
+				Check: sm.Check{
+					Target: "www.grafana.com",
+					Settings: sm.CheckSettings{
+						Tcp: nil,
+					},
 				},
 			},
 			expected:    Prober{},


### PR DESCRIPTION
Similar approach to https://github.com/grafana/synthetic-monitoring-agent/pull/904, but I chose to make a distinction between pure metadata, that is, data that makes it only to the telemetry and does not take part in any decision making, and actual information that is used for decision making. The latter is strongly typed.