### PR TITLE
ci: Fix argo workflow name conflict

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -191,7 +191,7 @@ steps:
   settings:
     add_ci_labels: true
     command: 'submit --from workflowtemplate/deploy-synthetic-monitoring-agent --name
-      deploy-synthetic-monitoring-agent-$(./scripts/version) --parameter mode=dev
+      deploy-synthetic-monitoring-agent-dev-$(./scripts/version) --parameter mode=dev
       --parameter dockertag=$(./scripts/version) --parameter commit=${DRONE_COMMIT}
       --parameter commit_author=${DRONE_COMMIT_AUTHOR} --parameter commit_link=${DRONE_COMMIT_LINK} '
     namespace: synthetic-monitoring-cd
@@ -208,7 +208,7 @@ steps:
   settings:
     add_ci_labels: true
     command: 'submit --from workflowtemplate/deploy-synthetic-monitoring-agent --name
-      deploy-synthetic-monitoring-agent-$(./scripts/version) --parameter mode=release
+      deploy-synthetic-monitoring-agent-release-$(./scripts/version) --parameter mode=release
       --parameter dockertag=$(./scripts/version) --parameter commit=${DRONE_COMMIT}
       --parameter commit_author=${DRONE_COMMIT_AUTHOR} --parameter commit_link=${DRONE_COMMIT_LINK} '
     namespace: synthetic-monitoring-cd


### PR DESCRIPTION
With the new release process, a push to main happens pretty much at the same time as the tag generation. Notice that the same naming is used for both workflows. This naming has a suffix that is set executing the ./scripts/version script, which will retrieve the current version with the command:
  git describe --dirty --tags --long --always
If this command executed for the push CI is run after the tag is created, it will generate a workflow name that conflicts with the one to be created for the tag, not allowing the tag CI/CD to create its workflow.

The fix adds an extra suffix to the workflow name that identifies the workflow "mode", dev for pushes to main, release for tags.