### PR TITLE
renovate: fix regex for self-updating

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -86,8 +86,8 @@
         "^\\.github/workflows/.*\\.ya?ml$",
       ],
       "matchStrings": [
-        "renovate-version: (?<currentValue>\\S+)",
-        "RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:(?<currentValue>\\S+)"
+        "renovate-version: (?<currentValue>[^@\\s]+)(?:@(?<currentDigest>\\S+))?",
+        "RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>\\S+))?"
       ]
     }
   ],


### PR DESCRIPTION
Follow-up to #768. I mistakenly thought that renovate would be fine to have `1.2.3@sha256:000` as `currentValue`, but it actually needs to have the sha part as `currentDigest`. This PR should fix that.