### PR TITLE
k6runner: rename error code "user" to "aborted"

### DIFF
--- a/internal/k6runner/http_test.go
+++ b/internal/k6runner/http_test.go
@@ -205,7 +205,7 @@ func TestScriptHTTPRun(t *testing.T) {
 				Metrics:   testMetrics,
 				Logs:      testLogs,
 				Error:     "syntax error somewhere or something",
-				ErrorCode: "user",
+				ErrorCode: "aborted",
 			},
 			statusCode:    http.StatusOK,
 			expectSuccess: false,
@@ -213,7 +213,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			expectLogs: nonDebugLogLine + fmt.Sprintf(
 				"msg=\"script did not execute successfully\" error=%q errorCode=%q\n",
 				"syntax error somewhere or something",
-				"user",
+				"aborted",
 			),
 		},
 		{
@@ -222,7 +222,7 @@ func TestScriptHTTPRun(t *testing.T) {
 				Metrics:   testMetrics,
 				Logs:      []byte(`level=error foo="b` + "\n"),
 				Error:     "we killed k6",
-				ErrorCode: "user",
+				ErrorCode: "aborted",
 			},
 			statusCode:    http.StatusUnprocessableEntity,
 			expectSuccess: false,
@@ -230,7 +230,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			expectLogs: `level="error"` + "\n" + fmt.Sprintf(
 				"msg=\"script did not execute successfully\" error=%q errorCode=%q\n",
 				"we killed k6",
-				"user",
+				"aborted",
 			),
 		},
 		{
@@ -239,7 +239,7 @@ func TestScriptHTTPRun(t *testing.T) {
 				Metrics:   []byte("probe_succ{"),
 				Logs:      testLogs,
 				Error:     "we killed k6",
-				ErrorCode: "user",
+				ErrorCode: "aborted",
 			},
 			statusCode:    http.StatusUnprocessableEntity,
 			expectSuccess: false,
@@ -247,7 +247,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			expectLogs: nonDebugLogLine + fmt.Sprintf(
 				"msg=\"script did not execute successfully\" error=%q errorCode=%q\n",
 				"we killed k6",
-				"user",
+				"aborted",
 			),
 		},
 		{

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -158,7 +158,8 @@ func (r Processor) Run(ctx context.Context, registry *prometheus.Registry, logge
 	case "":
 		// No error, all good.
 		return true, nil
-	case "timeout", "killed", "user", "failed":
+	// TODO: Remove "user" from this list, which has been renamed to "aborted".
+	case "timeout", "killed", "user", "failed", "aborted":
 		// These are user errors. The probe failed, but we don't return an error.
 		return false, nil
 	default:


### PR DESCRIPTION
Agent-side of https://github.com/grafana/sm-k6-runner/pull/310. This one should be merged **first**.