### PR TITLE
Update get-vault-secrets action

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: retrieve secrets
         id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@f0dd3480fa3e657d741dd9e8d9b999cfb61fc713
+        uses: grafana/shared-workflows/actions/get-vault-secrets@cb307dce8f12e7b1233da953f45a0565b4f4c728 # v1.0.0
         with:
           common_secrets: |
             GRAFANA_RENOVATE_APP_ID=grafana-renovate-app:app-id


### PR DESCRIPTION
Update get-vault-secrets-action to the last version to make it work with the new vault instance