### PR TITLE
Run agent + chromium as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,24 +10,36 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH
 
-ADD --chmod=0555 https://github.com/grafana/xk6-sm/releases/download/v0.0.3-pre/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
-COPY dist/${HOST_DIST}/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
-COPY scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
+RUN apk --no-cache add libcap
+RUN adduser -D -u 12345 -g 12345 sm
+
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.0.3-pre/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
+COPY --chown=sm:sm --chmod=0500 dist/${HOST_DIST}/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
+COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
+RUN setcap cap_net_raw=+ep /usr/local/bin/synthetic-monitoring-agent
+
+RUN apk del -f libcap
+USER sm
 ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
 
 # Third stage copies the setup from the base agent and
 # additionally installs Chromium to support browser checks.
 FROM ghcr.io/grafana/chromium-swiftshader-alpine:131.0.6778.264-r0-3.21.2@sha256:c3394ca2a5d82eecba8b8bceff972ca3f0f925ac9dec6cb24be8b84811f4f73f AS with-browser
-
 RUN apk --no-cache add --repository community tini
+RUN adduser -D -u 12345 -g 12345 sm
 
-COPY --from=release /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
-COPY --from=release /usr/local/bin/sm-k6 /usr/local/bin/sm-k6
+COPY --from=release --chown=sm:sm /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
+COPY --from=release --chown=sm:sm /usr/local/bin/sm-k6 /usr/local/bin/sm-k6
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
+# Removing any file with setuid bit set, such as /usr/lib/chromium/chrome-sandbox,
+# which is used for chromium sandboxing.
+RUN find / -type f -perm -4000 -delete
+
 ENV K6_BROWSER_ARGS=no-sandbox,disable-dev-shm-usage
 
+USER sm
 ENTRYPOINT ["tini", "--", "/usr/local/bin/synthetic-monitoring-agent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,29 +2,36 @@
 FROM --platform=$BUILDPLATFORM alpine:3.21.2@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS build
 RUN apk --no-cache add ca-certificates-bundle
 
-# Second stage copies the binaries, configuration and also the
-# certificates from the first stage.
-
-FROM alpine:3.21.2@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS release
+# setcapper stage handles adding file capabilities where needed
+FROM alpine:3.21.2@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS setcapper
 ARG TARGETOS
 ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH
 
 RUN apk --no-cache add libcap
-RUN adduser -D -u 12345 -g 12345 sm
 
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.0.3-pre/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
 COPY --chown=sm:sm --chmod=0500 dist/${HOST_DIST}/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
-COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 RUN setcap cap_net_raw=+ep /usr/local/bin/synthetic-monitoring-agent
 
-RUN apk del -f libcap
+# Base release copies the binaries, configuration and also the
+# certificates from the first stage.
+FROM alpine:3.21.2@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS release
+ARG TARGETOS
+ARG TARGETARCH
+ARG HOST_DIST=$TARGETOS-$TARGETARCH
+
+RUN adduser -D -u 12345 -g 12345 sm
+
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.0.3-pre/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
+COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
+COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 USER sm
 ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
 
-# Third stage copies the setup from the base agent and
+# Browser release copies the setup from the base agent and
 # additionally installs Chromium to support browser checks.
 FROM ghcr.io/grafana/chromium-swiftshader-alpine:131.0.6778.264-r0-3.21.2@sha256:c3394ca2a5d82eecba8b8bceff972ca3f0f925ac9dec6cb24be8b84811f4f73f AS with-browser
 RUN apk --no-cache add --repository community tini

--- a/Dockerfile.browser
+++ b/Dockerfile.browser
@@ -1,10 +1,16 @@
+FROM --platform=$BUILDPLATFORM alpine:3.21.2@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS build
+RUN adduser -D -u 12345 -g 12345 sm
+
 FROM --platform=$TARGETOS/$TARGETARCH scratch
 
 ARG TARGETOS
 ARG TARGETARCH
+RUN adduser -D -u 12345 -g 12345 sm
 
 ADD ./dist/container-image.browser.${TARGETOS}-${TARGETARCH}.tar /
+COPY --from=0 /etc/passwd /etc/passwd
 
+USER sm
 ENV K6_BROWSER_ARGS=no-sandbox,disable-dev-shm-usage
 
 ENTRYPOINT ["tini", "--", "/usr/local/bin/synthetic-monitoring-agent"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -2,29 +2,36 @@
 FROM --platform=$BUILDPLATFORM alpine:3.21.2@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS build
 RUN apk --no-cache add ca-certificates-bundle
 
-# Second stage copies the binaries, configuration and also the
-# certificates from the first stage.
-
-FROM alpine:3.21.2@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS release
+# setcapper stage handles adding file capabilities where needed
+FROM alpine:3.21.2@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS setcapper
 ARG TARGETOS
 ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH
 
 RUN apk --no-cache add libcap
-RUN adduser -D -u 12345 -g 12345 sm
 
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.0.3-pre/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
 COPY --chown=sm:sm --chmod=0500 dist/${HOST_DIST}/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
-COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 RUN setcap cap_net_raw=+ep /usr/local/bin/synthetic-monitoring-agent
 
-RUN apk del -f libcap
+# Base release copies the binaries, configuration and also the
+# certificates from the first stage.
+FROM alpine:3.21.2@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS release
+ARG TARGETOS
+ARG TARGETARCH
+ARG HOST_DIST=$TARGETOS-$TARGETARCH
+
+RUN adduser -D -u 12345 -g 12345 sm
+
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.0.3-pre/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
+COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
+COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
 USER sm
 ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
 
-# Third stage copies the setup from the base agent and
+# Browser release copies the setup from the base agent and
 # additionally installs Chromium to support browser checks.
 FROM ghcr.io/grafana/chromium-swiftshader-alpine:131.0.6778.264-r0-3.21.2@sha256:c3394ca2a5d82eecba8b8bceff972ca3f0f925ac9dec6cb24be8b84811f4f73f AS with-browser
 RUN apk --no-cache add --repository community tini
@@ -42,4 +49,4 @@ RUN find / -type f -perm -4000 -delete
 ENV K6_BROWSER_ARGS=no-sandbox,disable-dev-shm-usage
 
 USER sm
-ENTRYPOINT ["tini", "--", "/usr/local/bin/synthetic-monitoring-agent"
+ENTRYPOINT ["tini", "--", "/usr/local/bin/synthetic-monitoring-agent"]

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -10,24 +10,36 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH
 
-ADD --chmod=0555 https://github.com/grafana/xk6-sm/releases/download/v0.0.3-pre/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
-COPY dist/${HOST_DIST}/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
-COPY scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
+RUN apk --no-cache add libcap
+RUN adduser -D -u 12345 -g 12345 sm
+
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.0.3-pre/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
+COPY --chown=sm:sm --chmod=0500 dist/${HOST_DIST}/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
+COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
+RUN setcap cap_net_raw=+ep /usr/local/bin/synthetic-monitoring-agent
+
+RUN apk del -f libcap
+USER sm
 ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
 
 # Third stage copies the setup from the base agent and
 # additionally installs Chromium to support browser checks.
 FROM ghcr.io/grafana/chromium-swiftshader-alpine:131.0.6778.264-r0-3.21.2@sha256:c3394ca2a5d82eecba8b8bceff972ca3f0f925ac9dec6cb24be8b84811f4f73f AS with-browser
-
 RUN apk --no-cache add --repository community tini
+RUN adduser -D -u 12345 -g 12345 sm
 
-COPY --from=release /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
-COPY --from=release /usr/local/bin/sm-k6 /usr/local/bin/sm-k6
+COPY --from=release --chown=sm:sm /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
+COPY --from=release --chown=sm:sm /usr/local/bin/sm-k6 /usr/local/bin/sm-k6
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
+# Removing any file with setuid bit set, such as /usr/lib/chromium/chrome-sandbox,
+# which is used for chromium sandboxing.
+RUN find / -type f -perm -4000 -delete
+
 ENV K6_BROWSER_ARGS=no-sandbox,disable-dev-shm-usage
 
-ENTRYPOINT ["tini", "--", "/usr/local/bin/synthetic-monitoring-agent"]
+USER sm
+ENTRYPOINT ["tini", "--", "/usr/local/bin/synthetic-monitoring-agent"

--- a/Dockerfile.no-browser
+++ b/Dockerfile.no-browser
@@ -1,8 +1,14 @@
+FROM --platform=$BUILDPLATFORM alpine:3.21.2@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099 AS build
+RUN adduser -D -u 12345 -g 12345 sm
+
 FROM --platform=$TARGETOS/$TARGETARCH scratch
 
 ARG TARGETOS
 ARG TARGETARCH
+RUN adduser -D -u 12345 -g 12345 sm
 
 ADD ./dist/container-image.no-browser.${TARGETOS}-${TARGETARCH}.tar /
+COPY --from=0 /etc/passwd /etc/passwd
 
+USER sm
 ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-agent/issues/847

This might be a little naive, please keep me honest. cc @mem @nadiamoe 

**Looking for feedback on the following**
* ~~Confirm: version this as a breaking change?~~
* Can we make this more restrictive?
* ~~Q about k8s `securityContext` at the bottom of this description.~~

\
**Summary:**
* Sets up a non-root user for both the `release` and `with-browser` build targets of the Dockerfile.
* Updates the `scratch`/tarball-based images to do the same.
* Tested every protocol check config I could attempt (IPv4, IPv6, DNS, traceroute, etc.)
* Tested scripted and browser checks, seem to work.
* Tested on Docker directly as well as K8s.


### K8s securityContext
Here's the toy YAML that I used to run this in my local cluster:
```
apiVersion: v1
kind: Pod
metadata:
  name: agent
  labels:
    app.kubernetes.io/name: agent
spec:
  securityContext:
  containers:
    - name: agent-tip
      image: only-agent
      imagePullPolicy: Never
      ports:
        - containerPort: 4050
          name: http-metric
      args:
        - --api-server-address=$(API_SERVER)
        - --api-token=$(API_TOKEN)
        - --verbose=true
      env:
        - name: API_TOKEN
          value: "<API_TOKEN>"
        - name: API_SERVER
          value: "synthetic-monitoring-grpc-us-east-0.grafana.net:443"
      securityContext:
        runAsUser: 12345
        runAsGroup: 12345
        runAsNonRoot: true
        # allowPrivilegeEscalation: false
        capabilities:
          drop: ["all"]
          add: ["NET_RAW"]
```

The issue with this `securityContext`:
```
securityContext:
  runAsUser: 12345
  runAsGroup: 12345
  runAsNonRoot: true
  # allowPrivilegeEscalation: false
  capabilities:
    drop: ["all"]
    add: ["NET_RAW"]
```

Is that if I uncomment `allowPrivilegeEscalation: false` then I run into the following error:
```
listen ip4:icmp 0.0.0.0: socket: operation not permitted
```

Which, I guess, is from the default behaviour of listening on `localhost:4050` for the `/metrics` endpoint?