### PR TITLE
Fix: rework package creation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,13 +13,13 @@ steps:
   - ./scripts/enforce-clean
   depends_on:
   - runner identification
-  image: ghcr.io/grafana/grafana-build-tools:v0.27.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
   name: deps
 - commands:
   - make lint
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.27.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
   name: lint
 - commands:
   - git fetch origin --tags
@@ -30,14 +30,14 @@ steps:
   - make build
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.27.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
   name: build
 - commands:
   - make test
   depends_on:
   - lint
   - build
-  image: ghcr.io/grafana/grafana-build-tools:v0.27.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
   name: test
 - commands: []
   depends_on:
@@ -154,7 +154,7 @@ steps:
   - ./scripts/generate-tags browser > .tags
   depends_on:
   - docker publish (release)
-  image: ghcr.io/grafana/grafana-build-tools:v0.27.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
   name: docker publish (with browser) tags
 - commands: []
   depends_on:
@@ -256,7 +256,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.27.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
   name: write-key
 - commands:
   - make release-snapshot
@@ -264,7 +264,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.27.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
   name: test release
 - commands:
   - ./scripts/package/verify-deb-install.sh
@@ -290,7 +290,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.27.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
   name: release
   when:
     ref:
@@ -353,6 +353,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: c5adf50255ab515cd23e2c20e7ab9f55d0c5cce370009c93f2720463c50b6245
+hmac: e000d9eb3f6dc2dbfc513a0af3e7f139904d05f0ba570ed6c0d0a30bada3640c
 
 ...

--- a/.gbt.mk
+++ b/.gbt.mk
@@ -4,4 +4,4 @@
 # and a shell script. This is achieved by using the `VAR=value` syntax, which
 # is valid in both Makefile and shell.
 
-GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v0.27.0
+GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v0.29.1

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: github-hosted-ubuntu-${{ matrix.arch }}
 
     container:
-      image: ghcr.io/grafana/grafana-build-tools:v0.24.0@sha256:309c71f542b53fcb5fbc9042ec45cbab881a3b310c3a57b843d8ffe979bfa951
+      image: ghcr.io/grafana/grafana-build-tools:v0.29.1@sha256:c8728b51147a55389149fef94e6f6ae0ffd3ce08f85dea95716864c42f869fb1
     outputs:
       version: ${{ steps.version.outputs.value }}
 
@@ -82,6 +82,9 @@ jobs:
 
       - name: test
         run: make test
+
+      - name: build packages
+        run: make package-native
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1

--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/grafana/grafana-build-tools:v0.24.0@sha256:309c71f542b53fcb5fbc9042ec45cbab881a3b310c3a57b843d8ffe979bfa951
+      image: ghcr.io/grafana/grafana-build-tools:v0.29.1@sha256:c8728b51147a55389149fef94e6f6ae0ffd3ce08f85dea95716864c42f869fb1
 
     steps:
       - name: checkout

--- a/scripts/configs/drone/go-tools-image.libsonnet
+++ b/scripts/configs/drone/go-tools-image.libsonnet
@@ -1,1 +1,1 @@
-"ghcr.io/grafana/grafana-build-tools:v0.27.0"
+"ghcr.io/grafana/grafana-build-tools:v0.29.1"

--- a/scripts/make/helpers.mk
+++ b/scripts/make/helpers.mk
@@ -41,8 +41,16 @@ distclean: clean ## Clean up all build artifacts.
 
 .PHONY: version
 version: ## Create version information file.
+version: $(DISTDIR)/version.new
+	# Look at the new version file and replace it only if it has changed.
+	$(S) cmp -s $(DISTDIR)/version.new $(DISTDIR)/version && \
+		rm $(DISTDIR)/version.new || \
+		mv $(DISTDIR)/version.new $(DISTDIR)/version
+	$(S) cat $(DISTDIR)/version
+
+$(DISTDIR)/version $(DISTDIR)/version.new:
 	$(S) mkdir -p $(DISTDIR)
-	$(S) ./scripts/version | tee $(DISTDIR)/version
+	$(S) ./scripts/version > $@
 
 .PHONY: update-tools
 update-tools: ## Update tools
@@ -71,6 +79,7 @@ docker-image: docker-build
 
 .PHONY: docker-push
 docker-push:  docker
+
 	$(S) docker push $(DOCKER_TAG)
 	$(S) docker tag $(DOCKER_TAG) $(DOCKER_TAG):$(BUILD_VERSION)
 	$(S) docker push $(DOCKER_TAG):$(BUILD_VERSION)

--- a/scripts/make/release.mk
+++ b/scripts/make/release.mk
@@ -14,3 +14,54 @@ release: $(GORELEASER) ## Build a release and publish it to Github.
 release-snapshot: $(GORELEASER) ## Build a snapshot release for testing (not published).
 	$(S) echo "Building release files..."		
 	$(GORELEASER) release --snapshot --rm-dist $(GORELEASER_FLAGS)
+
+define package_template
+PACKAGE_TARGETS += package-$(1)-$(2)
+
+$(DISTDIR)/$(1)-$(2)/nfpm-input.yaml: $(DISTDIR)/version
+	'$(ROOTDIR)/scripts/package/create-parameters-file' '$$@' '$(1)' '$(2)' '$(BUILD_VERSION)' '$(ROOTDIR)' '$(DISTDIR)'
+
+$(DISTDIR)/$(1)-$(2)/nfpm.yaml : $(DISTDIR)/$(1)-$(2)/nfpm-input.yaml
+$(DISTDIR)/$(1)-$(2)/nfpm.yaml : $(ROOTDIR)/scripts/package/nfpm.yaml.template
+$(DISTDIR)/$(1)-$(2)/nfpm.yaml :
+	$(S) mkdir -p $(DISTDIR)/$(1)-$(2)
+	$(S) gomplate \
+		--context '.=file://$(DISTDIR)/$(1)-$(2)/nfpm-input.yaml' \
+		--file '$(ROOTDIR)/scripts/package/nfpm.yaml.template' \
+		> '$$@'
+
+package-deb-$(1)-$(2) : $(DISTDIR)/$(1)-$(2)/nfpm.yaml $(DISTDIR)/changelog.yaml
+	$(S) nfpm package \
+		--config $(DISTDIR)/$(1)-$(2)/nfpm.yaml \
+		--packager deb \
+		--target $(DISTDIR)/$(1)-$(2)/
+
+package-rpm-$(1)-$(2) : $(DISTDIR)/$(1)-$(2)/nfpm.yaml $(DISTDIR)/changelog.yaml
+	$(S) nfpm package \
+		--config $(DISTDIR)/$(1)-$(2)/nfpm.yaml \
+		--packager rpm \
+		--target $(DISTDIR)/$(1)-$(2)/
+
+package-$(1)-$(2) : package-deb-$(1)-$(2) package-rpm-$(1)-$(2)
+	@true
+
+package : package-$(1)-$(2)
+endef
+
+$(foreach BUILD_PLATFORM,$(PLATFORMS), \
+	$(eval $(call package_template,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
+
+$(DISTDIR)/changelog.yaml: $(DISTDIR)/version
+	$(S) chglog init \
+		--conventional-commits \
+		--exclude-merge-commits \
+		--owner 'Grafana Labs <support@grafana.com>' \
+		--config-file '$(ROOTDIR)/scripts/package/chglog.yaml' \
+		--output '$@'
+
+.PHONY: package
+package:
+	@true
+
+package-native : package-$(HOST_OS)-$(HOST_ARCH)
+	@true

--- a/scripts/package/chglog.yaml
+++ b/scripts/package/chglog.yaml
@@ -1,0 +1,2 @@
+debug: false
+package-name: synthetic-monitoring-agent

--- a/scripts/package/create-parameters-file
+++ b/scripts/package/create-parameters-file
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+if [ "$#" -ne 6 ] ; then
+	cat 1>&2 <<-EOT
+	E: Incorrect number of parameters.
+
+	$0 DEST OS ARCH VERSION DISTDIR ROOTDIR
+	EOT
+
+	exit 1
+fi
+
+for p in "$@" ; do
+	if [ -z "$p" ] ; then
+		cat 1>&2 <<-EOT
+		E: Invalid parameters.
+
+		Got:
+		    $0 $@
+
+		Want:
+		    $0 DEST OS ARCH VERSION DISTDIR ROOTDIR
+		EOT
+
+		exit 1
+	fi
+done
+
+dstfile=$1
+
+shift
+
+tmpfile=$(mktemp)
+
+trap 'rm -f "${tmpfile}"' EXIT
+
+full_version=$3
+ROOTDIR=$4
+DISTDIR=$5
+
+version=$(echo "${full_version}" | cut -d- -f1)
+release=$(echo "${full_version}" | cut -d- -f2)
+
+cat > "${tmpfile}" <<-EOT
+	Os: "$1"
+	Arch: "$2"
+	Version: "$version"
+	Release: "$release"
+	ROOTDIR: "$ROOTDIR"
+	DISTDIR: "$DISTDIR"
+EOT
+
+mv "${tmpfile}" "${dstfile}"

--- a/scripts/package/nfpm.yaml.template
+++ b/scripts/package/nfpm.yaml.template
@@ -1,0 +1,27 @@
+name: "synthetic-monitoring-agent"
+arch: "{{ .Arch }}"
+platform: "{{ .Os }}"
+version: "{{ .Version }}"
+release: "{{ .Release }}"
+section: "net"
+priority: "optional"
+maintainer: Grafana Labs <support@grafana.com>
+description: Synthetic Monitoring Agent
+vendor: Grafana Labs Inc
+homepage: https://grafana.com/products/cloud/features/#synthetic-monitoring
+license: Apache2.0
+changelog: {{.DISTDIR}}/changelog.yaml
+contents:
+- src: {{.DISTDIR}}/{{.Os}}-{{.Arch}}/synthetic-monitoring-agent
+  dst: /usr/bin/synthetic-monitoring-agent
+- src: ./scripts/package/config/systemd/synthetic-monitoring-agent.conf
+  dst: /etc/synthetic-monitoring/synthetic-monitoring-agent.conf
+  type: 'config|noreplace'
+- src: ./scripts/package/config/systemd/synthetic-monitoring-agent.service
+  dst: /etc/systemd/system/synthetic-monitoring-agent.service
+
+# Copy k6 as sm-k6 to prevent clashing with k6 if it's installed.
+- src: {{.DISTDIR}}/{{.Os}}-{{.Arch}}/k6
+  dst: /usr/bin/sm-k6
+rpm:
+deb:


### PR DESCRIPTION
Instead of the weird workarounds with goreleaser, just use nfpm to create the packages.

- This doesn't do signing.
- This is not changing how the current release works, only adding targets and using them in the GitHub workflow.