### PR TITLE
Upgrade grafana-build-tools to v0.30.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,13 +13,13 @@ steps:
   - ./scripts/enforce-clean
   depends_on:
   - runner identification
-  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
+  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
   name: deps
 - commands:
   - make lint
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
+  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
   name: lint
 - commands:
   - git fetch origin --tags
@@ -30,14 +30,14 @@ steps:
   - make build
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
+  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
   name: build
 - commands:
   - make test
   depends_on:
   - lint
   - build
-  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
+  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
   name: test
 - commands: []
   depends_on:
@@ -154,7 +154,7 @@ steps:
   - ./scripts/generate-tags browser > .tags
   depends_on:
   - docker publish (release)
-  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
+  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
   name: docker publish (with browser) tags
 - commands: []
   depends_on:
@@ -256,7 +256,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
+  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
   name: write-key
 - commands:
   - make release-snapshot
@@ -264,7 +264,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
+  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
   name: test release
 - commands:
   - ./scripts/package/verify-deb-install.sh
@@ -290,7 +290,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.29.1
+  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
   name: release
   when:
     ref:
@@ -353,6 +353,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: e000d9eb3f6dc2dbfc513a0af3e7f139904d05f0ba570ed6c0d0a30bada3640c
+hmac: 63f22f89957a3c2d8f8b657bb0908326af5c2689cdc05c26bc437f666169e661
 
 ...

--- a/.gbt.mk
+++ b/.gbt.mk
@@ -4,4 +4,4 @@
 # and a shell script. This is achieved by using the `VAR=value` syntax, which
 # is valid in both Makefile and shell.
 
-GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v0.29.1
+GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v0.30.0

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: github-hosted-ubuntu-${{ matrix.arch }}
 
     container:
-      image: ghcr.io/grafana/grafana-build-tools:v0.29.1@sha256:c8728b51147a55389149fef94e6f6ae0ffd3ce08f85dea95716864c42f869fb1
+      image: ghcr.io/grafana/grafana-build-tools:v0.30.0@sha256:3e9d25e770f9c11d35df577141845e892e1a4ec13ca20461a4d7d6cf98156688
     outputs:
       version: ${{ steps.version.outputs.value }}
 

--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/grafana/grafana-build-tools:v0.29.1@sha256:c8728b51147a55389149fef94e6f6ae0ffd3ce08f85dea95716864c42f869fb1
+      image: ghcr.io/grafana/grafana-build-tools:v0.30.0@sha256:3e9d25e770f9c11d35df577141845e892e1a4ec13ca20461a4d7d6cf98156688
 
     steps:
       - name: checkout
@@ -59,6 +59,9 @@ jobs:
 
       - name: test
         run: make test
+
+      - name: build packages
+        run: make package-native
 
       - name: test docker build (no browser)
         uses: grafana/shared-workflows/actions/build-push-to-dockerhub@7d18a46aafb8b875ed76a0bc98852d74b91e7f91 # v1.0.0

--- a/scripts/configs/drone/go-tools-image.libsonnet
+++ b/scripts/configs/drone/go-tools-image.libsonnet
@@ -1,1 +1,1 @@
-"ghcr.io/grafana/grafana-build-tools:v0.29.1"
+"ghcr.io/grafana/grafana-build-tools:v0.30.0"


### PR DESCRIPTION
This includes gomplate, which is needed by the packaging scripts.