### PR TITLE
Fix: add packages to release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,13 +13,13 @@ steps:
   - ./scripts/enforce-clean
   depends_on:
   - runner identification
-  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.31.1
   name: deps
 - commands:
   - make lint
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.31.1
   name: lint
 - commands:
   - git fetch origin --tags
@@ -30,14 +30,14 @@ steps:
   - make build
   depends_on:
   - deps
-  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.31.1
   name: build
 - commands:
   - make test
   depends_on:
   - lint
   - build
-  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.31.1
   name: test
 - commands: []
   depends_on:
@@ -154,7 +154,7 @@ steps:
   - ./scripts/generate-tags browser > .tags
   depends_on:
   - docker publish (release)
-  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.31.1
   name: docker publish (with browser) tags
 - commands: []
   depends_on:
@@ -256,7 +256,7 @@ steps:
     NFPM_SIGNING_KEY:
       from_secret: gpg_private_key
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.31.1
   name: write-key
 - commands:
   - make release-snapshot
@@ -264,7 +264,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.31.1
   name: test release
 - commands:
   - ./scripts/package/verify-deb-install.sh
@@ -290,7 +290,7 @@ steps:
     NFPM_DEFAULT_PASSPHRASE:
       from_secret: gpg_passphrase
     NFPM_SIGNING_KEY_FILE: /drone/src/release-private-key.key
-  image: ghcr.io/grafana/grafana-build-tools:v0.30.0
+  image: ghcr.io/grafana/grafana-build-tools:v0.31.1
   name: release
   when:
     ref:
@@ -353,6 +353,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 63f22f89957a3c2d8f8b657bb0908326af5c2689cdc05c26bc437f666169e661
+hmac: 363b099264e7e2a4a3b840857d963aa0a79968952eac8cd40edadbda755b3b54
 
 ...

--- a/.gbt.mk
+++ b/.gbt.mk
@@ -4,4 +4,4 @@
 # and a shell script. This is achieved by using the `VAR=value` syntax, which
 # is valid in both Makefile and shell.
 
-GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v0.30.0
+GBT_IMAGE=ghcr.io/grafana/grafana-build-tools:v0.31.1

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: github-hosted-ubuntu-${{ matrix.arch }}
 
     container:
-      image: ghcr.io/grafana/grafana-build-tools:v0.30.0@sha256:3e9d25e770f9c11d35df577141845e892e1a4ec13ca20461a4d7d6cf98156688
+      image: ghcr.io/grafana/grafana-build-tools:v0.31.1@sha256:576971e115fdb8def851e8d4141388262e2c9d6c23e6c00c5d584d8c06943bcf
     outputs:
       version: ${{ steps.version.outputs.value }}
 
@@ -144,6 +144,24 @@ jobs:
       image_name: ${{ steps.extract-image-metadata.outputs.image }}
       image_version: ${{ steps.extract-image-metadata.outputs.tag }}
     steps:
+      - name: Retrieve release app credentials
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@7d18a46aafb8b875ed76a0bc98852d74b91e7f91  # v1.0.0
+        with:
+          vault_instance: prod
+          repo_secrets: |
+            SM_RELEASE_APP_ID=github-app:app-id
+            SM_RELEASE_APP_PRIVATE_KEY=github-app:private-key
+
+      - name: Generate release app token
+        id: sm-release-app
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1
+        with:
+          app-id: ${{ env.SM_RELEASE_APP_ID }}
+          private-key: ${{ env.SM_RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ needs.preflight.outputs.repo_name }}
+
       - name: checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
@@ -221,8 +239,21 @@ jobs:
           ./scripts/extract-image-info "${DOCKER_METADATA_OUTPUT_BAKE_FILE_TAGS}"
           ./scripts/extract-image-info "${DOCKER_METADATA_OUTPUT_BAKE_FILE_TAGS}" >> "$GITHUB_OUTPUT"
 
-  release:
-    name: release
+      # Add packages to release, but only in production mode, because dev mode doesn't have a tag.
+      - name: add packages to release
+        id: add-packages-to-release
+        env:
+          GH_TOKEN: ${{ steps.sm-release-app.outputs.token }}
+        if: ${{ always() && inputs.mode == 'prod' }}
+        run: |
+          tag=${GITHUB_REF##*/}
+          # Make sure this is a tag. The following command will fail otherwise.
+          git rev-parse "refs/tags/$tag"
+          find dist/ -mindepth 2 -maxdepth 2 -type f \( -name \*.rpm -o -name \*.deb \) -print0 |
+            xargs -r0 gh release upload "$tag"
+
+  deploy:
+    name: deploy
     needs:
       - preflight
       - publish_images

--- a/.github/workflows/build_and_publish_tag.yaml
+++ b/.github/workflows/build_and_publish_tag.yaml
@@ -7,7 +7,7 @@ on:
 
 # This is needed so that pushing to GAR works.
 permissions:
-  contents: read
+  contents: write # needed to upload release artifacts
   id-token: write
 
 jobs:

--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ghcr.io/grafana/grafana-build-tools:v0.30.0@sha256:3e9d25e770f9c11d35df577141845e892e1a4ec13ca20461a4d7d6cf98156688
+      image: ghcr.io/grafana/grafana-build-tools:v0.31.1@sha256:576971e115fdb8def851e8d4141388262e2c9d6c23e6c00c5d584d8c06943bcf
 
     steps:
       - name: checkout

--- a/scripts/configs/drone/go-tools-image.libsonnet
+++ b/scripts/configs/drone/go-tools-image.libsonnet
@@ -1,1 +1,1 @@
-"ghcr.io/grafana/grafana-build-tools:v0.30.0"
+"ghcr.io/grafana/grafana-build-tools:v0.31.1"


### PR DESCRIPTION
Use GitHub's command line tool (gh) to add packages to the existing release. The assumption is that the tag was created because there's a matching release.

This feels wrong, because we are creating a release and then later, in a separate workflow, we are adding files to that release, instead of doing it in a single location. From my point of view, the problem is that we are conceptually creating a release which creates a tag instead of the other way around. It's even a little weirder because GitHub does support the concept of "draft release", but release-please doesn't.

Fixes: #956