### PR TITLE
fix: k6runner: add level=error to deferred log reporting code from runner

### DIFF
--- a/internal/k6runner/http_test.go
+++ b/internal/k6runner/http_test.go
@@ -191,7 +191,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			expectSuccess: false,
 			expectError:   ErrFromRunner,
 			expectLogs: nonDebugLogLine + fmt.Sprintf(
-				"msg=\"script did not execute successfully\" error=%q errorCode=%q\n",
+				"level=\"error\" msg=\"script did not execute successfully\" error=%q errorCode=%q\n",
 				"something went wrong",
 				"something-wrong",
 			),
@@ -209,7 +209,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			expectSuccess: false,
 			expectError:   nil,
 			expectLogs: nonDebugLogLine + fmt.Sprintf(
-				"msg=\"script did not execute successfully\" error=%q errorCode=%q\n",
+				"level=\"error\" msg=\"script did not execute successfully\" error=%q errorCode=%q\n",
 				"syntax error somewhere or something",
 				"aborted",
 			),
@@ -226,7 +226,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			expectSuccess: false,
 			expectErrorAs: &logfmt.SyntaxError{},
 			expectLogs: `level="error"` + "\n" + fmt.Sprintf(
-				"msg=\"script did not execute successfully\" error=%q errorCode=%q\n",
+				"level=\"error\" msg=\"script did not execute successfully\" error=%q errorCode=%q\n",
 				"we killed k6",
 				"aborted",
 			),
@@ -243,7 +243,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			expectSuccess: false,
 			expectErrorAs: expfmt.ParseError{},
 			expectLogs: nonDebugLogLine + fmt.Sprintf(
-				"msg=\"script did not execute successfully\" error=%q errorCode=%q\n",
+				"level=\"error\" msg=\"script did not execute successfully\" error=%q errorCode=%q\n",
 				"we killed k6",
 				"aborted",
 			),

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -151,7 +151,12 @@ func (r Processor) Run(ctx context.Context, registry *prometheus.Registry, logge
 	// other logs.
 	if result.ErrorCode != "" {
 		defer func() {
-			err := logger.Log("msg", "script did not execute successfully", "error", result.Error, "errorCode", result.ErrorCode)
+			err := logger.Log(
+				"level", "error",
+				"msg", "script did not execute successfully",
+				"error", result.Error,
+				"errorCode", result.ErrorCode,
+			)
 			if err != nil {
 				internalLogger.Error().
 					Err(err).


### PR DESCRIPTION
This log line is added right after logs from the script itself, and helps bring some context on why the run was marked as failed. Previously, this did not have a log level, making it grey colored and not standing out a lot in the logs. This PR fixes that by making it `level=error`.