### PR TITLE
Chore: change release commit title

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -13,5 +13,6 @@
     }
   },
   "draft-pull-request": true,
+  "pull-request-title-pattern": "Chore: release ${version}",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
By default release-please creates a commit that looks like this:

	chore(main): release vX.Y.Z

Change this to:

	Chore: release vX.Y.Z

because the scope is superflous (this is not a monorepo, we only have one thing that we can release) and using uppercase to start the subject line is good form.