### PR TITLE
Chore: move named anchor in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-<a name="v0.28.0"></a>
 ## [0.29.4](https://github.com/grafana/synthetic-monitoring-agent/compare/v0.29.3...v0.29.4) (2024-11-11)
 
 
@@ -52,6 +51,7 @@
 
 * internal release ([#918](https://github.com/grafana/synthetic-monitoring-agent/issues/918)) ([60727a5](https://github.com/grafana/synthetic-monitoring-agent/commit/60727a54971e13f4f46f90f65db2e4253c9f6e00))
 
+<a name="v0.28.0"></a>
 ## [v0.28.0] - 2024-09-19
 ### Feature
 - add retries to ICMP prober ([#896](https://github.com/grafana/synthetic-monitoring-agent/issues/896))


### PR DESCRIPTION
Something was left behind when we started using release-please, and this anchor

	<a name="v0.28.0"></a>

keeps showing up at the top of the changelog.

Move it to the correct location.