### PR TITLE
chore: Dockerfile: revert split installation for amd64/arm64

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -75,14 +75,13 @@
       "customType": "regex",
       "fileMatch": [ "Dockerfile", "Dockerfile.build" ],
       "matchStrings": [
-        // Lines that loosely look like "apk add --repository community --arch value something=version".
+        // Lines that loosely look like "apk add --repository community something=version".
         // To keep this regex simple, only one package per "apk add" is supported.
-        "\\bapk\\b.+?\\badd\\b.+?(--repository|-X)[ =\\t]+(?<alpineRepo>[a-z]+)\\s+(--arch[ =\\t]+(?<arch>\\w+)\\s+)?(?<depName>[-\\w]+?)=(?<currentValue>[-.\\w]+)"
+        "\\bapk\\b.+?\\badd\\b.+?(--repository|-X)[ =\\t]+(?<alpineRepo>[a-z]+)\\s+(?<depName>[-\\w]+?)=(?<currentValue>[-.\\w]+)"
       ],
       "versioningTemplate": "loose", // The most lenient versioning renovate supports.
-      // We use different datasources for main and community, as alpine serves them in different URLs.
-      // Specifying --arch is optional, if not found it will default to x86_64.
-      "datasourceTemplate": "custom.alpine-{{alpineRepo}}-{{#if arch}}{{arch}}{{else}}x86_64{{/if}}",
+      // We use two different datasources for main and community, as alpine serves them in different URLs.
+      "datasourceTemplate": "custom.alpine-{{alpineRepo}}",
       // Extracted "versions" include the package name, so here we strip that prefix using a regex.
       "extractVersionTemplate": "{{depName}}-(?<version>.+).apk",
     },
@@ -103,20 +102,12 @@
   "customDatasources": {
     // Use alpine HTML mirror page as a repository. When using `html` format, renovate produces version strings from
     // all links present in the page. The version is extracted from that using extractVersionTemplate above.
-    "alpine-main-x86_64": {
+    "alpine-main": {
       "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main/x86_64/",
       "format": "html",
     },
-    "alpine-community-x86_64": {
+    "alpine-community": {
       "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/",
-      "format": "html",
-    },
-    "alpine-main-aarch64": {
-      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main/aarch64/",
-      "format": "html",
-    },
-    "alpine-community-aarch64": {
-      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/aarch64/",
       "format": "html",
     },
   },

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,16 +23,11 @@ ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
 # additionally installs Chromium to support browser checks.
 FROM --platform=$TARGETPLATFORM alpine:3.20.3 AS with-browser
 
-ARG TARGETARCH
-
 # Renovate updates the pinned packages below.
 # The --repository arg is required for renovate to know which alpine repo it should look for updates in.
 # To keep the renovate regex simple, only keep one package installation per line.
-# Furthermore, we split this into two lines to allow for the arm64 and amd64 versions of chromium to be different, as 
-# they have drifted in the past.
-RUN apk --no-cache add --repository community tini=0.19.0-r3
-RUN [[ "$TARGETARCH" != "amd64" ]] || apk --no-cache add --repository community --arch x86_64 chromium-swiftshader=131.0.6778.69-r0
-RUN [[ "$TARGETARCH" != "arm64" ]] || apk --no-cache add --repository community --arch aarch64 chromium-swiftshader=131.0.6778.69-r0
+RUN apk --no-cache add --repository community tini=0.19.0-r3 && \
+  apk --no-cache add --repository community chromium-swiftshader=131.0.6778.69-r0
 
 COPY --from=release /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release /usr/local/bin/sm-k6 /usr/local/bin/sm-k6

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -20,20 +20,12 @@ ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
 # Third stage copies the setup from the base agent and
 # additionally installs Chromium to support browser checks.
 FROM alpine:3.20.3 AS with-browser
-ARG TARGETOS
-ARG TARGETARCH
 
 # Renovate updates the pinned packages below.
 # The --repository arg is required for renovate to know which alpine repo it should look for updates in.
-# The --arch flag is necessary so that it knows which architecture to target.
 # To keep the renovate regex simple, only keep one package installation per line.
-#
-# Alpine does not have a consistent set of packages across all the
-# architectures, so we have to install different versions depending on which
-# one we are targeting.
 RUN apk --no-cache add --repository community tini=0.19.0-r3
-RUN if test "$TARGETARCH" = "amd64" ; then apk --no-cache add --repository community --arch x86_64  chromium-swiftshader=131.0.6778.69-r0 ; fi
-RUN if test "$TARGETARCH" = "arm64" ; then apk --no-cache add --repository community --arch aarch64 chromium-swiftshader=131.0.6778.69-r0 ; fi
+RUN apk --no-cache add --repository community chromium-swiftshader=131.0.6778.69-r0
 
 COPY --from=release /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release /usr/local/bin/sm-k6 /usr/local/bin/sm-k6


### PR DESCRIPTION
Reverts most of #1053. My understanding is that what happened is a very rare event, and I don't think the complexity of the workaround is worth having.