### PR TITLE
Base browser image on grafana/chromium-swiftshader-alpine

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -71,22 +71,6 @@
       ]
     },
     {
-      // Update pinned alpine packages in Dockerfile.
-      "customType": "regex",
-      "fileMatch": [ "Dockerfile", "Dockerfile.build" ],
-      "matchStrings": [
-        // Lines that loosely look like "apk add --repository community --arch value something=version".
-        // To keep this regex simple, only one package per "apk add" is supported.
-        "\\bapk\\b.+?\\badd\\b.+?(--repository|-X)[ =\\t]+(?<alpineRepo>[a-z]+)\\s+(--arch[ =\\t]+(?<arch>\\w+)\\s+)?(?<depName>[-\\w]+?)=(?<currentValue>[-.\\w]+)"
-      ],
-      "versioningTemplate": "loose", // The most lenient versioning renovate supports.
-      // We use different datasources for main and community, as alpine serves them in different URLs.
-      // Specifying --arch is optional, if not found it will default to x86_64.
-      "datasourceTemplate": "custom.alpine-{{alpineRepo}}-{{#if arch}}{{arch}}{{else}}x86_64{{/if}}",
-      // Extracted "versions" include the package name, so here we strip that prefix using a regex.
-      "extractVersionTemplate": "{{depName}}-(?<version>.+).apk",
-    },
-    {
       // Update renovate version in GHA workflow file.
       "customType": "regex",
       "depNameTemplate": "ghcr.io/renovatebot/renovate",
@@ -99,25 +83,5 @@
         "RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>\\S+))?"
       ]
     }
-  ],
-  "customDatasources": {
-    // Use alpine HTML mirror page as a repository. When using `html` format, renovate produces version strings from
-    // all links present in the page. The version is extracted from that using extractVersionTemplate above.
-    "alpine-main-x86_64": {
-      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main/x86_64/",
-      "format": "html",
-    },
-    "alpine-community-x86_64": {
-      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/x86_64/",
-      "format": "html",
-    },
-    "alpine-main-aarch64": {
-      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main/aarch64/",
-      "format": "html",
-    },
-    "alpine-community-aarch64": {
-      "defaultRegistryUrlTemplate": "https://dl-cdn.alpinelinux.org/alpine/latest-stable/community/aarch64/",
-      "format": "html",
-    },
-  },
+  ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -41,7 +41,16 @@
     {
       "matchPackageNames": "**/renovate",
       "extends": ["schedule:weekly"]
-    }
+    },
+    {
+      // The default "docker" versioning will try to restrict upgrades to versions that do not change everything after
+      // a dash (-) for the current tag, as this typically indicates the "flavor" (e.g. postgresql:17.1-alpine will not
+      // be upgraded to postgresql:17.2-debian).
+      // This image in particular has lots of dashes and does not follow this convention, so we force "loose"
+      // versioning which is pretty much an alphabetical sort.
+      "matchPackageNames": ["ghcr.io/grafana/chromium-swiftshader-alpine"],
+      "versioning": "loose",
+    },
   ],
 
   "customManagers": [

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -19,21 +19,9 @@ ENTRYPOINT ["/usr/local/bin/synthetic-monitoring-agent"]
 
 # Third stage copies the setup from the base agent and
 # additionally installs Chromium to support browser checks.
-FROM alpine:3.20.3 AS with-browser
-ARG TARGETOS
-ARG TARGETARCH
+FROM ghcr.io/grafana/chromium-swiftshader-alpine:131.0.6778.85-r0-3.20.3 AS with-browser
 
-# Renovate updates the pinned packages below.
-# The --repository arg is required for renovate to know which alpine repo it should look for updates in.
-# The --arch flag is necessary so that it knows which architecture to target.
-# To keep the renovate regex simple, only keep one package installation per line.
-#
-# Alpine does not have a consistent set of packages across all the
-# architectures, so we have to install different versions depending on which
-# one we are targeting.
-RUN apk --no-cache add --repository community tini=0.19.0-r3
-RUN if test "$TARGETARCH" = "amd64" ; then apk --no-cache add --repository community --arch x86_64  chromium-swiftshader=131.0.6778.69-r0 ; fi
-RUN if test "$TARGETARCH" = "arm64" ; then apk --no-cache add --repository community --arch aarch64 chromium-swiftshader=131.0.6778.69-r0 ; fi
+RUN apk --no-cache add --repository community tini
 
 COPY --from=release /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release /usr/local/bin/sm-k6 /usr/local/bin/sm-k6


### PR DESCRIPTION
The new base image is built at https://github.com/grafana/chromium-swiftshader-alpine, and should allow us to both get chromium updates as PRs, while at the same time being stable so an outdated version does not break builds in the foreseeable future.