### PR TITLE
feat: k6runner: improve error handling for k6 output

### DIFF
--- a/internal/k6runner/error.go
+++ b/internal/k6runner/error.go
@@ -1,0 +1,50 @@
+package k6runner
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+
+	"github.com/go-logfmt/logfmt"
+	"golang.org/x/exp/maps"
+)
+
+var (
+	ErrStacktrace = errors.New("fatal error occurred while running the script")
+	ErrThrown     = errors.New("uncaught error occurred while running the script")
+)
+
+// errorFromLogs scans k6 logs for signs of significant errors that should be reported as such.
+func errorFromLogs(logs []byte) error {
+	dec := logfmt.NewDecoder(bytes.NewReader(logs))
+
+	keyVals := make(map[string]string, 8) // Typically will be less than 8 fields.
+
+	for dec.ScanRecord() {
+		maps.Clear(keyVals)
+
+		for dec.ScanKeyval() {
+			// dec.Key and dec.Value values are not reusable across calls of ScanRecord, but that should be fine.
+			keyVals[string(dec.Key())] = string(dec.Value())
+		}
+
+		if dec.Err() != nil {
+			// Ignore errors.
+			continue
+		}
+
+		// Stacktrace errors are often fatal, like syntax errors or accessing properties of undefined objects.
+		if keyVals["level"] == "error" && keyVals["source"] == "stacktrace" {
+			return ErrStacktrace
+		}
+
+		// Uncaught exceptions and errors.
+		// These do not have an identifiable attribute (https://github.com/grafana/k6/issues/3842), so we rely in
+		// string matching.
+		if keyVals["level"] == "error" && strings.HasPrefix(keyVals["msg"], "Uncaught (in promise)") {
+			return ErrThrown
+		}
+	}
+
+	return nil
+}

--- a/internal/k6runner/error_test.go
+++ b/internal/k6runner/error_test.go
@@ -1,0 +1,75 @@
+package k6runner
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestErrorFromLogs(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		logLines string
+		expect   error
+	}{
+		{
+			name:     "console.error",
+			logLines: `time="2024-04-18T19:39:22+02:00" level=error msg="console error" source=console`,
+			expect:   nil,
+		},
+		{
+			name: "stack trace",
+			logLines: `
+			time="2024-04-18T19:39:22+02:00" level=error msg="console error" source=console
+			level=error msg=foobar source=stacktrace
+			`,
+			expect: ErrStacktrace,
+		},
+		{
+			name: "unsupported browser",
+			logLines: `
+time="2024-07-12T16:47:13+02:00" level=error msg="Uncaught (in promise) GoError: browser not found in registry. make sure to set browser type option in scenario definition in order to use the browser module\n\tat github.com/grafana/xk6-browser/browser.syncMapBrowser.func7 (native)\n\tat file:///tmp/roobre/browser.js:20:15(4)\n" executor=shared-iterations scenario=default
+			`,
+			expect: ErrThrown,
+		},
+		{
+			name: "throw new Error()",
+			logLines: `
+time="2024-07-12T16:48:01+02:00" level=error msg="Uncaught (in promise) Error: foobar\n\tat file:///tmp/roobre/browser.js:22:8(8)\n" executor=shared-iterations scenario=ui
+			`,
+			expect: ErrThrown,
+		},
+		{
+			name: "required filds in different lines",
+			logLines: `
+			lever=error msg=something
+			source=stacktrace msg=something
+			`,
+			expect: nil,
+		},
+		{
+			name: "badly formatted lines and stactrace",
+			//nolint:dupword // Duped
+			logLines: `
+			something something
+			lever=error something something
+			source=stacktrace something something
+			level=error msg="missing a quote
+			level=error msg=foobar source=stacktrace
+			`,
+			expect: nil, // FIXME: Probably the parser should tolerate malformed lines.
+		},
+	} {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := errorFromLogs([]byte(tc.logLines))
+			if !errors.Is(err, tc.expect) {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -67,6 +67,14 @@ func CheckInfoFromSM(smc smmmodel.Check) CheckInfo {
 	return ci
 }
 
+// MarshalZerologObject implements zerolog.LogObjectMarshaler so it can be logged in a friendly way.
+func (ci *CheckInfo) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("type", ci.Type)
+	for k, v := range ci.Metadata {
+		e.Any(k, v)
+	}
+}
+
 // ErrNoTimeout is returned by [Runner] implementations if the supplied script has a timeout of zero.
 var ErrNoTimeout = errors.New("check has no timeout")
 


### PR DESCRIPTION
Closes #1060

This pull requests brings a number of improvements to how the local k6 runner, mostly used in private probe context, handles errors from k6. Most prominently:
- For errors that we can attribute to the script contents (user errors), it no longer returns `nil, err` (understood as "k6 could not be run"), but rather a response with a textual representation of the error, and the k6 output. This still causes the test to be marked as failed, but the error is reported to Loki and thus made visible.
- Logs are now parsed and searched for specific strings that, in SM context, are considered fatal errors.
- Limits are imposed on how many bytes will be read for log and metrics output. These are last-resort measures to prevent the whole payload to be rejected by mimir or loki if it is too big.

Based on https://github.com/grafana/synthetic-monitoring-agent/pull/1061 as I want CI/CD to be able to run.