### PR TITLE
chore: use grafana/sm-renovate shared presets and actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,47 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
-    ":semanticCommitsDisabled"
+    "github>grafana/sm-renovate//presets/grafana.json5",
+    "github>grafana/sm-renovate//presets/synthetic-monitoring.json5",
+    "github>grafana/sm-renovate//presets/go.json5",
+    "github>grafana/sm-renovate//presets/grafana-build-tools.json5"
   ],
-
-  "branchPrefix": "grafanarenovatebot/",
-  "commitMessagePrefix": "Chore: ",
-  "platformCommit": "enabled",
-  "dependencyDashboard": false,
-  "forkProcessing": "disabled",
-  "rebaseWhen": "behind-base-branch",
-  "prHourlyLimit": 0,
-  "prConcurrentLimit": 10,
-  "branchConcurrentLimit": 10,
-
-  "enabledManagers": ["custom.regex", "gomod"],
-
-  "labels": ["dependencies"],
-
-  "gomod": {
-    "enabled": true
-  },
-
-  "postUpdateOptions": [
-    "gomodTidyE"
-  ],
-
   "packageRules": [
-    {
-      "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["digest"],
-      "schedule": "before 8am on monday every 2 weeks"
-    },
-    {
-      "matchManagers": ["gomod"],
-      "matchPackageNames": "github.com/prometheus/*",
-      "groupName": "prometheus-go"
-    },
-    {
-      "matchPackageNames": "**/renovate",
-      "extends": ["schedule:weekly"]
-    },
     {
       // The default "docker" versioning will try to restrict upgrades to versions that do not change everything after
       // a dash (-) for the current tag, as this typically indicates the "flavor" (e.g. postgresql:17.1-alpine will not
@@ -49,26 +14,10 @@
       // This image in particular has lots of dashes and does not follow this convention, so we force "loose"
       // versioning which is pretty much an alphabetical sort.
       "matchPackageNames": ["ghcr.io/grafana/chromium-swiftshader-alpine"],
-      "versioning": "loose",
-    },
+      "versioning": "loose"
+    }
   ],
-
   "customManagers": [
-    {
-      "customType": "regex",
-      "datasourceTemplate": "docker",
-      "versioningTemplate": "semver",
-      "registryUrlTemplate": "https://ghcr.io",
-      "fileMatch": [
-        "(^|/)Makefile$",
-        ".*\\.jsonnet$",
-        ".*\\.mk$",
-        "^\\.github/workflows/.*\\.ya?ml$"
-      ],
-      "matchStrings": [
-        "\\bghcr\\.io/(?<depName>grafana/grafana-build-tools):(?<currentValue>v\\d+\\.\\d+\\.\\d+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?\\b"
-      ]
-    },
     {
       // Update k6 version in Dockerfiles.
       "customType": "regex",
@@ -77,19 +26,6 @@
       "fileMatch": [".*\\.mk"],
       "matchStrings": [
         "(?:^|\\n)[ \\t]*K6_VERSION\\s*:=\\s*(?<currentValue>\\S+)[ \\t]*(?:$|\\n)"
-      ]
-    },
-    {
-      // Update renovate version in GHA workflow file.
-      "customType": "regex",
-      "depNameTemplate": "ghcr.io/renovatebot/renovate",
-      "datasourceTemplate": "docker",
-      "fileMatch": [
-        "^\\.github/workflows/.*\\.ya?ml$",
-      ],
-      "matchStrings": [
-        "renovate-version: (?<currentValue>[^@\\s]+)(?:@(?<currentDigest>\\S+))?",
-        "RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>\\S+))?"
       ]
     }
   ]

--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -2,16 +2,23 @@ name: Validate renovate config
 on:
   pull_request:
     paths:
-      - '.github/renovate.*'
+      # When renovate config changes:
+      - "renovate.*"
+      - ".renovate.*"
+      - ".github/renovate.*"
+      # Also when renovate version changes:
+      - ".github/workflows/renovate*"
+
 jobs:
-  validate:
+  renovate:
+    permissions:
+      # Needed for logging into vault.
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout Code
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - name: Renovate config validator
-        run: |
-          # Renovate updates the line below. Please keep its formatting as it is.
-          export RENOVATE_IMAGE=ghcr.io/renovatebot/renovate:39.14.1@sha256:65e8c6c295d33569995412053890b983cd01a6c8de643adb4d175889a27a07ed
-          docker run -i --rm -v "$(realpath .):/repo" -w /repo --entrypoint renovate-config-validator "$RENOVATE_IMAGE" --strict
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Self-hosted renovate
+        uses: grafana/sm-renovate/actions/renovate-validate@main

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,47 +1,20 @@
-name: Renovate
+name: Self-hosted Renovate
+
 on:
   schedule:
-    - cron: "16 */4 * * *"
+    - cron: "12 */4 * * *"
   workflow_dispatch:
 
 jobs:
   renovate:
     permissions:
-      contents: read # needed to read the contents of the repository
-      id-token: write # needed to create a GitHub App token
+      # Needed for logging into vault.
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: Checkout Code
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-
-      - name: retrieve secrets
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@7d18a46aafb8b875ed76a0bc98852d74b91e7f91 # v1.0.0
-        with:
-          common_secrets: |
-            GRAFANA_RENOVATE_APP_ID=grafana-renovate-app:app-id
-            GRAFANA_RENOVATE_PRIVATE_KEY=grafana-renovate-app:private-key
-
-      - name: create GitHub app token
-        id: app-token
-        # Beware that the token generated here has elevated permissions wrt to
-        # the ones set in the action. In particular, it will be able to write
-        # to the repository (e.g. create branches) and create pull requests.
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ env.GRAFANA_RENOVATE_APP_ID }}
-          private-key: ${{ env.GRAFANA_RENOVATE_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Self-hosted Renovate
-        uses: renovatebot/github-action@7743ec9e19ceeb61a3862c5d4131e6710195af11 # v40.3.3
-        with:
-          renovate-version: 39.14.1@sha256:65e8c6c295d33569995412053890b983cd01a6c8de643adb4d175889a27a07ed
-          configurationFile: .github/renovate-app.json
-          token: "${{ steps.app-token.outputs.token }}"
-        env:
-          LOG_LEVEL: debug
-          RENOVATE_PLATFORM: github
-          RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_USERNAME: GrafanaRenovateBot
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Self-hosted renovate
+        uses: grafana/sm-renovate/actions/renovate@main


### PR DESCRIPTION
Similar to https://github.com/grafana/sm-k6-runner/pull/353, leverage action definitions and presets in https://github.com/grafana/sm-renovate to keep repo-specific renovate settings to a minimum.