### PR TITLE
Fix: trigger argo release workflow from GHA

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -185,23 +185,6 @@ steps:
     - refs/tags/v*.*.*
 - commands: []
   depends_on:
-  - docker publish (dev)
-  image: us.gcr.io/kubernetes-dev/drone/plugins/argo-cli
-  name: trigger argo workflow (dev)
-  settings:
-    add_ci_labels: true
-    command: 'submit --from workflowtemplate/deploy-synthetic-monitoring-agent --name
-      deploy-synthetic-monitoring-agent-dev-$(./scripts/version) --parameter mode=dev
-      --parameter dockertag=$(./scripts/version) --parameter commit=${DRONE_COMMIT}
-      --parameter commit_author=${DRONE_COMMIT_AUTHOR} --parameter commit_link=${DRONE_COMMIT_LINK} '
-    namespace: synthetic-monitoring-cd
-    token:
-      from_secret: argo_token
-  when:
-    ref:
-    - refs/heads/main
-- commands: []
-  depends_on:
   - docker publish (release)
   image: us.gcr.io/kubernetes-dev/drone/plugins/argo-cli
   name: trigger argo workflow (release)
@@ -353,6 +336,6 @@ kind: secret
 name: gpg_private_key
 ---
 kind: signature
-hmac: 363b099264e7e2a4a3b840857d963aa0a79968952eac8cd40edadbda755b3b54
+hmac: ebba11ba346f14c3e83c6ed062a09e816f74e904269e3191d9863961f86c27d8
 
 ...

--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -274,19 +274,18 @@ jobs:
         with:
           go-version-file: ./go.mod
 
-    # Commented out until we know it's working.
-    # - name: Trigger argo workflow
-    #   uses: grafana/shared-workflows/actions/trigger-argo-workflow@7d18a46aafb8b875ed76a0bc98852d74b91e7f91 # v1.0.0
-    #   with:
-    #     namespace: synthetic-monitoring-cd
-    #     workflow_template: deploy-${{ needs.preflight.outputs.repo_name }}
-    #     extra_args: "--generate-name deploy-${{ needs.preflight.outputs.repo_name }}-"
-    #     parameters: |
-    #       mode=${{ (inputs.mode == 'prod' && 'release') || (inputs.mode == 'dev' && 'dev') }}
-    #       image=${{ needs.publish_images.outputs.image_name }}:${{ needs.publish_images.outputs.image_version }}
-    #       image_name=${{ needs.publish_images.outputs.image_name }}
-    #       image_version=${{ needs.publish_images.outputs.image_version }}
-    #       dockertag=${{ needs.publish_images.outputs.image_version }}
-    #       commit=${{ github.sha }}
-    #       commit_author=${{ github.actor }}
-    #       commit_link=${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+      - name: Trigger argo workflow
+        uses: grafana/shared-workflows/actions/trigger-argo-workflow@7d18a46aafb8b875ed76a0bc98852d74b91e7f91 # v1.0.0
+        with:
+          namespace: synthetic-monitoring-cd
+          workflow_template: deploy-${{ needs.preflight.outputs.repo_name }}
+          extra_args: "--generate-name deploy-${{ needs.preflight.outputs.repo_name }}-"
+          parameters: |
+            mode=${{ (inputs.mode == 'prod' && 'release') || (inputs.mode == 'dev' && 'dev') }}
+            image=${{ needs.publish_images.outputs.image_name }}:${{ needs.publish_images.outputs.image_version }}
+            image_name=${{ needs.publish_images.outputs.image_name }}
+            image_version=${{ needs.publish_images.outputs.image_version }}
+            dockertag=${{ needs.publish_images.outputs.image_version }}
+            commit=${{ github.sha }}
+            commit_author=${{ github.actor }}
+            commit_link=${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}

--- a/scripts/configs/drone/go-tools-image.libsonnet
+++ b/scripts/configs/drone/go-tools-image.libsonnet
@@ -1,1 +1,1 @@
-"ghcr.io/grafana/grafana-build-tools:v0.31.1"
+'ghcr.io/grafana/grafana-build-tools:v0.31.1'

--- a/scripts/configs/drone/main.jsonnet
+++ b/scripts/configs/drone/main.jsonnet
@@ -206,26 +206,26 @@ local docker_publish_with_browser(repo, auth, tag, os, arch) =
     ])
     + releaseOnly,
 
-    step('trigger argo workflow (dev)', [])
-    + {
-      settings: {
-        namespace: 'synthetic-monitoring-cd',
-        token: { from_secret: 'argo_token' },
-        command: std.strReplace(|||
-          submit --from workflowtemplate/deploy-synthetic-monitoring-agent
-          --name deploy-synthetic-monitoring-agent-dev-$(./scripts/version)
-          --parameter mode=dev
-          --parameter dockertag=$(./scripts/version)
-          --parameter commit=${DRONE_COMMIT}
-          --parameter commit_author=${DRONE_COMMIT_AUTHOR}
-          --parameter commit_link=${DRONE_COMMIT_LINK}
-        |||, '\n', ' '),
-        add_ci_labels: true,
-      },
-      image: 'us.gcr.io/kubernetes-dev/drone/plugins/argo-cli',
-    }
-    + dependsOn([ 'docker publish (dev)' ])
-    + devOnly,
+    // step('trigger argo workflow (dev)', [])
+    // + {
+    //   settings: {
+    //     namespace: 'synthetic-monitoring-cd',
+    //     token: { from_secret: 'argo_token' },
+    //     command: std.strReplace(|||
+    //       submit --from workflowtemplate/deploy-synthetic-monitoring-agent
+    //       --name deploy-synthetic-monitoring-agent-dev-$(./scripts/version)
+    //       --parameter mode=dev
+    //       --parameter dockertag=$(./scripts/version)
+    //       --parameter commit=${DRONE_COMMIT}
+    //       --parameter commit_author=${DRONE_COMMIT_AUTHOR}
+    //       --parameter commit_link=${DRONE_COMMIT_LINK}
+    //     |||, '\n', ' '),
+    //     add_ci_labels: true,
+    //   },
+    //   image: 'us.gcr.io/kubernetes-dev/drone/plugins/argo-cli',
+    // }
+    // + dependsOn([ 'docker publish (dev)' ])
+    // + devOnly,
 
     step('trigger argo workflow (release)', [])
     + {


### PR DESCRIPTION
We have the drone pipeline running in parallel with the GHA one, with the exception of the release step. In order to unblock this, disable triggering the argo workflow in Drone and enable it in GHA. I'm 100% sure this is going to fail without changes on the workflow side, but making those changes first will very likely break the drone pipeline. Start it here, with dev releases, so that we can figure out what else needs changing but keep the prod path enabled in Drone, in case we need to make a release before this is done.