### PR TITLE
Fix: increase SHA-1 short version length

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -1,3 +1,9 @@
 #!/bin/sh
-
-git describe --dirty --tags --long --always
+#
+# --abbrev=12 asks for at least 12 characters in the SHA-1 hash. The trick is
+# that git might choose to output more if 10 are not enough to keep the value
+# unique.
+#
+# This is a balance between having a predictable value and having something
+# that is not too long, as this value gets displayed in a couple of places.
+git describe --dirty --tags --long --always --abbrev=12


### PR DESCRIPTION
It's been observed that two different runs of git produce two different values of the short SHA-1 value (which is weird, because this is supposed to be based on the number of objects in the repository). Fix this at 12, because that is longer than what git automatically decides to use.