### PR TITLE
Fix: bump minor, not patch, for features

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -3,6 +3,7 @@
     ".": {
       "release-type": "go",
       "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": false,
       "include-component-in-tag": false,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
From the wonderful world of "we have opinions but we don't document them" comes "we provide a sane default configuration but we don't document it."

When 5c21ba3535a071c6166d45812a4d0e11fb1680fe introduced a configuration file for release please, it replaced a built-in default configuration, which does not consist of the default values but a particular set of hand-picked values, with one where default values suddenly apply. In other words, by having an explicit configuration, all the options for which a value is not supplied use the default value. By *not* having a configuration, a predefined one is used, which is not composed of all the default values for all the options.

I do not have the time to figure out where this default configuration comes from, but I can see that it does one thing if an empty configuration is provided and a different thing if no configuration is provided. At first glance, it seems to be the CLI flags but I do not know.

Part of that sane default configuration is that when a feature is added, the minor version should be bumped, even if there hasn't been a major release yet. The default value, bump patch unless there's has been a major release already, is indeed a surprising bad default.