### PR TITLE
chore: rename add err prefix to unsupportedCheckType error

### DIFF
--- a/internal/prober/prober.go
+++ b/internal/prober/prober.go
@@ -24,7 +24,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-const unsupportedCheckType = error_types.BasicError("unsupported check type")
+const errUnsupportedCheckType = error_types.BasicError("unsupported check type")
 
 type Prober interface {
 	Name() string
@@ -119,7 +119,7 @@ func (f proberFactory) New(ctx context.Context, logger zerolog.Logger, check mod
 		target = check.Target
 
 	default:
-		return nil, "", unsupportedCheckType
+		return nil, "", errUnsupportedCheckType
 	}
 
 	return p, target, err

--- a/internal/prober/prober_test.go
+++ b/internal/prober/prober_test.go
@@ -24,6 +24,6 @@ func TestProberFactoryCoverage(t *testing.T) {
 		require.NoError(t, check.FromSM(sm.GetCheckInstance(checkType)))
 
 		_, _, err := pf.New(ctx, testLogger, check)
-		require.NotErrorIs(t, err, unsupportedCheckType)
+		require.NotErrorIs(t, err, errUnsupportedCheckType)
 	}
 }


### PR DESCRIPTION
Makes the linter happy

Fixes a linting error blocking https://github.com/grafana/synthetic-monitoring-agent/pull/1102