### PR TITLE
fix: increase Scripted and Browser max timeout to 90s

### DIFF
--- a/cmd/synthetic-monitoring-agent/grpc.go
+++ b/cmd/synthetic-monitoring-agent/grpc.go
@@ -17,7 +17,7 @@ func dialAPIServer(ctx context.Context, addr string, allowInsecure bool, apiToke
 	apiCreds := creds{Token: apiToken}
 
 	opts := []grpc.DialOption{
-		grpc.WithBlock(), //nolint:staticcheck // Will be removed in v2. TODO: Migrate to NewClient.
+		grpc.WithBlock(), //nolint:staticcheck,nolintlint // Will be removed in v2. TODO: Migrate to NewClient.
 		grpc.WithPerRPCCredentials(apiCreds),
 		// Keep-alive is necessary to detect network failures in absence of writes from the client.
 		// Without it, the agent would hang if the server disappears while waiting for a response.
@@ -40,7 +40,7 @@ func dialAPIServer(ctx context.Context, addr string, allowInsecure bool, apiToke
 	}
 	opts = append(opts, grpc.WithTransportCredentials(transportCreds))
 
-	return grpc.DialContext(ctx, addr, opts...) //nolint:staticcheck // Will be removed in v2. TODO: Migrate to NewClient.
+	return grpc.DialContext(ctx, addr, opts...) //nolint:staticcheck,nolintlint // Will be removed in v2. TODO: Migrate to NewClient.
 }
 
 func grpcApiHost(addr string) string {

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -148,7 +148,7 @@ const (
 	minCheckTimeout      = minCheckFrequency
 	MaxCheckTimeout      = 1 * 60 * 1000   // Maximum value for the check's timeout (1 minute).
 	minScriptedTimeout   = minCheckTimeout // Minimum timeout for scripted checks (1 second).
-	maxScriptedTimeout   = MaxCheckTimeout // Maximum timeout for scripted checks (1 minute).
+	maxScriptedTimeout   = 90 * 1000       // Maximum timeout for scripted checks (90 second).
 	minTracerouteTimeout = 30 * 1000       // Minimum timeout for traceroute checks (30 second).
 	maxTracerouteTimeout = 30 * 1000       // Minimum timeout for traceroute checks (30 second).
 )


### PR DESCRIPTION
This is a first step in increasing the maximum timeout for scripted and brower checks. After further testing with this and once we have higher confidence we aim to increase this to 3 minutes.

Related: https://github.com/grafana/synthetic-monitoring/issues/117