### PR TITLE
fix: Use the recommended 'persist-credentials: false' setting

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -44,6 +44,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
 
@@ -170,6 +171,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up global git config
@@ -305,6 +307,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Go

--- a/.github/workflows/renovate-validate.yaml
+++ b/.github/workflows/renovate-validate.yaml
@@ -20,5 +20,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
       - name: Self-hosted renovate
         uses: grafana/sm-renovate/actions/renovate-validate@main

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -16,5 +16,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
       - name: Self-hosted renovate
         uses: grafana/sm-renovate/actions/renovate@main

--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
 


### PR DESCRIPTION
The GitHub checkout action has this `persist-credentials` setting.

It's described like this:

    # Whether to configure the token or SSH key with the local git config
    # Default: true
    persist-credentials: ''

Sounds harmless, right? It almosts makes it sound as if it's going to modify `~/.gitconfig`.

This default of `true` causes credentials to end up in the working copy's `.git/config`, which interacts badly with other stuff happening in GHA.

Set it to false just in case.