### PR TITLE
fix: increase Scripted and Browser max timeout to 120s (#1136)

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -148,7 +148,7 @@ const (
 	minCheckTimeout      = minCheckFrequency
 	MaxCheckTimeout      = 1 * 60 * 1000   // Maximum value for the check's timeout (1 minute).
 	minScriptedTimeout   = minCheckTimeout // Minimum timeout for scripted checks (1 second).
-	maxScriptedTimeout   = 90 * 1000       // Maximum timeout for scripted checks (90 second).
+	maxScriptedTimeout   = 120 * 1000      // Maximum timeout for scripted checks (120 second).
 	minTracerouteTimeout = 30 * 1000       // Minimum timeout for traceroute checks (30 second).
 	maxTracerouteTimeout = 30 * 1000       // Minimum timeout for traceroute checks (30 second).
 )


### PR DESCRIPTION
This is the next step (following https://github.com/grafana/synthetic-monitoring-agent/pull/1136) in increasing the maximum timeout for scripted and browser checks. After further testing with this and once we have higher confidence we aim to increase this to 3 minutes.

Related: https://github.com/grafana/synthetic-monitoring/issues/117