### PR TITLE
fix: tag images with the bare version.

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -38,6 +38,7 @@ jobs:
       image: ghcr.io/grafana/grafana-build-tools:v0.37.0@sha256:64c6ff07fce6f93ba3732d4617b7ea3a370d7e87fd4e4cb92fd4faa25364cd50
     outputs:
       version: ${{ steps.version.outputs.value }}
+      version_bare: ${{ steps.version.outputs.bare_value }}
 
     steps:
       - name: checkout
@@ -73,6 +74,7 @@ jobs:
         run: |
           make version
           echo "value=$(cat dist/version)" >> "$GITHUB_OUTPUT"
+          echo "bare_value=$(cat dist/version | cut -d- -f1)" >> "$GITHUB_OUTPUT"
 
       - name: build
         run: make build-native
@@ -216,6 +218,7 @@ jobs:
           platforms: ${{ steps.extract-build-artifacts.outputs.platforms }}
           tags: |-
             type=raw,value=${{ needs.validate.outputs.version }}
+            type=raw,value=${{ needs.validate.outputs.version_bare }}
             type=sha,prefix=sha-,format=short
             latest
           file: Dockerfile.no-browser
@@ -229,6 +232,7 @@ jobs:
           platforms: ${{ steps.extract-build-artifacts.outputs.platforms }}
           tags: |-
             type=raw,value=${{ needs.validate.outputs.version }}-browser
+            type=raw,value=${{ needs.validate.outputs.version_bare }}-browser
             type=sha,prefix=sha-,suffix=-browser,format=short
             latest-browser
           file: Dockerfile.browser


### PR DESCRIPTION
At one point we tagged images with the bare version. For example [v0.29.10](https://hub.docker.com/layers/grafana/synthetic-monitoring-agent/v0.29.10/images/sha256-ddad54c24c4a22cb18169d3e8a52e5a38bf8ac94d21c7e0276f87c5c25fc3372). In the move from drone to github actions this has changed. The latest release has the version [v0.32.0-0-gc17d85830691](https://hub.docker.com/layers/grafana/synthetic-monitoring-agent/v0.32.0-0-gc17d85830691/images/sha256-b55df3b4394dd44a9ae7f28163fb475c922a7f94ae2833cc03641294dde24c8c).

Tools like renovate ignore these tags and thus my images have not been updated since v0.29.10. This PR adds the bare version back, which should make it easier for users to keep up with the latest.