### PR TITLE
fix: increase Scripted and Browser max timeout to 180s

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -148,7 +148,7 @@ const (
 	minCheckTimeout      = minCheckFrequency
 	MaxCheckTimeout      = 1 * 60 * 1000   // Maximum value for the check's timeout (1 minute).
 	minScriptedTimeout   = minCheckTimeout // Minimum timeout for scripted checks (1 second).
-	maxScriptedTimeout   = 120 * 1000      // Maximum timeout for scripted checks (120 second).
+	maxScriptedTimeout   = 180 * 1000      // Maximum timeout for scripted checks (180 second).
 	minTracerouteTimeout = 30 * 1000       // Minimum timeout for traceroute checks (30 second).
 	maxTracerouteTimeout = 30 * 1000       // Minimum timeout for traceroute checks (30 second).
 )


### PR DESCRIPTION
This is the final step (following https://github.com/grafana/synthetic-monitoring-agent/pull/1160) in increasing the maximum timeout for scripted and browser checks. Increasing the maximum timeout to 3 minutes.

Related: https://github.com/grafana/synthetic-monitoring/issues/117