### PR TITLE
fix: tag docker images with the bare version

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -272,6 +272,7 @@ jobs:
           platforms: ${{ steps.extract-build-artifacts.outputs.platforms }}
           tags: |-
             type=raw,value=${{ needs.validate.outputs.version }}
+            type=raw,value=${{ needs.validate.outputs.version_bare }}
             type=sha,prefix=sha-,format=short
             latest
           file: Dockerfile.no-browser
@@ -287,6 +288,7 @@ jobs:
           platforms: ${{ steps.extract-build-artifacts.outputs.platforms }}
           tags: |-
             type=raw,value=${{ needs.validate.outputs.version }}-browser
+            type=raw,value=${{ needs.validate.outputs.version_bare }}-browser
             type=sha,prefix=sha-,suffix=-browser,format=short
             latest-browser
           file: Dockerfile.browser


### PR DESCRIPTION
This was missing from https://github.com/grafana/synthetic-monitoring-agent/pull/1166 which tagged only the images uploaded to GHA. It should have also tagged images on docker.