### PR TITLE
Pass secret store from API

### DIFF
--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"time"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/secrets"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/rs/zerolog"
@@ -107,6 +109,7 @@ type HandlerOpts struct {
 	PromRegisterer prometheus.Registerer
 	Features       feature.Collection
 	K6Runner       k6runner.Runner
+	TenantSecrets  *secrets.TenantSecrets
 
 	// these two fields exists so that tests can pass alternate
 	// implementations, they are unexported so that clients of this
@@ -139,7 +142,7 @@ func NewHandler(opts HandlerOpts) (*Handler, error) {
 		tenantCh:                     opts.TenantCh,
 		runnerFactory:                opts.runnerFactory,
 		grpcAdhocChecksClientFactory: opts.grpcAdhocChecksClientFactory,
-		proberFactory:                prober.NewProberFactory(opts.K6Runner, 0, opts.Features),
+		proberFactory:                prober.NewProberFactory(opts.K6Runner, 0, opts.Features, opts.TenantSecrets),
 		api: apiInfo{
 			conn: opts.Conn,
 		},

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -29,6 +29,7 @@ import (
 	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
 	"github.com/grafana/synthetic-monitoring-agent/internal/scraper"
+	"github.com/grafana/synthetic-monitoring-agent/internal/secrets"
 	"github.com/grafana/synthetic-monitoring-agent/internal/telemetry"
 	"github.com/grafana/synthetic-monitoring-agent/internal/version"
 	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
@@ -79,6 +80,7 @@ type Updater struct {
 	k6Runner       k6runner.Runner
 	scraperFactory scraper.Factory
 	tenantLimits   *limits.TenantLimits
+	tenantSecrets  *secrets.TenantSecrets
 	telemeter      *telemetry.Telemeter
 }
 
@@ -114,6 +116,7 @@ type UpdaterOptions struct {
 	ScraperFactory scraper.Factory
 	TenantLimits   *limits.TenantLimits
 	Telemeter      *telemetry.Telemeter
+	TenantSecrets  *secrets.TenantSecrets
 }
 
 func NewUpdater(opts UpdaterOptions) (*Updater, error) {
@@ -235,6 +238,7 @@ func NewUpdater(opts UpdaterOptions) (*Updater, error) {
 		k6Runner:       opts.K6Runner,
 		scraperFactory: scraperFactory,
 		tenantLimits:   opts.TenantLimits,
+		tenantSecrets:  opts.TenantSecrets,
 		telemeter:      opts.Telemeter,
 		metrics: metrics{
 			changeErrorsCounter: changeErrorsCounter,
@@ -896,7 +900,7 @@ func (c *Updater) addAndStartScraperWithLock(ctx context.Context, check model.Ch
 		c.logger,
 		metrics,
 		c.k6Runner,
-		c.tenantLimits, c.telemeter,
+		c.tenantLimits, c.telemeter, c.tenantSecrets,
 	)
 	if err != nil {
 		return fmt.Errorf("cannot create new scraper: %w", err)

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/secrets"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/rs/zerolog"
@@ -471,6 +473,7 @@ func testScraperFactory(ctx context.Context, check model.Check, publisher pusher
 	k6Runner k6runner.Runner,
 	labelsLimiter scraper.LabelsLimiter,
 	telemeter *telemetry.Telemeter,
+	secretStore *secrets.TenantSecrets,
 ) (*scraper.Scraper, error) {
 	return scraper.NewWithOpts(
 		ctx,

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -38,6 +38,11 @@ type SecretStore struct {
 	Token string `json:"token"`
 }
 
+// IsConfigured returns true if the SecretStore has both URL and token configured.
+func (s SecretStore) IsConfigured() bool {
+	return s.Url != "" && s.Token != ""
+}
+
 // Settings is a common representation of the fields common to all implementation-specific check settings that the
 // runners are interested about.
 type Settings struct {

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -28,7 +28,14 @@ type Script struct {
 	Settings Settings `json:"settings"`
 	// CheckInfo holds information about the SM check that triggered this script.
 	CheckInfo CheckInfo `json:"check"`
+	// SecretStore holds the location and token for accessing secrets
+	SecretStore SecretStore `json:"secretStore"`
 	// TODO: Add features.
+}
+
+type SecretStore struct {
+	Url   string `json:"url"`
+	Token string `json:"token"`
 }
 
 // Settings is a common representation of the fields common to all implementation-specific check settings that the

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -75,7 +75,18 @@ func (r Local) Run(ctx context.Context, script Script) (*RunResponse, error) {
 		return nil, fmt.Errorf("cannot write temporary script file: %w", err)
 	}
 
-	k6Path, err := exec.LookPath(r.k6path)
+	executable := r.k6path
+	// TODO(d0ugal): This is a short-term hack to use a different k6 binary when
+	// secrets are configured. This should be removed when the default binary has been updated
+	if script.SecretStore.IsConfigured() {
+		executable = r.k6path + "-gsm"
+		logger.Info().
+			Str("k6_path", r.k6path).
+			Str("k6_gsm_path", executable).
+			Msg("Using k6-gsm binary for secrets")
+	}
+
+	k6Path, err := exec.LookPath(executable)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find k6 executable: %w", err)
 	}

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -105,8 +105,7 @@ func (r Local) Run(ctx context.Context, script Script) (*RunResponse, error) {
 	cmd.Stdin = nil
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	env := k6Env(os.Environ())
-	cmd.Env = env
+	cmd.Env = k6Env(os.Environ())
 
 	start := time.Now()
 	logger.Info().Str("command", cmd.String()).Bytes("script", script.Script).Msg("running k6 script")

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -199,7 +199,7 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, tokenFile
 	// Add secretStore configuration if available
 	if script.SecretStore.Url != "" && script.SecretStore.Token != "" {
 		// Encode the URL to avoid any parsing issues
-		encodedURL := base64.StdEncoding.EncodeToString([]byte(script.SecretStore.Url))
+		encodedURL := base64.URLEncoding.EncodeToString([]byte(script.SecretStore.Url))
 
 		args = append(args, "--secret-source", "grafanasecrets=url_base64="+encodedURL+",token="+tokenFile)
 	}

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -200,7 +200,7 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, tokenFile
 		// Encode the URL to avoid any parsing issues
 		encodedURL := base64.URLEncoding.EncodeToString([]byte(script.SecretStore.Url))
 
-		args = append(args, "--secret-source", "grafanasecrets=url_base64="+encodedURL+",token="+tokenFile)
+		args = append(args, "--secret-source", "grafanasecrets=url_base64="+encodedURL+":token="+tokenFile)
 	}
 
 	if script.CheckInfo.Type != synthetic_monitoring.CheckTypeBrowser.String() {

--- a/internal/k6runner/local_test.go
+++ b/internal/k6runner/local_test.go
@@ -84,7 +84,7 @@ func TestBuildK6Args(t *testing.T) {
 		tokenFilename string
 		wantArgs      []string
 	}{
-		"basic script without secrets": {
+		"script without secrets": {
 			metricsFn:     "/tmp/metrics.json",
 			logsFn:        "/tmp/logs.log",
 			scriptFn:      "/tmp/script.js",
@@ -112,7 +112,7 @@ func TestBuildK6Args(t *testing.T) {
 				"--out", "sm=/tmp/metrics.json",
 				"--log-output", "file=/tmp/logs.log",
 				"--blacklist-ip", "127.0.0.1",
-				"--secret-source", "grafanasecrets=url_base64=" + secretUrlBase64 + ",token=" + tokenFilename,
+				"--secret-source", "grafanasecrets=url_base64=" + secretUrlBase64 + ":token=" + tokenFilename,
 			},
 		},
 	}

--- a/internal/k6runner/local_test.go
+++ b/internal/k6runner/local_test.go
@@ -68,7 +68,7 @@ func TestCreateSecureTokenFile(t *testing.T) {
 
 func TestBuildK6Args(t *testing.T) {
 	secretUrl := "http://secrets.example.com"
-	secretUrlBase64 := base64.StdEncoding.EncodeToString([]byte(secretUrl))
+	secretUrlBase64 := base64.URLEncoding.EncodeToString([]byte(secretUrl))
 	tokenFilename, cleanup, err := createSecureTokenFile("secret-token")
 	if err != nil {
 		t.Fatalf("failed to create token file: %v", err)

--- a/internal/k6runner/local_test.go
+++ b/internal/k6runner/local_test.go
@@ -1,0 +1,136 @@
+package k6runner
+
+import (
+	"encoding/base64"
+	"os"
+	"slices"
+	"testing"
+)
+
+func TestCreateSecureTokenFile(t *testing.T) {
+	tests := map[string]struct {
+		tokenData string
+	}{
+		"valid token": {
+			tokenData: "secret-token-123",
+		},
+		"empty token": {
+			tokenData: "",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			filename, cleanup, err := createSecureTokenFile(tt.tokenData)
+			defer cleanup()
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			// Check if file exists
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Error("token file was not created")
+				return
+			}
+
+			// Check file permissions
+			info, err := os.Stat(filename)
+			if err != nil {
+				t.Errorf("failed to get file info: %v", err)
+				return
+			}
+
+			if info.Mode().Perm() != 0600 {
+				t.Errorf("expected file permissions 0600, got %v", info.Mode().Perm())
+			}
+
+			// Check file contents
+			content, err := os.ReadFile(filename)
+			if err != nil {
+				t.Errorf("failed to read token file: %v", err)
+				return
+			}
+
+			if string(content) != tt.tokenData {
+				t.Errorf("expected token data %q, got %q", tt.tokenData, string(content))
+			}
+
+			// Test cleanup function
+			cleanup()
+			if _, err := os.Stat(filename); !os.IsNotExist(err) {
+				t.Error("cleanup function did not remove the file")
+			}
+		})
+	}
+}
+
+func TestBuildK6Args(t *testing.T) {
+	secretUrl := "http://secrets.example.com"
+	secretUrlBase64 := base64.StdEncoding.EncodeToString([]byte(secretUrl))
+	tokenFilename, cleanup, err := createSecureTokenFile("secret-token")
+	if err != nil {
+		t.Fatalf("failed to create token file: %v", err)
+	}
+	defer cleanup()
+
+	tests := map[string]struct {
+		script        Script
+		metricsFn     string
+		logsFn        string
+		scriptFn      string
+		blacklistedIP string
+		tokenFilename string
+		wantArgs      []string
+	}{
+		"basic script without secrets": {
+			metricsFn:     "/tmp/metrics.json",
+			logsFn:        "/tmp/logs.log",
+			scriptFn:      "/tmp/script.js",
+			blacklistedIP: "127.0.0.1",
+			tokenFilename: "",
+			wantArgs: []string{
+				"--out", "sm=/tmp/metrics.json",
+				"--log-output", "file=/tmp/logs.log",
+				"--blacklist-ip", "127.0.0.1",
+			},
+		},
+		"script with secrets": {
+			script: Script{
+				SecretStore: SecretStore{
+					Url:   secretUrl,
+					Token: "secret-token",
+				},
+			},
+			metricsFn:     "/tmp/metrics.json",
+			logsFn:        "/tmp/logs.log",
+			scriptFn:      "/tmp/script.js",
+			blacklistedIP: "127.0.0.1",
+			tokenFilename: tokenFilename,
+			wantArgs: []string{
+				"--out", "sm=/tmp/metrics.json",
+				"--log-output", "file=/tmp/logs.log",
+				"--blacklist-ip", "127.0.0.1",
+				"--secret-source", "grafanasecrets=url_base64=" + secretUrlBase64 + ",token=" + tokenFilename,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := Local{blacklistedIP: tt.blacklistedIP}
+			args, err := r.buildK6Args(tt.script, tt.metricsFn, tt.logsFn, tt.scriptFn, tt.tokenFilename)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			for _, want := range tt.wantArgs {
+				if !slices.Contains(args, want) {
+					t.Errorf("buildK6Args() missing expected argument got \n%v\nwant \n%v", args, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -57,8 +57,6 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 			Url:   secretStore.Url,
 			Token: secretStore.Token,
 		}
-	} else {
-		logger.Error().Msg("Failed to get secrets")
 	}
 
 	processor, err := k6runner.NewProcessor(p.module.Script, runner)

--- a/internal/prober/browser/browser_test.go
+++ b/internal/prober/browser/browser_test.go
@@ -58,7 +58,8 @@ func TestNewProber(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			var runner noopRunner
-			p, err := NewProber(ctx, tc.check, logger, runner)
+			var store noopSecretStore
+			p, err := NewProber(ctx, tc.check, logger, runner, store)
 			if tc.expectFailure {
 				require.Error(t, err)
 				return
@@ -81,4 +82,10 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 
 func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
+}
+
+type noopSecretStore struct{}
+
+func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+	return &sm.SecretStore{}, nil
 }

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -72,8 +72,6 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 			Url:   secretStore.Url,
 			Token: secretStore.Token,
 		}
-	} else {
-		logger.Error().Msg("Failed to get secrets")
 	}
 
 	processor, err := k6runner.NewProcessor(p.module.Script, runner)

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/secrets"
+
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
 	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
@@ -29,7 +31,7 @@ type Prober struct {
 	processor *k6runner.Processor
 }
 
-func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, reservedHeaders http.Header) (Prober, error) {
+func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, reservedHeaders http.Header, store secrets.SecretProvider) (Prober, error) {
 	var p Prober
 
 	if check.Settings.Multihttp == nil {
@@ -42,6 +44,11 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 
 	if len(reservedHeaders) > 0 {
 		augmentHttpHeaders(&check.Check, reservedHeaders)
+	}
+
+	secretStore, err := store.GetSecretCredentials(ctx, check.TenantId)
+	if err != nil {
+		return p, err
 	}
 
 	script, err := settingsToScript(check.Settings.Multihttp)
@@ -58,6 +65,15 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 			},
 			CheckInfo: k6runner.CheckInfoFromSM(check),
 		},
+	}
+
+	if secretStore != nil {
+		p.module.Script.SecretStore = k6runner.SecretStore{
+			Url:   secretStore.Url,
+			Token: secretStore.Token,
+		}
+	} else {
+		logger.Error().Msg("Failed to get secrets")
 	}
 
 	processor, err := k6runner.NewProcessor(p.module.Script, runner)

--- a/internal/prober/multihttp/multihttp_test.go
+++ b/internal/prober/multihttp/multihttp_test.go
@@ -123,11 +123,12 @@ func TestNewProber(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			var runner noopRunner
+			var store noopSecretStore
 			checkId := tc.check.Id
 			reservedHeaders := http.Header{}
 			reservedHeaders.Add("x-sm-id", fmt.Sprintf("%d-%d", checkId, checkId))
 
-			p, err := NewProber(ctx, tc.check, logger, runner, reservedHeaders)
+			p, err := NewProber(ctx, tc.check, logger, runner, reservedHeaders, store)
 			if tc.expectFailure {
 				require.Error(t, err)
 				return
@@ -156,4 +157,10 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 
 func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
+}
+
+type noopSecretStore struct{}
+
+func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+	return &sm.SecretStore{}, nil
 }

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -856,8 +856,9 @@ func TestSettingsToScript(t *testing.T) {
 	k6path := filepath.Join(testhelper.ModuleDir(t), "dist", runtime.GOOS+"-"+runtime.GOARCH, "sm-k6")
 	t.Log(k6path)
 	runner := k6runner.New(k6runner.RunnerOpts{Uri: k6path})
+	store := noopSecretStore{}
 
-	prober, err := NewProber(ctx, check, logger, runner, http.Header{})
+	prober, err := NewProber(ctx, check, logger, runner, http.Header{}, &store)
 	require.NoError(t, err)
 
 	reg := prometheus.NewPedanticRegistry()

--- a/internal/prober/prober_test.go
+++ b/internal/prober/prober_test.go
@@ -15,7 +15,8 @@ func TestProberFactoryCoverage(t *testing.T) {
 	// This test will assert that the prober factory is handling all the
 	// known check types (as defined in the synthetic_monitoring package).
 
-	pf := NewProberFactory(nil, 0, feature.Collection{})
+	var store noopSecretStore
+	pf := NewProberFactory(nil, 0, feature.Collection{}, &store)
 	ctx := context.Background()
 	testLogger := zerolog.New(zerolog.NewTestWriter(t))
 
@@ -26,4 +27,10 @@ func TestProberFactoryCoverage(t *testing.T) {
 		_, _, err := pf.New(ctx, testLogger, check)
 		require.NotErrorIs(t, err, errUnsupportedCheckType)
 	}
+}
+
+type noopSecretStore struct{}
+
+func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+	return &sm.SecretStore{}, nil
 }

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -57,8 +57,6 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 			Url:   secretStore.Url,
 			Token: secretStore.Token,
 		}
-	} else {
-		logger.Error().Msg("Failed to get secrets")
 	}
 
 	processor, err := k6runner.NewProcessor(p.module.Script, runner)

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/secrets"
+
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
 	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober/logger"
@@ -27,11 +29,16 @@ type Prober struct {
 	processor *k6runner.Processor
 }
 
-func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner) (Prober, error) {
+func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, store secrets.SecretProvider) (Prober, error) {
 	var p Prober
 
 	if check.Settings.Scripted == nil {
 		return p, errUnsupportedCheck
+	}
+
+	secretStore, err := store.GetSecretCredentials(ctx, check.TenantId)
+	if err != nil {
+		return p, err
 	}
 
 	p.module = Module{
@@ -43,6 +50,15 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 			},
 			CheckInfo: k6runner.CheckInfoFromSM(check),
 		},
+	}
+
+	if secretStore != nil {
+		p.module.Script.SecretStore = k6runner.SecretStore{
+			Url:   secretStore.Url,
+			Token: secretStore.Token,
+		}
+	} else {
+		logger.Error().Msg("Failed to get secrets")
 	}
 
 	processor, err := k6runner.NewProcessor(p.module.Script, runner)

--- a/internal/prober/scripted/scripted_test.go
+++ b/internal/prober/scripted/scripted_test.go
@@ -57,7 +57,8 @@ func TestNewProber(t *testing.T) {
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
 			var runner noopRunner
-			p, err := NewProber(ctx, tc.check, logger, runner)
+			var store noopSecretStore
+			p, err := NewProber(ctx, tc.check, logger, runner, store)
 			if tc.expectFailure {
 				require.Error(t, err)
 				return
@@ -80,6 +81,12 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 
 func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
+}
+
+type noopSecretStore struct{}
+
+func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+	return &sm.SecretStore{}, nil
 }
 
 func testContext(t *testing.T) (context.Context, func()) {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/secrets"
+
 	kitlog "github.com/go-kit/kit/log" //nolint:staticcheck // TODO(mem): replace in BBE
 	"github.com/go-kit/kit/log/level"  //nolint:staticcheck // TODO(mem): replace in BBE
 	"github.com/go-logfmt/logfmt"
@@ -85,6 +87,7 @@ type Factory func(
 	k6runner k6runner.Runner,
 	labelsLimiter LabelsLimiter,
 	telemeter *telemetry.Telemeter,
+	secretStore *secrets.TenantSecrets,
 ) (*Scraper, error)
 
 type (
@@ -118,13 +121,14 @@ func New(
 	k6runner k6runner.Runner,
 	labelsLimiter LabelsLimiter,
 	telemeter *telemetry.Telemeter,
+	secretStore *secrets.TenantSecrets,
 ) (*Scraper, error) {
 	return NewWithOpts(ctx, check, ScraperOpts{
 		Probe:         probe,
 		Publisher:     publisher,
 		Logger:        logger,
 		Metrics:       metrics,
-		ProbeFactory:  prober.NewProberFactory(k6runner, probe.Id, features),
+		ProbeFactory:  prober.NewProberFactory(k6runner, probe.Id, features, secretStore),
 		LabelsLimiter: labelsLimiter,
 		Telemeter:     telemeter,
 	})

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -499,6 +499,7 @@ func setupMultiHTTPProbe(ctx context.Context, t *testing.T) (prober.Prober, mode
 	}
 
 	var runner k6runner.Runner
+	var store noopSecretStore
 
 	if k6Path := os.Getenv("K6_PATH"); k6Path != "" {
 		runner = k6runner.New(k6runner.RunnerOpts{Uri: k6Path})
@@ -515,7 +516,7 @@ func setupMultiHTTPProbe(ctx context.Context, t *testing.T) (prober.Prober, mode
 		zerolog.New(zerolog.NewTestWriter(t)),
 		runner,
 		http.Header{},
-		nil,
+		store,
 	)
 	if err != nil {
 		t.Fatalf("cannot create MultiHTTP prober: %s", err)

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -457,11 +457,14 @@ func setupScriptedProbe(ctx context.Context, t *testing.T) (prober.Prober, model
 		}
 	}
 
+	var store noopSecretStore
+
 	prober, err := scripted.NewProber(
 		ctx,
 		check,
 		zerolog.New(zerolog.NewTestWriter(t)),
 		runner,
+		store,
 	)
 	if err != nil {
 		t.Fatalf("cannot create scripted prober: %s", err)
@@ -512,6 +515,7 @@ func setupMultiHTTPProbe(ctx context.Context, t *testing.T) (prober.Prober, mode
 		zerolog.New(zerolog.NewTestWriter(t)),
 		runner,
 		http.Header{},
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("cannot create MultiHTTP prober: %s", err)
@@ -539,6 +543,7 @@ func setupBrowserProbe(ctx context.Context, t *testing.T) (prober.Prober, model.
 	}
 
 	var runner k6runner.Runner
+	var store noopSecretStore
 
 	if k6Path := os.Getenv("K6_PATH"); k6Path != "" {
 		runner = k6runner.New(k6runner.RunnerOpts{Uri: k6Path})
@@ -554,6 +559,7 @@ func setupBrowserProbe(ctx context.Context, t *testing.T) (prober.Prober, model.
 		check,
 		zerolog.New(zerolog.NewTestWriter(t)),
 		runner,
+		store,
 	)
 	if err != nil {
 		t.Fatalf("cannot create scripted prober: %s", err)
@@ -2017,4 +2023,10 @@ func TestTickWithOffset(t *testing.T) {
 			require.Equal(t, tc.expected, results)
 		})
 	}
+}
+
+type noopSecretStore struct{}
+
+func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+	return &sm.SecretStore{}, nil
 }

--- a/internal/secrets/tenant.go
+++ b/internal/secrets/tenant.go
@@ -1,0 +1,39 @@
+package secrets
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+type SecretProvider interface {
+	GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error)
+}
+
+type TenantProvider interface {
+	GetTenant(context.Context, *sm.TenantInfo) (*sm.Tenant, error)
+}
+
+type TenantSecrets struct {
+	tp     TenantProvider
+	logger zerolog.Logger
+}
+
+func NewTenantSecrets(tp TenantProvider, logger zerolog.Logger) *TenantSecrets {
+	return &TenantSecrets{
+		tp:     tp,
+		logger: logger,
+	}
+}
+
+func (ts *TenantSecrets) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+	tenant, err := ts.tp.GetTenant(ctx, &sm.TenantInfo{
+		Id: tenantID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tenant.SecretStore, nil
+}

--- a/internal/secrets/tenant_test.go
+++ b/internal/secrets/tenant_test.go
@@ -1,0 +1,49 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/stretchr/testify/assert"
+)
+
+type tenantProvider struct {
+	tenant sm.Tenant
+	err    error
+}
+
+func (m *tenantProvider) GetTenant(ctx context.Context, info *sm.TenantInfo) (*sm.Tenant, error) {
+	return &m.tenant, m.err
+}
+
+func TestGetSecretCredentials_Success(t *testing.T) {
+	mockSecretStore := &sm.SecretStore{}
+	mockTenant := sm.Tenant{SecretStore: mockSecretStore}
+	mockTenantProvider := &tenantProvider{tenant: mockTenant}
+	ts := NewTenantSecrets(mockTenantProvider, zerolog.Nop())
+	ctx := context.Background()
+	tenantID := int64(1234)
+
+	secretStore, err := ts.GetSecretCredentials(ctx, tenantID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, mockSecretStore, secretStore)
+}
+
+func TestGetSecretCredentials_Error(t *testing.T) {
+	getTenantErr := errors.New("tenant not found")
+	mockTenantProvider := &tenantProvider{err: getTenantErr}
+	ts := NewTenantSecrets(mockTenantProvider, zerolog.Nop())
+	ctx := context.Background()
+	tenantID := int64(1234)
+
+	secretStore, err := ts.GetSecretCredentials(ctx, tenantID)
+
+	assert.Error(t, err)
+	assert.Nil(t, secretStore)
+	assert.Equal(t, getTenantErr, err)
+}

--- a/pkg/pb/synthetic_monitoring/checks.proto
+++ b/pkg/pb/synthetic_monitoring/checks.proto
@@ -175,7 +175,7 @@ message TenantLimits {
   int64 maxBrowserChecks = 5 [(gogoproto.jsontag) = "maxBrowserChecks"];
 }
 
-// SecretStore contains details for accessing Grafana secrets
+// SecretStore contains details for accessing the Grafana secret store
 message SecretStore {
   string url = 1 [(gogoproto.jsontag) = "url"]; // secret service URL
   string token = 2 [(gogoproto.jsontag) = "token"]; // secret service token


### PR DESCRIPTION
This change uses the new protobuf fields from https://github.com/grafana/synthetic-monitoring-agent/pull/1192 and passes them down to the k6 executable.

This change requires quite a bit of plumbing to get the details in the right place.

It also includes a small refactor of local.go to make it easier to test the construction of the CLI args.