### PR TITLE
fix: k6runner/local: disable k6 api server

### DIFF
--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -90,6 +90,7 @@ func (r Local) Run(ctx context.Context, script Script) (*RunResponse, error) {
 		"--summary-time-unit", "s",
 		// "--discard-response-bodies",                        // TODO(mem): make this configurable
 		"--dns", "ttl=30s,select=random,policy=preferIPv4", // TODO(mem): this needs fixing, preferIPv4 is probably not what we want
+		"--address", "", // Disable REST API server
 		"--no-thresholds",
 		"--no-usage-report",
 		"--no-color",


### PR DESCRIPTION
fix: k6runner/local: disable k6 api server

k6 includes a REST API, enabled by default on localhost, that allows querying it about the state of the test, among other things: https://grafana.com/docs/k6/latest/misc/k6-rest-api/

In SM context, we do not really care about this, and having this enabled will cause k6 to emit a warning if there is another k6 check running, as the second one will fail to bind the same address (`localhost:6565`).

This commit disables the REST API.