### PR TITLE
feat: k6runner: default K6_BROWSER_LOG to info

### DIFF
--- a/internal/k6runner/env.go
+++ b/internal/k6runner/env.go
@@ -1,0 +1,19 @@
+package k6runner
+
+import (
+	"slices"
+	"strings"
+)
+
+// k6Env returns the environment variables that are passed to the k6 process that runs checks.
+// Ideally, this should be a clean slate env, but we know people are relying on the fact that k6 inherits the agent's
+// environment.
+// TODO: Make this a clean slate on the next major release, as a breaking change.
+func k6Env(localEnv []string) []string {
+	// Set K6_BROWSER_LOG=info if it is not set already.
+	if !slices.ContainsFunc(localEnv, func(e string) bool { return strings.HasPrefix(e, "K6_BROWSER_LOG=") }) {
+		localEnv = append(localEnv, "K6_BROWSER_LOG=info")
+	}
+
+	return localEnv
+}

--- a/internal/k6runner/env_test.go
+++ b/internal/k6runner/env_test.go
@@ -1,0 +1,36 @@
+package k6runner
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestEnv(t *testing.T) {
+	t.Parallel()
+
+	t.Run("adds k6 browser log default", func(t *testing.T) {
+		t.Parallel()
+
+		osenv := []string{"SOMETHING=else", "FOO=bar"}
+		modified := k6Env(osenv)
+
+		if !slices.Contains(modified, "K6_BROWSER_LOG=info") {
+			t.Fatalf("Expected env to contain browser log info")
+		}
+	})
+
+	t.Run("does not modify existing value", func(t *testing.T) {
+		t.Parallel()
+
+		osenv := []string{"SOMETHING=else", "FOO=bar", "K6_BROWSER_LOG=debug"}
+		modified := k6Env(osenv)
+
+		if !slices.Contains(modified, "K6_BROWSER_LOG=debug") {
+			t.Fatalf("Expected env to contain original variable")
+		}
+
+		if slices.Contains(modified, "K6_BROWSER_LOG=info") {
+			t.Fatalf("Expected env to _not_ contain browser log info")
+		}
+	})
+}

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"time"
 
@@ -119,6 +120,7 @@ func (r Local) Run(ctx context.Context, script Script) (*RunResponse, error) {
 	cmd.Stdin = nil
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	cmd.Env = k6Env(os.Environ())
 
 	start := time.Now()
 	logger.Info().Str("command", cmd.String()).Bytes("script", script.Script).Msg("running k6 script")


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-agent/issues/1193

Add a tiny helper, `k6Env`, that does some processing on the local environment before passing it down to k6. For now, it adds `K6_BROWSER_LOG=info` if `K6_BROWSER_LOG` is not already set.