### PR TITLE
chore: golangcilint: disable `exportloopref` linter

### DIFF
--- a/scripts/configs/golangci.yml
+++ b/scripts/configs/golangci.yml
@@ -21,7 +21,6 @@ linters:
     - errname
     # TODO(mem): - errorlint
     # TODO(mem): - exhaustive
-    - exportloopref
     - gocheckcompilerdirectives
     # - TODO(mem): gochecknoglobals
     - gochecknoinits


### PR DESCRIPTION
This linter is disabled, declaring it causes golangci-lint to emit an error and exit with status 7
```
level=error msg="[linters_context] exportloopref: This linter is fully
inactivated: it will not produce any reports."
```

Fixes https://github.com/grafana/synthetic-monitoring-agent/pull/1200 https://github.com/grafana/synthetic-monitoring-agent/pull/1190 