### PR TITLE
fix: multihttp: remove custom __raw_url__ tag

### DIFF
--- a/internal/prober/multihttp/script.tmpl
+++ b/internal/prober/multihttp/script.tmpl
@@ -88,7 +88,7 @@ export default function() {
 	{{ range $queries }}{{ . }};
 	{{ end -}}
 	{{- $method := .Request.Method.String }}
-	
+
 	body = {{ buildBody .Request.Body }};
 	{{- $bodyVars := interpolateBodyVars "body" .Request.Body }}
 	{{ range $bodyVars }}{{ . }};
@@ -98,8 +98,9 @@ export default function() {
 	response = http.request('{{ $method }}', url.toString(), body, {
 		// TODO(mem): build params out of options for the check
 		tags: {
+      // TODO: xk6-sm as of v0.3.0 no longer gives the `name` tag any preferential treatment. We should consider if this
+      // is still needed.
 		  name: '{{ $idx }}', // TODO(mem): give the user some control over this?
-		  __raw_url__: '{{ .Request.Url }}',
 		},
 		redirects: 0{{ if gt (len $headers) 0 }},
 		headers: {{ $headers }}{{ end }}


### PR DESCRIPTION
xk6-sm < v0.3.0 used to give special treatment to the `__raw_url__` tag (and also `name`, which is not the scope of this PR to tackle).

Specifically, it was used as the key to aggregate target metrics by:
https://github.com/grafana/xk6-sm/blob/bd43062f3d1f440278d041833f0e08ad86265bb6/output.go#L762

And then removed because it is not a valid prometheus label name:
https://github.com/grafana/xk6-sm/blob/bd43062f3d1f440278d041833f0e08ad86265bb6/output.go#L305

xk6-sm >= v0.3.0 no longer has the concept of target metrics, nor it performs any aggregation by label, only by timeseries (which requires all labels to match exactly. That change should make `__raw_url__` unnecessary.

Furthermore, as xk6-sm >= v0.3.0 is not removing this tag, this is causing the metrics output to be invalid and the agent to error out when parsing it:


```
{"level":"error","program":"synthetic-monitoring-agent","subsystem":"updater","region_id":0,"tenantId":0,"check_id":0,"probe":"Redacted","target":"https://grafana.com/","job":"default-multihttp","check":"multihttp","error":"creating prometheus metric: \"__raw_url__\" is not a valid label name for metric \"probe_http_ssl\"","time":1740670534186,"message":"running probe"}
```