### PR TITLE
feat: Add the sm-k6-gsm binary for secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ARG HOST_DIST=$TARGETOS-$TARGETARCH
 RUN adduser -D -u 12345 -g 12345 sm
 
 ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.0.3-pre/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.4.0/sm-k6-${TARGETOS}-${TARGETARCH}-gsm /usr/local/bin/sm-k6-gsm
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
@@ -39,6 +40,7 @@ RUN adduser -D -u 12345 -g 12345 sm
 
 COPY --from=release --chown=sm:sm /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release --chown=sm:sm /usr/local/bin/sm-k6 /usr/local/bin/sm-k6
+COPY --from=release --chown=sm:sm /usr/local/bin/sm-k6-gsm /usr/local/bin/sm-k6-gsm
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -24,6 +24,7 @@ ARG HOST_DIST=$TARGETOS-$TARGETARCH
 RUN adduser -D -u 12345 -g 12345 sm
 
 ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.0.3-pre/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.4.0/sm-k6-${TARGETOS}-${TARGETARCH}-gsm /usr/local/bin/sm-k6-gsm
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
@@ -39,6 +40,7 @@ RUN adduser -D -u 12345 -g 12345 sm
 
 COPY --from=release --chown=sm:sm /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release --chown=sm:sm /usr/local/bin/sm-k6 /usr/local/bin/sm-k6
+COPY --from=release --chown=sm:sm /usr/local/bin/sm-k6-gsm /usr/local/bin/sm-k6-gsm
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/scripts/make/sm-k6.mk
+++ b/scripts/make/sm-k6.mk
@@ -11,11 +11,17 @@ $(DISTDIR)/$(1)-$(2)/sm-k6:
 	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v0.0.3/sm-k6-$(1)-$(2) -o "$$@"
 	chmod +x "$$@"
 
-sm-k6: $(DISTDIR)/$(1)-$(2)/sm-k6
+$(DISTDIR)/$(1)-$(2)/sm-k6-gsm:
+	mkdir -p "$(DISTDIR)/$(1)-$(2)"
+	# Renovate updates the following line. Keep its syntax as it is.
+	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v0.4.0/sm-k6-$(1)-$(2)-gsm -o "$$@"
+	chmod +x "$$@"
+
+sm-k6: $(DISTDIR)/$(1)-$(2)/sm-k6 $(DISTDIR)/$(1)-$(2)/sm-k6-gsm
 endef
 
 $(foreach BUILD_PLATFORM,$(XK6_PLATFORMS), \
 	$(eval $(call sm-k6,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
 
 .PHONY: sm-k6-native
-sm-k6-native: $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/sm-k6
+sm-k6-native: $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/sm-k6 $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/sm-k6-gsm

--- a/scripts/package/nfpm.yaml.template
+++ b/scripts/package/nfpm.yaml.template
@@ -23,5 +23,7 @@ contents:
 # Copy k6 as sm-k6 to prevent clashing with k6 if it's installed.
 - src: {{.DISTDIR}}/{{.Os}}-{{.Arch}}/sm-k6
   dst: /usr/bin/sm-k6
+- src: {{.DISTDIR}}/{{.Os}}-{{.Arch}}/sm-k6-gsm
+  dst: /usr/bin/sm-k6-gsm
 rpm:
 deb:


### PR DESCRIPTION
~~This depends on https://github.com/grafana/xk6-sm/pull/75/ and therefore the release: https://github.com/grafana/xk6-sm/pull/74~~

To support secrets in the short term we need to add a second k6 binary which tracks the upstream secrets work. This means it is an unreleased k6 version.

This binary will only be used when secret source configuration is provided from the API. This will start to happen with https://github.com/grafana/synthetic-monitoring-agent/pull/1179