### PR TITLE
fix: Update version reporting logic

### DIFF
--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/grafana/synthetic-monitoring-agent/internal/version"
+
+func main() {
+	println(version.Short())
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/synthetic-monitoring-agent
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.1
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2025 Grafana Labs.
+// SPDX-License-Identifier: AGPL-3.0-only
+
 package version
 
 import (
@@ -5,39 +8,77 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"slices"
+	"strings"
+	"sync"
 )
 
-const smHomepage = "https://github.com/grafana/synthetic-monitoring-agent"
-
-var (
-	version    = "unknown"
-	commit     = "0000000000000000000000000000000000000000"
-	buildstamp = "1970-01-01 00:00:00+00:00"
-	userAgent  = buildUserAgentStr()
+const (
+	revisionKey = "vcs.revision"
+	timeKey     = "vcs.time"
+	smHomepage  = "https://github.com/grafana/synthetic-monitoring-agent"
 )
 
 func Short() string {
-	return version
+	bi := getBuildInfo()
+
+	return bi.Main.Version
 }
 
 func Commit() string {
-	return commit
+	return getBuildInfoByKey(revisionKey)
 }
 
 func Buildstamp() string {
-	return buildstamp
+	return getBuildInfoByKey(timeKey)
 }
 
 func UserAgent() string {
-	return userAgent
+	return userAgentStr()
 }
 
-func buildUserAgentStr() string {
-	program := "unknown"
-
-	if info, ok := debug.ReadBuildInfo(); ok {
-		program = filepath.Base(info.Path)
+func getBuildInfoByKey(key string) string {
+	bi := getBuildInfo()
+	if bi == nil {
+		return "invalid"
 	}
 
-	return fmt.Sprintf("%s/%s (%s %s; %s; %s; +%s)", program, version, runtime.GOOS, runtime.GOARCH, commit, buildstamp, smHomepage)
+	idx, found := slices.BinarySearchFunc(bi.Settings, key, isKey)
+	if found {
+		return bi.Settings[idx].Value
+	}
+
+	return "unknown"
+}
+
+//nolint:gochecknoglobals // This variable is only accessed in this package.
+var getBuildInfo = sync.OnceValue(func() *debug.BuildInfo {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil
+	}
+
+	slices.SortFunc(bi.Settings, cmpBuildSettings)
+
+	return bi
+})
+
+var userAgentStr = sync.OnceValue(func() string {
+	bi := getBuildInfo()
+
+	program := filepath.Base(bi.Path)
+
+	return fmt.Sprintf("%s/%s (%s %s; %s; %s; +%s)", program, Short(), runtime.GOOS, runtime.GOARCH, Commit(), Buildstamp(), smHomepage)
+})
+
+func cmpBuildSettings(a, b debug.BuildSetting) int {
+	if v := strings.Compare(a.Key, b.Key); v != 0 {
+		return v
+	}
+
+	return strings.Compare(a.Value, b.Value)
+}
+
+func isKey(a debug.BuildSetting, key string) int {
+	return strings.Compare(a.Key, key)
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2025 Grafana Labs.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package version
+
+import (
+	"runtime/debug"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAll validates that the various function are returning _something_.
+func TestAll(t *testing.T) {
+	t.Parallel()
+
+	const (
+		versionValue  = "(devel)"
+		revisionValue = "test-revision"
+		timeValue     = "test-time"
+	)
+
+	// Override the getBuildInfo variable to ensure that we can test the
+	// functions without having to rely on the actual build information.
+	//
+	// Before Go 1.24, test binaries would get their buildinfo populated in
+	// the same way as regular packages. Starting with 1.24, that
+	// information is no longer available, so the only possible test is to
+	// ensure that the functions return _something_. This is basically
+	// another instance of Hyrum's Law.
+	//
+	// Note that instead of simply returning a fixed value for the
+	// buildinfo, this modifies the actual value returned by
+	// debug.ReadBuildInfo. In this way if the behavior changes again, e.g.
+	// it starts to return a value when running as part of a test, the test
+	// will fail and we can decide what to do with that.
+	//
+	// See https://github.com/golang/go/issues/33976, sort of.
+	getBuildInfo = sync.OnceValue(func() *debug.BuildInfo {
+		bi, ok := debug.ReadBuildInfo()
+		if !ok {
+			return nil
+		}
+
+		slices.SortFunc(bi.Settings, cmpBuildSettings)
+
+		if _, found := slices.BinarySearchFunc(bi.Settings, revisionKey, isKey); !found {
+			bi.Settings = append(bi.Settings, debug.BuildSetting{Key: revisionKey, Value: revisionValue})
+		}
+
+		if _, found := slices.BinarySearchFunc(bi.Settings, timeKey, isKey); !found {
+			bi.Settings = append(bi.Settings, debug.BuildSetting{Key: timeKey, Value: timeValue})
+		}
+
+		slices.SortFunc(bi.Settings, cmpBuildSettings)
+
+		return bi
+	})
+
+	require.Equal(t, versionValue, Short())
+	require.Equal(t, revisionValue, Commit())
+	require.Equal(t, timeValue, Buildstamp())
+	require.NotEmpty(t, UserAgent())
+}

--- a/scripts/make/build.mk
+++ b/scripts/make/build.mk
@@ -39,7 +39,6 @@ define build_go_command
 	$(V) GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build \
 		$(GO_BUILD_FLAGS) \
 		-o '$(DIST_FILENAME)' \
-		-ldflags '-X "$(VERSION_PKG).commit=$(BUILD_COMMIT)" -X "$(VERSION_PKG).version=$(BUILD_VERSION)" -X "$(VERSION_PKG).buildstamp=$(BUILD_STAMP)"' \
 		'$(1)'
 	$(V) test '$(GOOS)' = '$(HOST_OS)' -a '$(GOARCH)' = '$(HOST_ARCH)' && \
 		cp -a '$(DIST_FILENAME)' '$(DISTDIR)/$(notdir $(1))' || \

--- a/scripts/version
+++ b/scripts/version
@@ -1,9 +1,15 @@
 #!/bin/sh
-#
-# --abbrev=12 asks for at least 12 characters in the SHA-1 hash. The trick is
-# that git might choose to output more if 10 are not enough to keep the value
-# unique.
-#
-# This is a balance between having a predictable value and having something
-# that is not too long, as this value gets displayed in a couple of places.
-git describe --dirty --tags --long --always --abbrev=12
+
+set -e
+set -u
+
+if test ! -d ./cmd/version ; then
+	git describe --dirty --tags --long --always --abbrev=12
+else
+	tmpdir=$(mktemp -d)
+	trap 'rm -rf "$tmpdir"' EXIT
+
+	go build -o "$tmpdir/version" ./cmd/version &&
+		"$tmpdir/version" 2>&1 ||
+		echo "unknown"
+fi


### PR DESCRIPTION
Go 1.24 added a way to obtain the version (extract from the current Git repo) from the running program. Switch to that instead of passing linker flags at build time.