### PR TITLE
fix: Use a global tenant ID when retrieving secrets information

### DIFF
--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -36,7 +36,7 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 		return p, errUnsupportedCheck
 	}
 
-	secretStore, err := store.GetSecretCredentials(ctx, check.TenantId)
+	secretStore, err := store.GetSecretCredentials(ctx, check.GlobalTenantID())
 	if err != nil {
 		return p, err
 	}

--- a/internal/prober/browser/browser_test.go
+++ b/internal/prober/browser/browser_test.go
@@ -86,6 +86,6 @@ func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.Ru
 
 type noopSecretStore struct{}
 
-func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID model.GlobalID) (*sm.SecretStore, error) {
 	return &sm.SecretStore{}, nil
 }

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -46,7 +46,7 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 		augmentHttpHeaders(&check.Check, reservedHeaders)
 	}
 
-	secretStore, err := store.GetSecretCredentials(ctx, check.TenantId)
+	secretStore, err := store.GetSecretCredentials(ctx, check.GlobalTenantID())
 	if err != nil {
 		return p, err
 	}

--- a/internal/prober/multihttp/multihttp_test.go
+++ b/internal/prober/multihttp/multihttp_test.go
@@ -161,6 +161,6 @@ func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.Ru
 
 type noopSecretStore struct{}
 
-func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID model.GlobalID) (*sm.SecretStore, error) {
 	return &sm.SecretStore{}, nil
 }

--- a/internal/prober/prober_test.go
+++ b/internal/prober/prober_test.go
@@ -31,6 +31,6 @@ func TestProberFactoryCoverage(t *testing.T) {
 
 type noopSecretStore struct{}
 
-func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID model.GlobalID) (*sm.SecretStore, error) {
 	return &sm.SecretStore{}, nil
 }

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -36,7 +36,7 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 		return p, errUnsupportedCheck
 	}
 
-	secretStore, err := store.GetSecretCredentials(ctx, check.TenantId)
+	secretStore, err := store.GetSecretCredentials(ctx, check.GlobalTenantID())
 	if err != nil {
 		return p, err
 	}

--- a/internal/prober/scripted/scripted_test.go
+++ b/internal/prober/scripted/scripted_test.go
@@ -85,7 +85,7 @@ func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.Ru
 
 type noopSecretStore struct{}
 
-func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID model.GlobalID) (*sm.SecretStore, error) {
 	return &sm.SecretStore{}, nil
 }
 

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -2028,6 +2028,6 @@ func TestTickWithOffset(t *testing.T) {
 
 type noopSecretStore struct{}
 
-func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+func (n noopSecretStore) GetSecretCredentials(ctx context.Context, tenantID model.GlobalID) (*sm.SecretStore, error) {
 	return &sm.SecretStore{}, nil
 }

--- a/internal/secrets/tenant.go
+++ b/internal/secrets/tenant.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
 type SecretProvider interface {
-	GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error)
+	GetSecretCredentials(ctx context.Context, tenantID model.GlobalID) (*sm.SecretStore, error)
 }
 
 type TenantProvider interface {
@@ -28,9 +29,9 @@ func NewTenantSecrets(tp TenantProvider, logger zerolog.Logger) *TenantSecrets {
 	}
 }
 
-func (ts *TenantSecrets) GetSecretCredentials(ctx context.Context, tenantID int64) (*sm.SecretStore, error) {
+func (ts *TenantSecrets) GetSecretCredentials(ctx context.Context, tenantID model.GlobalID) (*sm.SecretStore, error) {
 	tenant, err := ts.tp.GetTenant(ctx, &sm.TenantInfo{
-		Id: tenantID,
+		Id: int64(tenantID),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/secrets/tenant_test.go
+++ b/internal/secrets/tenant_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/stretchr/testify/assert"
 )
@@ -26,7 +27,7 @@ func TestGetSecretCredentials_Success(t *testing.T) {
 	mockTenantProvider := &tenantProvider{tenant: mockTenant}
 	ts := NewTenantSecrets(mockTenantProvider, zerolog.Nop())
 	ctx := context.Background()
-	tenantID := int64(1234)
+	tenantID := model.GlobalID(1234)
 
 	secretStore, err := ts.GetSecretCredentials(ctx, tenantID)
 
@@ -39,7 +40,7 @@ func TestGetSecretCredentials_Error(t *testing.T) {
 	mockTenantProvider := &tenantProvider{err: getTenantErr}
 	ts := NewTenantSecrets(mockTenantProvider, zerolog.Nop())
 	ctx := context.Background()
-	tenantID := int64(1234)
+	tenantID := model.GlobalID(1234)
 
 	secretStore, err := ts.GetSecretCredentials(ctx, tenantID)
 


### PR DESCRIPTION
We have several places that need a global tenant ID. We usually communicate this by using models.GlobalTenantID instead of just int64, but the GetTenant function takes a structure that doesn't make a distinction, because it would require updating the protocol buffer definition in a way that would be hard to handle.

Fix the various locations that are using a local ID instead of a global ID.