### PR TITLE
fix: Pass Tenant ID to adhoc checks

### DIFF
--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -384,6 +384,7 @@ func defaultGrpcAdhocChecksClientFactory(conn ClientConn) (sm.AdHocChecksClient,
 func (h *Handler) defaultRunnerFactory(ctx context.Context, req *sm.AdHocRequest) (*runner, error) {
 	check := model.Check{
 		Check: sm.Check{
+			TenantId: req.AdHocCheck.TenantId,
 			Target:   req.AdHocCheck.Target,
 			Timeout:  req.AdHocCheck.Timeout,
 			Settings: req.AdHocCheck.Settings,


### PR DESCRIPTION
It seems ad hoc checks have never used the tenant ID. The secrets handling code needs this information in order to be able to retrieve secrets.