### PR TITLE
feat: report metrics about requests made to remote runners

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -273,6 +273,7 @@ func run(args []string, stdout io.Writer) error {
 		k6Runner = k6runner.New(k6runner.RunnerOpts{
 			Uri:           config.K6URI,
 			BlacklistedIP: config.K6BlacklistedIP,
+			Registerer:    promRegisterer,
 		})
 	}
 

--- a/internal/k6runner/http_test.go
+++ b/internal/k6runner/http_test.go
@@ -301,7 +301,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			srv := httptest.NewServer(mux)
 			t.Cleanup(srv.Close)
 
-			runner := HttpRunner{url: srv.URL + "/run", graceTime: time.Second, backoff: time.Second}
+			runner := HttpRunner{url: srv.URL + "/run", graceTime: time.Second, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry())}
 			script, err := NewProcessor(Script{
 				Script: []byte("tee-hee"),
 				Settings: Settings{
@@ -443,7 +443,7 @@ func TestHTTPProcessorRetries(t *testing.T) {
 				srv := httptest.NewServer(mux)
 				t.Cleanup(srv.Close)
 
-				runner := HttpRunner{url: srv.URL + "/run", graceTime: tc.graceTime, backoff: time.Second}
+				runner := HttpRunner{url: srv.URL + "/run", graceTime: tc.graceTime, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry())}
 				processor, err := NewProcessor(Script{Script: nil, Settings: Settings{tc.scriptTimeout.Milliseconds()}}, runner)
 				require.NoError(t, err)
 
@@ -489,7 +489,7 @@ func TestHTTPProcessorRetries(t *testing.T) {
 
 		addr := <-listenerCh
 
-		runner := HttpRunner{url: "http://" + addr + "/run", graceTime: time.Second, backoff: time.Second}
+		runner := HttpRunner{url: "http://" + addr + "/run", graceTime: time.Second, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry())}
 		processor, err := NewProcessor(Script{Script: nil, Settings: Settings{Timeout: 1000}}, runner)
 		require.NoError(t, err)
 

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -98,11 +98,16 @@ type Runner interface {
 type RunnerOpts struct {
 	Uri           string
 	BlacklistedIP string
+	Registerer    prometheus.Registerer
 }
 
 func New(opts RunnerOpts) Runner {
 	var r Runner
 	logger := zerolog.Nop()
+	var registerer prometheus.Registerer = prometheus.NewRegistry() // NOOP registry.
+	if opts.Registerer != nil {
+		registerer = opts.Registerer
+	}
 
 	if strings.HasPrefix(opts.Uri, "http") {
 		r = &HttpRunner{
@@ -110,6 +115,7 @@ func New(opts RunnerOpts) Runner {
 			logger:    &logger,
 			graceTime: defaultGraceTime,
 			backoff:   defaultBackoff,
+			metrics:   NewHTTPMetrics(registerer),
 		}
 	} else {
 		r = Local{


### PR DESCRIPTION
In certain environments, the sm-agent delegates running k6 scripts to a remote runner, through an HTTP API. Requests to this API are subject to retries, and the success rate of requests and the number of attempts they took are key metrics to measure the healthiness of the system.

This PR adds two metrics:
- `requests_total` is a counter that keeps track of each individual HTTP request made. Both the first and subsequent attempts to run a script increment this counter. Labels `success` and `retriable` can be used to see how many requests where successful, and how many errors were retriable. Note that `retriable="1"` does not necessarily mean the request was retried.
- `requests_per_run` is a histogram that keeps track of the number of individual HTTP requests that were made for a given script run, with the minimum number being 1 (0 retries). The `success` label can be used to see if the run ultimately succeeded.

Using this metrics, we should be able to answer interesting questions, such as:
- The total number of requests made to runners (rps). This is already monitored on the runner side, but this should give us the client perspective.
- The per-request failure ratio (`requests_total{success=0}/requests_total`)
- The per-run failure ratio (`requests_per_run_count{success=0}/requests_per_run_count`)
- How many retries are needed, on average, for a run to succeed (`histogram_quantile` of `requests_per_run_bucket{success=1}`)
- How many runs fail without any retry attempted (`requests_per_run_count{success=0, le=1}`)
- How many runs retries "save" from failing (`requests_per_run_count{success=1, le!=1}`)