### PR TITLE
fix: Remove second k6 binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,7 @@ ARG HOST_DIST=$TARGETOS-$TARGETARCH
 
 RUN adduser -D -u 12345 -g 12345 sm
 
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.4.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.4.0/sm-k6-${TARGETOS}-${TARGETARCH}-gsm /usr/local/bin/sm-k6-gsm
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.5.2/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
@@ -40,7 +39,6 @@ RUN adduser -D -u 12345 -g 12345 sm
 
 COPY --from=release --chown=sm:sm /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release --chown=sm:sm /usr/local/bin/sm-k6 /usr/local/bin/sm-k6
-COPY --from=release --chown=sm:sm /usr/local/bin/sm-k6-gsm /usr/local/bin/sm-k6-gsm
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -23,8 +23,7 @@ ARG HOST_DIST=$TARGETOS-$TARGETARCH
 
 RUN adduser -D -u 12345 -g 12345 sm
 
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.4.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.4.0/sm-k6-${TARGETOS}-${TARGETARCH}-gsm /usr/local/bin/sm-k6-gsm
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.5.2/sm-k6-${TARGETOS}-${TARGETARCH} /usr/local/bin/sm-k6
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
@@ -40,7 +39,6 @@ RUN adduser -D -u 12345 -g 12345 sm
 
 COPY --from=release --chown=sm:sm /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release --chown=sm:sm /usr/local/bin/sm-k6 /usr/local/bin/sm-k6
-COPY --from=release --chown=sm:sm /usr/local/bin/sm-k6-gsm /usr/local/bin/sm-k6-gsm
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -75,18 +75,7 @@ func (r Local) Run(ctx context.Context, script Script, secretStore SecretStore) 
 		return nil, fmt.Errorf("cannot write temporary script file: %w", err)
 	}
 
-	executable := r.k6path
-	// TODO(d0ugal): This is a short-term hack to use a different k6 binary when
-	// secrets are configured. This should be removed when the default binary has been updated
-	if secretStore.IsConfigured() {
-		executable = r.k6path + "-gsm"
-		logger.Info().
-			Str("k6_path", r.k6path).
-			Str("k6_gsm_path", executable).
-			Msg("Using k6-gsm binary for secrets")
-	}
-
-	k6Path, err := exec.LookPath(executable)
+	k6Path, err := exec.LookPath(r.k6path)
 	if err != nil {
 		return nil, fmt.Errorf("cannot find k6 executable: %w", err)
 	}

--- a/scripts/make/sm-k6.mk
+++ b/scripts/make/sm-k6.mk
@@ -8,20 +8,14 @@ define sm-k6
 $(DISTDIR)/$(1)-$(2)/sm-k6:
 	mkdir -p "$(DISTDIR)/$(1)-$(2)"
 	# Renovate updates the following line. Keep its syntax as it is.
-	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v0.4.0/sm-k6-$(1)-$(2) -o "$$@"
+	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v0.5.2/sm-k6-$(1)-$(2) -o "$$@"
 	chmod +x "$$@"
 
-$(DISTDIR)/$(1)-$(2)/sm-k6-gsm:
-	mkdir -p "$(DISTDIR)/$(1)-$(2)"
-	# Renovate updates the following line. Keep its syntax as it is.
-	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v0.4.0/sm-k6-$(1)-$(2)-gsm -o "$$@"
-	chmod +x "$$@"
-
-sm-k6: $(DISTDIR)/$(1)-$(2)/sm-k6 $(DISTDIR)/$(1)-$(2)/sm-k6-gsm
+sm-k6: $(DISTDIR)/$(1)-$(2)/sm-k6
 endef
 
 $(foreach BUILD_PLATFORM,$(XK6_PLATFORMS), \
 	$(eval $(call sm-k6,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
 
 .PHONY: sm-k6-native
-sm-k6-native: $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/sm-k6 $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/sm-k6-gsm
+sm-k6-native: $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/sm-k6

--- a/scripts/package/nfpm.yaml.template
+++ b/scripts/package/nfpm.yaml.template
@@ -23,7 +23,5 @@ contents:
 # Copy k6 as sm-k6 to prevent clashing with k6 if it's installed.
 - src: {{.DISTDIR}}/{{.Os}}-{{.Arch}}/sm-k6
   dst: /usr/bin/sm-k6
-- src: {{.DISTDIR}}/{{.Os}}-{{.Arch}}/sm-k6-gsm
-  dst: /usr/bin/sm-k6-gsm
 rpm:
 deb:


### PR DESCRIPTION
Now that we have a more recent k6 version in xk6-sm[1] we can consolidate

[1]: https://github.com/grafana/xk6-sm/pull/106