### PR TITLE
chore: examples: mount an emptydir volume in /tmp

### DIFF
--- a/examples/kubernetes/deployment.yaml
+++ b/examples/kubernetes/deployment.yaml
@@ -67,3 +67,9 @@ spec:
             requests:
               cpu: 200m
               memory: 500Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
For some types of checks, such as HTTP checks with a custom certificate, the agent needs to be able to write the certificate to a temporary path.

The `emptyDir` volume mounted on `/tmp` makes this possible while keeping `readOnlyRootFilesystem: true`.