### PR TITLE
fix: Change how the secret store is handled

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -43,6 +43,19 @@ import (
 const (
 	exitFail             = 1
 	defTelemetryTimeSpan = 5 // min
+
+	// The expiration time for access tokens is 10 minutes. Until we get
+	// expiration information from the API, set this to a low number.
+	// Normally it should be 15 minutes.
+	//
+	// This specific number is accounting for ~ 3 minutes of total
+	// execution time for scripts, plus 30 seconds of buffer for retrieving
+	// secrets, sending script to runner, etc. We expect secrets to be
+	// loaded near the start of the script, but given it's a program we
+	// cannot enforce that. k6 would have enforced that by making secrets
+	// part of the options block, but we do not want to go anywhere near
+	// that.
+	secretsTimeout = 450 * time.Second // 7.5 minutes
 )
 
 // run is the main entry point for the program.
@@ -281,7 +294,7 @@ func run(args []string, stdout io.Writer) error {
 		ctx,
 		synthetic_monitoring.NewTenantsClient(conn),
 		tenantCh,
-		15*time.Minute,
+		secretsTimeout,
 		zl.With().Str("subsystem", "tenant_manager").Logger(),
 	)
 

--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -277,7 +277,13 @@ func run(args []string, stdout io.Writer) error {
 		})
 	}
 
-	tm := tenants.NewManager(ctx, synthetic_monitoring.NewTenantsClient(conn), tenantCh, 15*time.Minute)
+	tm := tenants.NewManager(
+		ctx,
+		synthetic_monitoring.NewTenantsClient(conn),
+		tenantCh,
+		15*time.Minute,
+		zl.With().Str("subsystem", "tenant_manager").Logger(),
+	)
 
 	pusherRegistry := pusher.NewRegistry[pusher.Factory]()
 	pusherRegistry.MustRegister(pusherV1.Name, pusherV1.NewPublisher)

--- a/internal/adhoc/adhoc_test.go
+++ b/internal/adhoc/adhoc_test.go
@@ -600,6 +600,6 @@ func (r *testK6Runner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (r *testK6Runner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
+func (r *testK6Runner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -504,7 +504,7 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
+func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }
 

--- a/internal/k6runner/http.go
+++ b/internal/k6runner/http.go
@@ -63,7 +63,7 @@ func (r HttpRunner) WithLogger(logger *zerolog.Logger) Runner {
 
 var ErrUnexpectedStatus = errors.New("unexpected status code")
 
-func (r HttpRunner) Run(ctx context.Context, script Script) (*RunResponse, error) {
+func (r HttpRunner) Run(ctx context.Context, script Script, secretStore SecretStore) (*RunResponse, error) {
 	if r.backoff == 0 {
 		panic("zero backoff, runner is misconfigured, refusing to DoS")
 	}

--- a/internal/k6runner/http_test.go
+++ b/internal/k6runner/http_test.go
@@ -80,7 +80,7 @@ func TestHttpRunnerRun(t *testing.T) {
 	ctx, cancel := testhelper.Context(ctx, t)
 	t.Cleanup(cancel)
 
-	_, err := runner.Run(ctx, script)
+	_, err := runner.Run(ctx, script, SecretStore{})
 	require.NoError(t, err)
 }
 
@@ -129,7 +129,7 @@ func TestHttpRunnerRunError(t *testing.T) {
 	ctx, cancel = testhelper.Context(ctx, t)
 	t.Cleanup(cancel)
 
-	_, err := runner.Run(ctx, script)
+	_, err := runner.Run(ctx, script, SecretStore{})
 	require.ErrorIs(t, err, ErrUnexpectedStatus)
 }
 
@@ -322,7 +322,7 @@ func TestScriptHTTPRun(t *testing.T) {
 				zlogger  = zerolog.Nop()
 			)
 
-			success, err := script.Run(ctx, registry, logger, zlogger)
+			success, err := script.Run(ctx, registry, logger, zlogger, SecretStore{})
 			require.Equal(t, tc.expectSuccess, success)
 			require.Equal(t, tc.expectLogs, logger.buf.String())
 			if tc.expectErrorAs == nil {
@@ -457,7 +457,7 @@ func TestHTTPProcessorRetries(t *testing.T) {
 					logger   testLogger
 					zlogger  = zerolog.New(io.Discard)
 				)
-				success, err := processor.Run(ctx, registry, &logger, zlogger)
+				success, err := processor.Run(ctx, registry, &logger, zlogger, SecretStore{})
 				require.ErrorIs(t, err, tc.expectError)
 				require.Equal(t, tc.expectError == nil, success)
 				require.Equal(t, tc.expectRequests, requests.Load())
@@ -503,7 +503,7 @@ func TestHTTPProcessorRetries(t *testing.T) {
 			logger   testLogger
 			zlogger  = zerolog.New(io.Discard)
 		)
-		success, err := processor.Run(ctx, registry, &logger, zlogger)
+		success, err := processor.Run(ctx, registry, &logger, zlogger, SecretStore{})
 		require.NoError(t, err)
 		require.True(t, success)
 	})

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -29,8 +29,6 @@ type Script struct {
 	// CheckInfo holds information about the SM check that triggered this script.
 	CheckInfo CheckInfo `json:"check"`
 	// SecretStore holds the location and token for accessing secrets
-	SecretStore SecretStore `json:"secretStore"`
-	// TODO: Add features.
 }
 
 type SecretStore struct {
@@ -92,7 +90,7 @@ var ErrNoTimeout = errors.New("check has no timeout")
 
 type Runner interface {
 	WithLogger(logger *zerolog.Logger) Runner
-	Run(ctx context.Context, script Script) (*RunResponse, error)
+	Run(ctx context.Context, script Script, secretStore SecretStore) (*RunResponse, error)
 }
 
 type RunnerOpts struct {
@@ -149,11 +147,11 @@ var (
 	ErrFromRunner  = errors.New("runner reported an error")
 )
 
-func (r Processor) Run(ctx context.Context, registry *prometheus.Registry, logger logger.Logger, internalLogger zerolog.Logger) (bool, error) {
+func (r Processor) Run(ctx context.Context, registry *prometheus.Registry, logger logger.Logger, internalLogger zerolog.Logger, secretStore SecretStore) (bool, error) {
 	k6runner := r.runner.WithLogger(&internalLogger)
 
 	// TODO: This error message is okay to be Debug for local k6 execution, but should be Error for remote runners.
-	result, err := k6runner.Run(ctx, r.script)
+	result, err := k6runner.Run(ctx, r.script, secretStore)
 	if err != nil {
 		internalLogger.Debug().
 			Err(err).

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -90,7 +90,7 @@ func TestScriptRun(t *testing.T) {
 	// We already know tha parsing the metrics and the logs is working, so
 	// we are only interested in verifying that the script runs without
 	// errors.
-	success, err := processor.Run(ctx, registry, &logger, zlogger)
+	success, err := processor.Run(ctx, registry, &logger, zlogger, SecretStore{})
 	require.NoError(t, err)
 	require.True(t, success)
 }
@@ -130,7 +130,7 @@ type testRunner struct {
 
 var _ Runner = &testRunner{}
 
-func (r *testRunner) Run(ctx context.Context, script Script) (*RunResponse, error) {
+func (r *testRunner) Run(ctx context.Context, script Script, secretStore SecretStore) (*RunResponse, error) {
 	return &RunResponse{
 		Metrics: r.metrics,
 		Logs:    r.logs,

--- a/internal/k6runner/local_test.go
+++ b/internal/k6runner/local_test.go
@@ -110,12 +110,7 @@ func TestBuildK6Args(t *testing.T) {
 			},
 		},
 		"script with secrets": {
-			script: Script{
-				SecretStore: SecretStore{
-					Url:   secretUrl,
-					Token: "secret-token",
-				},
-			},
+			script:        Script{},
 			metricsFn:     "/tmp/metrics.json",
 			logsFn:        "/tmp/logs.log",
 			scriptFn:      "/tmp/script.js",

--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -24,9 +24,10 @@ type Module struct {
 }
 
 type Prober struct {
-	logger    zerolog.Logger
-	module    Module
-	processor *k6runner.Processor
+	logger           zerolog.Logger
+	module           Module
+	processor        *k6runner.Processor
+	secretsRetriever func(context.Context) (k6runner.SecretStore, error)
 }
 
 func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, store secrets.SecretProvider) (Prober, error) {
@@ -34,11 +35,6 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 
 	if check.Settings.Browser == nil {
 		return p, errUnsupportedCheck
-	}
-
-	secretStore, err := store.GetSecretCredentials(ctx, check.GlobalTenantID())
-	if err != nil {
-		return p, err
 	}
 
 	p.module = Module{
@@ -52,13 +48,6 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 		},
 	}
 
-	if secretStore != nil {
-		p.module.Script.SecretStore = k6runner.SecretStore{
-			Url:   secretStore.Url,
-			Token: secretStore.Token,
-		}
-	}
-
 	processor, err := k6runner.NewProcessor(p.module.Script, runner)
 	if err != nil {
 		return p, err
@@ -66,6 +55,7 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 
 	p.processor = processor
 	p.logger = logger
+	p.secretsRetriever = newCredentialsRetriever(store, check.GlobalTenantID())
 
 	return p, nil
 }
@@ -75,7 +65,14 @@ func (p Prober) Name() string {
 }
 
 func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
-	success, err := p.processor.Run(ctx, registry, logger, p.logger)
+	secretStore, err := p.secretsRetriever(ctx)
+
+	if err != nil {
+		p.logger.Error().Err(err).Msg("running probe")
+		return false, 0
+	}
+
+	success, err := p.processor.Run(ctx, registry, logger, p.logger, secretStore)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0
@@ -83,4 +80,25 @@ func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.R
 
 	// TODO(mem): implement custom duration extraction.
 	return success, 0
+}
+
+// TODO(mem): This should probably be in the k6runner package.
+func newCredentialsRetriever(provider secrets.SecretProvider, tenantID model.GlobalID) func(context.Context) (k6runner.SecretStore, error) {
+	return func(ctx context.Context) (k6runner.SecretStore, error) {
+		var store k6runner.SecretStore
+
+		credentials, err := provider.GetSecretCredentials(ctx, tenantID)
+		if err != nil {
+			return store, err
+		}
+
+		if credentials != nil {
+			store = k6runner.SecretStore{
+				Url:   credentials.Url,
+				Token: credentials.Token,
+			}
+		}
+
+		return store, nil
+	}
 }

--- a/internal/prober/browser/browser_test.go
+++ b/internal/prober/browser/browser_test.go
@@ -80,7 +80,7 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
+func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }
 

--- a/internal/prober/multihttp/multihttp_test.go
+++ b/internal/prober/multihttp/multihttp_test.go
@@ -155,7 +155,7 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
+func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }
 

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -66,7 +66,6 @@ func (p Prober) Name() string {
 
 func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	secretStore, err := p.secretsRetriever(ctx)
-
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -24,9 +24,10 @@ type Module struct {
 }
 
 type Prober struct {
-	logger    zerolog.Logger
-	module    Module
-	processor *k6runner.Processor
+	logger           zerolog.Logger
+	module           Module
+	processor        *k6runner.Processor
+	secretsRetriever func(context.Context) (k6runner.SecretStore, error)
 }
 
 func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, store secrets.SecretProvider) (Prober, error) {
@@ -34,11 +35,6 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 
 	if check.Settings.Scripted == nil {
 		return p, errUnsupportedCheck
-	}
-
-	secretStore, err := store.GetSecretCredentials(ctx, check.GlobalTenantID())
-	if err != nil {
-		return p, err
 	}
 
 	p.module = Module{
@@ -52,13 +48,6 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 		},
 	}
 
-	if secretStore != nil {
-		p.module.Script.SecretStore = k6runner.SecretStore{
-			Url:   secretStore.Url,
-			Token: secretStore.Token,
-		}
-	}
-
 	processor, err := k6runner.NewProcessor(p.module.Script, runner)
 	if err != nil {
 		return p, err
@@ -66,6 +55,7 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 
 	p.processor = processor
 	p.logger = logger
+	p.secretsRetriever = newCredentialsRetriever(store, check.GlobalTenantID())
 
 	return p, nil
 }
@@ -75,7 +65,14 @@ func (p Prober) Name() string {
 }
 
 func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
-	success, err := p.processor.Run(ctx, registry, logger, p.logger)
+	secretStore, err := p.secretsRetriever(ctx)
+
+	if err != nil {
+		p.logger.Error().Err(err).Msg("running probe")
+		return false, 0
+	}
+
+	success, err := p.processor.Run(ctx, registry, logger, p.logger, secretStore)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0
@@ -83,4 +80,24 @@ func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.R
 
 	// TODO(mem): implement custom duration extraction.
 	return success, 0
+}
+
+func newCredentialsRetriever(provider secrets.SecretProvider, tenantID model.GlobalID) func(context.Context) (k6runner.SecretStore, error) {
+	return func(ctx context.Context) (k6runner.SecretStore, error) {
+		var store k6runner.SecretStore
+
+		credentials, err := provider.GetSecretCredentials(ctx, tenantID)
+		if err != nil {
+			return store, err
+		}
+
+		if credentials != nil {
+			store = k6runner.SecretStore{
+				Url:   credentials.Url,
+				Token: credentials.Token,
+			}
+		}
+
+		return store, nil
+	}
 }

--- a/internal/prober/scripted/scripted_test.go
+++ b/internal/prober/scripted/scripted_test.go
@@ -79,7 +79,7 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (noopRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
+func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }
 

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1763,7 +1763,7 @@ type testRunner struct {
 
 var _ k6runner.Runner = &testRunner{}
 
-func (r *testRunner) Run(ctx context.Context, script k6runner.Script) (*k6runner.RunResponse, error) {
+func (r *testRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{
 		Metrics: r.metrics,
 		Logs:    r.logs,

--- a/internal/tenants/manager.go
+++ b/internal/tenants/manager.go
@@ -22,7 +22,17 @@ type Manager struct {
 var _ pusher.TenantProvider = &Manager{}
 
 const (
-	secretsTimeout = 8 * time.Minute
+	// The expiration time for access tokens is 10 minutes. Until we get
+	// expiration information from the API, set this to a fixed number.
+	//
+	// This specific number is accounting for ~ 3 minutes of total
+	// execution time for scripts, plus 30 seconds of buffer for retrieving
+	// secrets, sending script to runner, etc. We expect secrets to be
+	// loaded near the start of the script, but given it's a program we
+	// cannot enforce that. k6 would have enforced that by making secrets
+	// part of the options block, but we do not want to go anywhere near
+	// that.
+	secretsTimeout = 450 * time.Second // 7.5 minutes
 )
 
 type tenantInfo struct {

--- a/internal/tenants/manager.go
+++ b/internal/tenants/manager.go
@@ -2,6 +2,7 @@ package tenants
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -78,12 +79,16 @@ func (tm *Manager) run(ctx context.Context) {
 // and the secret store expiration date (if set), returning the earlier of the two.
 func (tm *Manager) calculateValidUntil(tenant *sm.Tenant) time.Time {
 	validUntil := time.Now().Add(tm.timeout)
+
 	if tenant.SecretStore != nil && tenant.SecretStore.Expiry > 0 {
-		expirationTime := time.Unix(0, int64(tenant.SecretStore.Expiry*1e9))
+		seconds, nanonseconds := math.Modf(tenant.SecretStore.Expiry)
+		expirationTime := time.Unix(int64(seconds), int64(nanonseconds*1e9))
+
 		if expirationTime.Before(validUntil) {
 			validUntil = expirationTime
 		}
 	}
+
 	return validUntil
 }
 

--- a/internal/tenants/manager_test.go
+++ b/internal/tenants/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -66,7 +67,8 @@ func TestTenantManagerGetTenant(t *testing.T) {
 
 	tenantCh := make(chan sm.Tenant)
 	cacheExpirationTime := 200 * time.Millisecond
-	tm := NewManager(ctx, &tc, tenantCh, cacheExpirationTime)
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	tm := NewManager(ctx, &tc, tenantCh, cacheExpirationTime, logger)
 
 	t1 := tc.tenants[1]
 


### PR DESCRIPTION
In the current version of the code, the secret store is populated when the prober is created. The problem with that is that the prober is created *once* in the lifetime of the check, but the secret store needs to be updated more or less on a continuous basis (because it contains the token used to access the secrets).