### PR TITLE
fix: deployment: add commented-out mountpoint for `/home/sm` (browser)

### DIFF
--- a/examples/kubernetes/deployment.yaml
+++ b/examples/kubernetes/deployment.yaml
@@ -69,7 +69,13 @@ spec:
               memory: 500Mi
           volumeMounts:
             - name: tmp
+              subPath: tmp
               mountPath: /tmp
+            # Uncomment the following volumeMount if you are using the -browser image, as Chromium needs to be able to
+            # write temporary files.
+            # - name: tmp
+            #   subPath: home-sm
+            #   mountPath: /home/sm
       volumes:
         - name: tmp
           emptyDir: {}


### PR DESCRIPTION
The `-browser` images need to be able to write temporary data to the home directory.