### PR TITLE
fix: Redact password field in RemoteInfo type

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -20,6 +20,7 @@ package synthetic_monitoring
 //go:generate ../../../scripts/enumer -type=MultiHttpEntryAssertionType,MultiHttpEntryAssertionSubjectVariant,MultiHttpEntryAssertionConditionVariant,MultiHttpEntryVariableType -trimprefix=MultiHttpEntryAssertionType_,MultiHttpEntryAssertionSubjectVariant_,MultiHttpEntryAssertionConditionVariant_,MultiHttpEntryVariableType_ -transform=upper -output=multihttp_string.go
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"mime"
@@ -30,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog"
 	"golang.org/x/exp/constraints"
 	"golang.org/x/net/http/httpguts"
 )
@@ -1584,4 +1586,20 @@ func GetCheckInstance(checkType CheckType) Check {
 	}
 
 	return instance
+}
+
+func (ri RemoteInfo) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("name", ri.Name).
+		Str("url", ri.Url).
+		Str("username", ri.Username).
+		Str("password", "<encrypted>")
+}
+
+func (ri RemoteInfo) MarshalJSON() ([]byte, error) {
+	type T RemoteInfo
+	var tmp T = T(ri)
+
+	tmp.Password = `<encrypted>`
+
+	return json.Marshal(tmp)
 }


### PR DESCRIPTION
When logging using zerolog or when marshaling to JSON, we don't really have a need to log the actual password and instead we have a requirement not to do so.

Add that behavior by implementing a couple of interfaces, one for zerolog and one for the JSON marshaller (stdlib).