### PR TITLE
chore: ci: pin exact version of actions/github-create-app-token

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Generate release app token
         id: sm-release-app
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ env.SM_RELEASE_APP_ID }}
           private-key: ${{ env.SM_RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
The actual version is already SHA pinned, but the comment will cause renovate to create PRs saying "Update to vX.Y.Z" instead of "Update to abcdef123456".

So this is a no-op aesthetic change.