### PR TITLE
fix: remove hardcoded blacklistIPs and blockHostnames for multihttp checks

### DIFF
--- a/internal/prober/multihttp/script.tmpl
+++ b/internal/prober/multihttp/script.tmpl
@@ -40,8 +40,6 @@ export const options = {
 	userAgent: 'synthetic-monitoring-agent/v0.14.3 (linux amd64; g64b8bab; +https://github.com/grafana/synthetic-monitoring-agent)',
 
 	maxRedirects: 10,
-	blacklistIPs: ['10.0.0.0/8'],
-	blockHostnames: ['*.cluster.local'],
 
 	// k6 options
 	vus: 1,
@@ -88,7 +86,7 @@ export default function() {
 	{{ range $queries }}{{ . }};
 	{{ end -}}
 	{{- $method := .Request.Method.String }}
-	
+
 	body = {{ buildBody .Request.Body }};
 	{{- $bodyVars := interpolateBodyVars "body" .Request.Body }}
 	{{ range $bodyVars }}{{ . }};


### PR DESCRIPTION
`--blackist-ips` is already supplied as a CLI flag. Having it specified here causes a conflict where this value will only take effect if `--blacklist-ips` is empty, which is non-obvious.

`blockHostnames` follows the same pattern. On top of that, it's not helping much: The default blocklist can be easily circumvented by not fully qualifying a k8s hostname with `.cluster.local`, which will work in most kubernetes environments due to the very common `ndots 5` setting. Having this option here is more likely to create a sense of false security than anything else.

Fixes https://github.com/grafana/synthetic-monitoring-agent/issues/735