### PR TITLE
feat: Implement usage report client

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/grafana/synthetic-monitoring-agent/internal/secrets"
 	"github.com/grafana/synthetic-monitoring-agent/internal/telemetry"
 	"github.com/grafana/synthetic-monitoring-agent/internal/tenants"
+	"github.com/grafana/synthetic-monitoring-agent/internal/usage"
 	"github.com/grafana/synthetic-monitoring-agent/internal/version"
 	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
@@ -74,15 +75,17 @@ func run(args []string, stdout io.Writer) error {
 			AutoMemLimit         bool
 			MemLimitRatio        float64
 			DisableK6            bool
+			DisableUsageReports  bool
 		}{
-			GrpcApiServerAddr: "localhost:4031",
-			HttpListenAddr:    "localhost:4050",
-			K6URI:             "sm-k6",
-			K6BlacklistedIP:   "10.0.0.0/8",
-			SelectedPublisher: pusherV2.Name,
-			TelemetryTimeSpan: defTelemetryTimeSpan,
-			AutoMemLimit:      true,
-			MemLimitRatio:     0.9,
+			GrpcApiServerAddr:   "localhost:4031",
+			HttpListenAddr:      "localhost:4050",
+			K6URI:               "sm-k6",
+			K6BlacklistedIP:     "10.0.0.0/8",
+			SelectedPublisher:   pusherV2.Name,
+			TelemetryTimeSpan:   defTelemetryTimeSpan,
+			AutoMemLimit:        true,
+			MemLimitRatio:       0.9,
+			DisableUsageReports: true,
 		}
 	)
 
@@ -103,6 +106,7 @@ func run(args []string, stdout io.Writer) error {
 	flags.IntVar(&config.TelemetryTimeSpan, "telemetry-time-span", config.TelemetryTimeSpan, "time span between telemetry push executions per tenant")
 	flags.BoolVar(&config.AutoMemLimit, "enable-auto-memlimit", config.AutoMemLimit, "automatically set GOMEMLIMIT")
 	flags.BoolVar(&config.DisableK6, "disable-k6", config.DisableK6, "disables running k6 checks on this probe")
+	flags.BoolVar(&config.DisableUsageReports, "disable-usage-reports", config.DisableUsageReports, "disables sending Usage Reports to Grafana")
 	flags.Float64Var(&config.MemLimitRatio, "memlimit-ratio", config.MemLimitRatio, "fraction of available memory to use")
 	flags.Var(&features, "features", "optional feature flags")
 
@@ -207,6 +211,19 @@ func run(args []string, stdout io.Writer) error {
 		zl.Info().Str("k6URI", config.K6URI).Msg("enabling k6 checks")
 	} else {
 		zl.Info().Msg("disabling k6 checks")
+	}
+
+	var usageReporter *usage.UsageReporter
+
+	if !config.DisableUsageReports {
+		zl.Info().Str("usage endpoint", usage.DefaultUsageStatsEndpoint).Msg("Starting usage stats reporting")
+		endpoint := usage.DefaultUsageStatsEndpoint
+		if config.DevMode {
+			// TODO: Make this point to staging
+			endpoint = "http://localhost:4200"
+		}
+		usageReporter = usage.NewUsageReporter(endpoint, features)
+		zl.Info().Msg("Usage stats reporting")
 	}
 
 	promRegisterer := prometheus.NewRegistry()
@@ -319,6 +336,7 @@ func run(args []string, stdout io.Writer) error {
 		TenantLimits:   limits,
 		TenantSecrets:  secrets,
 		Telemeter:      telemetry,
+		UsageReporter:  usageReporter,
 	})
 	if err != nil {
 		return fmt.Errorf("Cannot create checks updater: %w", err)

--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -76,6 +76,7 @@ func run(args []string, stdout io.Writer) error {
 			MemLimitRatio        float64
 			DisableK6            bool
 			DisableUsageReports  bool
+			UsageStatsEndpoint   string
 		}{
 			GrpcApiServerAddr: "localhost:4031",
 			HttpListenAddr:    "localhost:4050",
@@ -106,6 +107,7 @@ func run(args []string, stdout io.Writer) error {
 	flags.BoolVar(&config.AutoMemLimit, "enable-auto-memlimit", config.AutoMemLimit, "automatically set GOMEMLIMIT")
 	flags.BoolVar(&config.DisableK6, "disable-k6", config.DisableK6, "disables running k6 checks on this probe")
 	flags.BoolVar(&config.DisableUsageReports, "disable-usage-reports", config.DisableUsageReports, "Disable anonymous usage reports")
+	flags.StringVar(&config.UsageStatsEndpoint, "usage-stats-endpoint", usage.DefaultUsageStatsEndpoint, "usage stats endpoint to send reports to")
 	flags.Float64Var(&config.MemLimitRatio, "memlimit-ratio", config.MemLimitRatio, "fraction of available memory to use")
 	flags.Var(&features, "features", "optional feature flags")
 
@@ -214,7 +216,7 @@ func run(args []string, stdout io.Writer) error {
 
 	usageReporter := usage.NewNoOPReporter()
 	if !config.DisableUsageReports {
-		usageReporter = usage.NewHTTPReporter(usage.DefaultUsageStatsEndpoint, features)
+		usageReporter = usage.NewHTTPReporter(config.UsageStatsEndpoint, features)
 		zl.Info().Msg("enabled collecting anonymous usage reports.")
 	}
 

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -388,7 +388,7 @@ func (c *Updater) loop(ctx context.Context) (bool, error) {
 
 	c.probe = &result.Probe
 
-	err = c.usageReporter.ReportProbe(ctx, result.Probe)
+	err = c.usageReporter.ReportProbe(ctx, result.Probe, c.features)
 	if err != nil {
 		c.logger.Warn().Err(err).Msg("reporting usage failed")
 	}

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -388,7 +388,6 @@ func (c *Updater) loop(ctx context.Context) (bool, error) {
 
 	c.probe = &result.Probe
 
-	// usageReporter will be nil if the usage report configuration is disabled
 	err = c.usageReporter.ReportProbe(ctx, result.Probe)
 	if err != nil {
 		c.logger.Warn().Err(err).Msg("reporting usage failed")

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -84,7 +84,7 @@ type Updater struct {
 	tenantLimits   *limits.TenantLimits
 	tenantSecrets  *secrets.TenantSecrets
 	telemeter      *telemetry.Telemeter
-	usageReporter  *usage.UsageReporter
+	usageReporter  usage.Reporter
 }
 
 type apiInfo struct {
@@ -120,7 +120,7 @@ type UpdaterOptions struct {
 	TenantLimits   *limits.TenantLimits
 	Telemeter      *telemetry.Telemeter
 	TenantSecrets  *secrets.TenantSecrets
-	UsageReporter  *usage.UsageReporter
+	UsageReporter  usage.Reporter
 }
 
 func NewUpdater(opts UpdaterOptions) (*Updater, error) {
@@ -389,11 +389,9 @@ func (c *Updater) loop(ctx context.Context) (bool, error) {
 	c.probe = &result.Probe
 
 	// usageReporter will be nil if the usage report configuration is disabled
-	if c.usageReporter != nil {
-		err = c.usageReporter.ReportProbe(context.Background(), result.Probe)
-		if err != nil {
-			c.logger.Warn().Err(err).Msg("reporting usage failed")
-		}
+	err = c.usageReporter.ReportProbe(ctx, result.Probe)
+	if err != nil {
+		c.logger.Warn().Err(err).Msg("reporting usage failed")
 	}
 
 	logger := c.logger.With().Int64("probe_id", c.probe.Id).Logger()

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	logproto "github.com/grafana/loki/pkg/push"
+
 	"github.com/grafana/synthetic-monitoring-agent/internal/error_types"
 	"github.com/grafana/synthetic-monitoring-agent/internal/feature"
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
@@ -31,6 +32,7 @@ import (
 	"github.com/grafana/synthetic-monitoring-agent/internal/scraper"
 	"github.com/grafana/synthetic-monitoring-agent/internal/secrets"
 	"github.com/grafana/synthetic-monitoring-agent/internal/telemetry"
+	"github.com/grafana/synthetic-monitoring-agent/internal/usage"
 	"github.com/grafana/synthetic-monitoring-agent/internal/version"
 	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
@@ -82,6 +84,7 @@ type Updater struct {
 	tenantLimits   *limits.TenantLimits
 	tenantSecrets  *secrets.TenantSecrets
 	telemeter      *telemetry.Telemeter
+	usageReporter  *usage.UsageReporter
 }
 
 type apiInfo struct {
@@ -117,6 +120,7 @@ type UpdaterOptions struct {
 	TenantLimits   *limits.TenantLimits
 	Telemeter      *telemetry.Telemeter
 	TenantSecrets  *secrets.TenantSecrets
+	UsageReporter  *usage.UsageReporter
 }
 
 func NewUpdater(opts UpdaterOptions) (*Updater, error) {
@@ -249,6 +253,7 @@ func NewUpdater(opts UpdaterOptions) (*Updater, error) {
 			scrapeErrorCounter:  scrapeErrorCounter,
 			scrapesCounter:      scrapesCounter,
 		},
+		usageReporter: opts.UsageReporter,
 	}, nil
 }
 
@@ -326,6 +331,7 @@ func handleError(ctx context.Context, logger zerolog.Logger, backoff Backoffer, 
 	return false, nil
 }
 
+//goland:noinspection GoBoolExpressions
 func (c *Updater) loop(ctx context.Context) (bool, error) {
 	connected := false
 
@@ -381,6 +387,14 @@ func (c *Updater) loop(ctx context.Context) (bool, error) {
 	}
 
 	c.probe = &result.Probe
+
+	// usageReporter will be nil if the usage report configuration is disabled
+	if c.usageReporter != nil {
+		err = c.usageReporter.ReportProbe(context.Background(), result.Probe)
+		if err != nil {
+			c.logger.Warn().Err(err).Msg("reporting usage failed")
+		}
+	}
 
 	logger := c.logger.With().Int64("probe_id", c.probe.Id).Logger()
 

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -47,7 +47,7 @@ const (
 	// in github.com/grafana/usage-stats for synthetic monitoring agents
 	UsageStatsApplication = "synthetic-monitoring-agent-usage-report"
 	// Base Endpoint for usage stats
-	ProdStatsEndpoint = "https://stats.grafana.com"
+	ProdStatsEndpoint = "https://stats.grafana.org"
 )
 
 func NewHTTPReporter(endpoint string) *HTTPReporter {
@@ -112,11 +112,10 @@ func (r *NoOPReporter) ReportProbe(_ context.Context, _ sm.Probe, _ feature.Coll
 	return nil
 }
 
-// hashOfProbe returns a string representation of the sm.Probe passed in by concatenating a few attributes of the probe,
-// generating an FNV hash of the probe, and converting it back to a string.
-// FNV is deterministic so that a probe will always return the same value
+// hashOfProbe returns a string representation of the probe by concatenating identifying attributes and
+// generating an FNV(https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function) hash.
+// The hash function is deterministic to ensure a probe always results in the same string.
 func hashOfProbe(p sm.Probe) (string, error) {
-	// Create a single string representation of the probe using the name, id, region, and public flag
 	s := p.Name + strconv.FormatInt(p.Id, 10) + p.Region + strconv.FormatBool(p.Public) + strconv.FormatInt(p.TenantId, 10)
 	h := fnv.New64a()
 	_, err := h.Write([]byte(s))

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -116,7 +116,7 @@ func (r *NoOPReporter) ReportProbe(_ context.Context, _ sm.Probe, _ feature.Coll
 // FNV is deterministic so that a probe will always return the same value
 func hashOfProbe(p sm.Probe) (string, error) {
 	// Create a single string representation of the probe using the name, id, region, and public flag
-	s := p.Name + strconv.FormatInt(p.Id, 10) + p.Region + strconv.FormatBool(p.Public)
+	s := p.Name + strconv.FormatInt(p.Id, 10) + p.Region + strconv.FormatBool(p.Public) + strconv.FormatInt(p.TenantId, 10)
 	h := fnv.New64a()
 	_, err := h.Write([]byte(s))
 	if err != nil {

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -1,0 +1,96 @@
+package usage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"runtime"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/feature"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+// Report represents a specific usage event that will be sent to https://stats.grafana.com to be processed and stored.
+// Each attribute represents a column in a BigQuery table that can be easily searched.
+// Adding new attributes to Report will not automatically update the table, and instead needs to be handled in https://github.com/grafana/usage-stats
+type Report struct {
+	CreatedAt    string `json:"createdAt"`
+	OS           string `json:"os"`
+	Arch         string `json:"arch"`
+	Report       string `json:"report"`
+	Version      string `json:"version"`
+	Public       bool   `json:"public"`
+	Features     string `json:"features"`
+	UsageStatsId string `json:"usageStatsId"`
+	TenantID     int64  `json:"tenantId"`
+}
+
+// UsageReporter represents
+type UsageReporter struct {
+	endpoint string
+	features feature.Collection
+}
+
+const (
+	// UsageReportApplication aligns with the usage-stats service endpoint defined
+	// in github.com/grafana/usage-stats for synthetic monitoring agents
+	UsageStatsApplication = "synthetic-monitoring-agent-usage-report"
+	// Base Endpoint for usage stats
+	DefaultUsageStatsEndpoint = "https://stats.grafana.com"
+)
+
+func NewUsageReporter(endpoint string, features feature.Collection) *UsageReporter {
+	if endpoint == "" {
+		endpoint = DefaultUsageStatsEndpoint
+	}
+	return &UsageReporter{
+		endpoint: endpoint,
+		features: features,
+	}
+}
+
+// submitReport is responsible for sending a report to the stats endpoint via an http POST request. The primary concern is that
+// the http server responds with http.StatusOK. Otherwise, there are no other expected responses.
+func (r *UsageReporter) submitReport(ctx context.Context, report *Report) error {
+	jsonData, err := json.Marshal(&report)
+	if err != nil {
+		return fmt.Errorf("failed to marshal data: %w", err)
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	endpoint := fmt.Sprintf("%s/%s", r.endpoint, UsageStatsApplication)
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to do request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// ReportProbe creates a Report from the probe and then sends the report to the stats api endpoint via the report method.
+func (r *UsageReporter) ReportProbe(ctx context.Context, probe sm.Probe) error {
+	report := &Report{
+		Report:       probe.String(),
+		CreatedAt:    time.Now().Format(time.RFC3339),
+		OS:           runtime.GOOS,
+		Arch:         runtime.GOARCH,
+		Version:      probe.Version,
+		UsageStatsId: uuid.NewString(),
+		Features:     r.features.String(),
+		Public:       probe.Public,
+		TenantID:     probe.TenantId,
+	}
+	return r.submitReport(ctx, report)
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -112,7 +112,8 @@ func (r *NoOPReporter) ReportProbe(_ context.Context, _ sm.Probe, _ feature.Coll
 	return nil
 }
 
-// hashOfProbe returns a string representation of the sm.Probe passed in by concatenating a few attributes of the probe, generating an FNV hash of the probe, and converting it back to a string.
+// hashOfProbe returns a string representation of the sm.Probe passed in by concatenating a few attributes of the probe,
+// generating an FNV hash of the probe, and converting it back to a string.
 // FNV is deterministic so that a probe will always return the same value
 func hashOfProbe(p sm.Probe) (string, error) {
 	// Create a single string representation of the probe using the name, id, region, and public flag

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -1,0 +1,50 @@
+package usage
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/feature"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+func TestUsageReporter_Report(t *testing.T) {
+
+	// Create a test http server that intercepts requests to https://stats.grafana.net
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	tests := map[string]struct {
+		endpoint string
+		features []string
+		ctx      context.Context
+		wantErr  bool
+	}{
+		"Send over zero features": {
+			endpoint: ts.URL,
+			features: []string{},
+			ctx:      context.Background(),
+		},
+		"Send over a full list of features": {
+			endpoint: ts.URL,
+			ctx:      context.Background(),
+			features: []string{feature.K6, feature.Traceroute, feature.ExperimentalDnsProber},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			features := feature.NewCollection()
+			for _, f := range tt.features {
+				_ = features.Set(f)
+			}
+			r := NewUsageReporter(tt.endpoint, features)
+			if err := r.ReportProbe(tt.ctx, sm.Probe{}); (err != nil) != tt.wantErr {
+				t.Errorf("Report() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -144,12 +144,13 @@ func Test_hashOfProbe(t *testing.T) {
 		},
 		"Probe with everything set but slightly different values should return a different hash value": {
 			p: sm.Probe{
-				Id:     10,
-				Region: "test",
-				Name:   "Some Name",
-				Public: true,
+				Id:       10,
+				Region:   "test",
+				Name:     "Some Name",
+				Public:   true,
+				TenantId: 1,
 			},
-			want:    "17885419548661010353",
+			want:    "9777170254191072896",
 			wantErr: false,
 		},
 	}

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestUsageReporter_Report(t *testing.T) {
-
 	// Create a test http server that intercepts requests to https://stats.grafana.net
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -120,26 +120,26 @@ func Test_hashOfProbe(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		"Nil probe should return an errorn": {
+		"Nil probe should return an error": {
 			p:       sm.Probe{},
-			want:    "10238674498380227310",
+			want:    "4547005171780583226",
 			wantErr: false,
 		},
 		"Probe with an ID should generate a consistent hash": {
 			p: sm.Probe{
 				Id: 1,
 			},
-			want:    "11825251301467821359",
+			want:    "10535204341849580461",
 			wantErr: false,
 		},
-		"Probe with everything set should return a consistent has": {
+		"Probe with everything set should return a consistent hash": {
 			p: sm.Probe{
 				Id:     1,
 				Region: "test",
 				Name:   "Some Name",
 				Public: true,
 			},
-			want:    "9816051699785545891",
+			want:    "1162427638690750921",
 			wantErr: false,
 		},
 		"Probe with everything set but slightly different values should return a different hash value": {

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -1,34 +1,93 @@
 package usage
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/grafana/synthetic-monitoring-agent/internal/feature"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
-func TestUsageReporter_Report(t *testing.T) {
+func TestHTTPUsageReporter_Report(t *testing.T) {
 	// Create a test http server that intercepts requests to https://stats.grafana.net
 	t.Parallel()
 
+	var gotReport *report
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&gotReport); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+		// Clear these values out as they're dynamic attributes that are not important to validate the result of
+		gotReport.UsageStatsId = ""
+		gotReport.CreatedAt = ""
+		gotReport.Report = ""
 		w.WriteHeader(http.StatusOK)
 	}))
+
 	defer ts.Close()
 
 	tests := map[string]struct {
-		endpoint string
-		features []string
-		wantErr  bool
+		endpoint       string
+		features       []string
+		probe          sm.Probe
+		wantErr        bool
+		expectedReport *report
 	}{
 		"Send over zero features": {
 			endpoint: ts.URL,
 			features: []string{},
+			expectedReport: &report{
+				Public:   false,
+				ProbeID:  1,
+				TenantID: 1,
+				Arch:     runtime.GOARCH,
+				OS:       runtime.GOOS,
+			},
+			probe: sm.Probe{
+				Id:       1,
+				TenantId: 1,
+				Public:   false,
+			},
+		},
+		"Send over a single features": {
+			endpoint: ts.URL,
+			expectedReport: &report{
+				Public:   false,
+				ProbeID:  1,
+				TenantID: 1,
+				Arch:     runtime.GOARCH,
+				OS:       runtime.GOOS,
+				Features: "k6",
+			},
+			probe: sm.Probe{
+				Id:       1,
+				TenantId: 1,
+				Public:   false,
+			},
+			features: []string{feature.K6},
 		},
 		"Send over a full list of features": {
 			endpoint: ts.URL,
+			expectedReport: &report{
+				Public:   false,
+				ProbeID:  1,
+				TenantID: 1,
+				Arch:     runtime.GOARCH,
+				OS:       runtime.GOOS,
+				Features: "experimental-dns-prober,k6,traceroute",
+			},
+			probe: sm.Probe{
+				Id:       1,
+				TenantId: 1,
+				Public:   false,
+			},
 			features: []string{feature.K6, feature.Traceroute, feature.ExperimentalDnsProber},
 		},
 	}
@@ -38,10 +97,18 @@ func TestUsageReporter_Report(t *testing.T) {
 			for _, f := range tt.features {
 				_ = features.Set(f)
 			}
-			r := NewHTTPReporter(tt.endpoint, features)
-			if err := r.ReportProbe(t.Context(), sm.Probe{}); (err != nil) != tt.wantErr {
+			r := NewHTTPReporter(tt.endpoint)
+			if err := r.ReportProbe(t.Context(), tt.probe, features); (err != nil) != tt.wantErr {
 				t.Errorf("Report() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			assert.Equal(t, tt.expectedReport, gotReport)
 		})
+	}
+}
+
+func TestNoOPUsageReporter_Report(t *testing.T) {
+	r := NewNoOPReporter()
+	if err := r.ReportProbe(t.Context(), sm.Probe{}, nil); err != nil {
+		t.Errorf("Report() error = %v", err)
 	}
 }

--- a/tmp/build-errors.log
+++ b/tmp/build-errors.log
@@ -1,0 +1,1 @@
+exit status 1

--- a/tmp/build-errors.log
+++ b/tmp/build-errors.log
@@ -1,1 +1,0 @@
-exit status 1


### PR DESCRIPTION
Implement usage report client that can send reports to https://stats.grafana.net/. See https://github.com/grafana/usage-stats/ and https://github.com/grafana/usage-stats-handler/ for backend details about the stats endpoint.

Updates `checks.go` to submit a report whenever a probe is registered or updated. The following metadata is sent over
- Version
- Arch
- OS
- Features
- Public bool
- TenantID

These are the fields that implemented as columns in usage stats(https://github.com/grafana/usage-stats/pull/55). Any other fields that we add to the Report struct will be included as raw json and stored in a `report` field in BigQuery.

Added a flag `disable-usage-reports` which is initially set to true. This provides a buffer so that we can announce that Grafana Labs will start to collect usage statistics for Agent's _and_ ensure documentation is clearly updated to reflect that usage reports will be gathered.