### PR TITLE
fix: error out early if grpc address doesn't have a port

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -144,6 +144,12 @@ func run(args []string, stdout io.Writer) error {
 		}
 	}
 
+	if _, _, err := net.SplitHostPort(config.GrpcApiServerAddr); err != nil {
+		// SplitHostPort errors if the address has no port. This is intended, as omitting the port in the address is
+		// almost likely a user error that is hard to troubleshoot otherwise.
+		return fmt.Errorf("parsing GRPC api server address %q: %w", config.GrpcApiServerAddr, err)
+	}
+
 	// If the token is provided on the command line, prefer that. Otherwise
 	// pull it from the environment variable SM_AGENT_API_TOKEN. If that's
 	// not available, fallback to API_TOKEN, which was the environment


### PR DESCRIPTION
For nearly all users, the port needs to be specified and needs to be `443`. If skipped, GRPC will fall back to a different port that may not respond to SYN TCP segments. As a result, the agent process will just hang without logging anything.

This change causes the agent to error out if the port is omitted, which allegedly should provide earlier feedback about this and other common mistakes.