### PR TITLE
fix: k6: do not log k6 script contents before execution

### DIFF
--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -119,7 +119,7 @@ func (r Local) Run(ctx context.Context, script Script, secretStore SecretStore) 
 	cmd.Env = k6Env(os.Environ())
 
 	start := time.Now()
-	logger.Info().Str("command", cmd.String()).Bytes("script", script.Script).Msg("running k6 script")
+	logger.Info().Str("command", cmd.String()).Msg("running k6 script")
 	err = cmd.Run()
 
 	duration := time.Since(start)


### PR DESCRIPTION
While doing some tests earlier this week, I noticed that when using the k6 runner, the script being executed is logged:

<img width="2562" height="265" alt="image" src="https://github.com/user-attachments/assets/7cf93f35-531f-43b7-8986-f8e27074b1fb" />


I think doing this clutters the logs, provides no relevant information, and may contribute leak sensitive information that script authors have included in the script (against best security practices, but also lacking any better means as of today).

As of recently, all log lines related to a script run include the check ID which can be used to identify which script is being run more precisely than by comparing the long, non-unique string that is the script body.