### PR TITLE
feat: runner/local: run k6 with `--throw` to raise common errors as exceptions

### DIFF
--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -211,6 +211,7 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFil
 		"--no-color",
 		"--no-summary",
 		"--verbose",
+		"--throw", // Abort with an exception on certain abnormal cases: https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/#throw
 	}
 
 	// Add secretStore configuration if available


### PR DESCRIPTION
Namely, failures making HTTP requests and other common runtime faults will throw exceptions instead of logging a warning and continuing.

Ref:
https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/#throw