### PR TITLE
fix: Update the metrics labels limit const

### DIFF
--- a/internal/limits/tenant_test.go
+++ b/internal/limits/tenant_test.go
@@ -158,7 +158,7 @@ func TestValidateMetricLabels(t *testing.T) {
 		{
 			name:     "over tenant metric labels limit",
 			tenantID: 2,
-			nLabels:  21,
+			nLabels:  23,
 			expErr:   ErrTooManyMetricLabels,
 		},
 	}

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -130,7 +130,7 @@ const (
 )
 
 const (
-	MaxMetricLabels          = 20   // Prometheus allows for 32 labels, but limit to 20.
+	MaxMetricLabels          = 22   // Prometheus allows for 32 labels, but limit to 22.
 	MaxLogLabels             = 15   // Loki allows a maximum of 15 labels.
 	MaxProbeLabels           = 3    // 3 for probes, leaving 7 for internal use.
 	maxValidLabelValueLength = 2048 // This is the actual max label value length.


### PR DESCRIPTION
This was updated to a default of `22` a while ago - update the constant to reflect that.