### PR TITLE
chore: update Go version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/synthetic-monitoring-agent
 
-go 1.24.0
-
-toolchain go1.24.6
+go 1.25.0
 
 require (
 	github.com/go-kit/kit v0.13.0


### PR DESCRIPTION
This PR fixes the failing Renovate PR #1426 by properly updating both the 'go' directive and 'toolchain' directive to 1.25.0.

## Problem
The Renovate PR #1426 was failing because it only updated the toolchain directive to  but left the go directive as , causing validation failures.

## Solution
This PR updates both directives to be consistent:
- Changed  to 
- Changed  to 

## Testing
- ✅  passes
- ✅  passes
- ✅ All existing functionality preserved

Closes #1426