### PR TITLE
feat: add frequency and timeout to checkInfo and thus logs

### DIFF
--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -73,6 +73,8 @@ func CheckInfoFromSM(smc smmmodel.Check) CheckInfo {
 	ci.Metadata["regionID"] = smc.RegionId
 	ci.Metadata["created"] = smc.Created
 	ci.Metadata["modified"] = smc.Modified
+	ci.Metadata["frequency"] = smc.Frequency
+	ci.Metadata["timeout"] = smc.Timeout
 
 	return ci
 }


### PR DESCRIPTION
CheckInfo holds metadata about a check, which is added to log lines related to that check. It is useful to find logs for a given check ID, or to trace the check that yielded a particularly interesting log line.

We suspect that some frequency/timeout combinations are problematic, specifically where those values are too close. By adding them to this logged metadata, we may be able to spot if problematic log lines are due to these combinations.