### PR TITLE
feat: add checkInfo as log context for k6-related checks

### DIFF
--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -66,13 +66,13 @@ func (p Prober) Name() string {
 
 func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	secretStore, err := p.secretsRetriever(ctx)
-
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0
 	}
 
-	success, err := p.processor.Run(ctx, registry, logger, p.logger, secretStore)
+	runLogger := p.logger.With().Object("checkInfo", &p.module.Script.CheckInfo).Logger()
+	success, err := p.processor.Run(ctx, registry, logger, runLogger, secretStore)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -89,13 +89,13 @@ func (p Prober) Name() string {
 
 func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
 	secretStore, err := p.secretsRetriever(ctx)
-
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0
 	}
 
-	success, err := p.processor.Run(ctx, registry, logger, p.logger, secretStore)
+	runLogger := p.logger.With().Object("checkInfo", &p.module.Script.CheckInfo).Logger()
+	success, err := p.processor.Run(ctx, registry, logger, runLogger, secretStore)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -71,7 +71,8 @@ func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.R
 		return false, 0
 	}
 
-	success, err := p.processor.Run(ctx, registry, logger, p.logger, secretStore)
+	runLogger := p.logger.With().Object("checkInfo", &p.module.Script.CheckInfo).Logger()
+	success, err := p.processor.Run(ctx, registry, logger, runLogger, secretStore)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0


### PR DESCRIPTION
Previously, check information was absent from log lines, except for runs using the local k6 runner

This commit changes the Probers so they propagate down a logger object contextualized with metadata about the check, such as check id, tenant id, etc.