### PR TITLE
chore: k6/http: log checkInfo when when retries are exhausted

### DIFF
--- a/internal/k6runner/http.go
+++ b/internal/k6runner/http.go
@@ -124,7 +124,7 @@ func (r HttpRunner) Run(ctx context.Context, script Script, secretStore SecretSt
 		case <-ctx.Done():
 			waitTimer.Stop()
 			// TODO: Log the returned error in the Processor instead.
-			r.logger.Error().Err(err).Msg("retries exhausted")
+			r.logger.Error().Err(err).Object("checkInfo", &script.CheckInfo).Msg("retries exhausted")
 			r.metrics.RequestsPerRun.WithLabelValues("0").Observe(attempts)
 			return nil, fmt.Errorf("cannot retry further: %w", errors.Join(err, ctx.Err()))
 		case <-waitTimer.C:


### PR DESCRIPTION
Quick ad-hoc alternative to https://github.com/grafana/synthetic-monitoring-agent/pull/1443, https://github.com/grafana/synthetic-monitoring-agent/pull/1444.