### PR TITLE
feat: Add IsUsingSecrets to synthetic_monitoring.Check

### DIFF
--- a/pkg/pb/synthetic_monitoring/testdata/script_not_using_secrets_commented_out_import.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_not_using_secrets_commented_out_import.js
@@ -1,0 +1,18 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+// import secrets from 'k6/secrets'
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_not_using_secrets_no_import.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_not_using_secrets_no_import.js
@@ -1,0 +1,14 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+
+export default function() {
+	const result = http.get('https://grafana.com/');
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_not_using_secrets_sideffect_import_1.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_not_using_secrets_sideffect_import_1.js
@@ -1,0 +1,18 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+
+// k6/secrets does not have documented side-effects, the following code shouldn't do anything. For
+// that reason, this script is not considered as using secrets.
+import 'k6/secrets'
+
+export default function() {
+	const result = http.get('https://grafana.com/');
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_not_using_secrets_sideffect_import_2.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_not_using_secrets_sideffect_import_2.js
@@ -1,0 +1,18 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+
+// k6/secrets does not have documented side-effects, the following code shouldn't do anything. For
+// that reason, this script is not considered as using secrets.
+import "k6/secrets"
+
+export default function() {
+	const result = http.get('https://grafana.com/');
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_browser_default_import_1.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_browser_default_import_1.js
@@ -1,0 +1,42 @@
+import { check } from 'k6'
+import { browser } from 'k6/browser'
+import secrets from 'k6/secrets'
+
+export const options = {
+	scenarios: {
+		ui: {
+			options: {
+				browser: {
+					type: 'chromium',
+				},
+			},
+		},
+	},
+};
+
+export default async function() {
+	const my_secret = await secrets.get('secret_name');
+	const context = await browser.newContext();
+	const page = await context.newPage();
+
+	try {
+		await page.goto("https://test.k6.io/my_messages.php");
+
+		await page.locator('input[name="login"]').type("admin");
+		await page.locator('input[name="password"]').type(my_secret);
+
+		await Promise.all([
+			page.waitForNavigation(),
+			page.locator('input[type="submit"]').click(),
+		]);
+
+		await check(page.locator("h2"), {
+			header: async (locator) => (await locator.textContent()) == "Welcome, admin!",
+		});
+	} catch (e) {
+		console.log('Error during execution:', e);
+		throw e;
+	} finally {
+		await page.close();
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_default_import_1.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_default_import_1.js
@@ -1,0 +1,18 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+import secrets from 'k6/secrets'
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_default_import_2.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_default_import_2.js
@@ -1,0 +1,18 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+import secrets from "k6/secrets"
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_default_import_3.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_default_import_3.js
@@ -1,0 +1,20 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+// *shrug*
+// import secrets from 'k6/secrets'
+import secrets from 'k6/secrets'
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_1.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_1.js
@@ -1,0 +1,18 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+import { secrets } from 'k6/secrets'
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_2.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_2.js
@@ -1,0 +1,18 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+import { secrets } from "k6/secrets"
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_aliased_1.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_aliased_1.js
@@ -1,0 +1,18 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+import { secrets as s } from 'k6/secrets'
+
+export default async () => {
+	const my_secret = await s.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_aliased_2.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_aliased_2.js
@@ -1,0 +1,18 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+import { secrets as s } from "k6/secrets"
+
+export default async () => {
+	const my_secret = await s.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_1.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_1.js
@@ -1,0 +1,19 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+// Right now k6/secrets exports a single thing, secrets, but just in case that changes in the future, test with multiple identifiers.
+import { secrets, foo } from 'k6/secrets'
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_2.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_2.js
@@ -1,0 +1,19 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+// Right now k6/secrets exports a single thing, secrets, but just in case that changes in the future, test with multiple identifiers.
+import { foo, secrets } from 'k6/secrets'
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_3.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_3.js
@@ -1,0 +1,19 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+// Right now k6/secrets exports a single thing, secrets, but just in case that changes in the future, test with multiple identifiers.
+import { foo, secrets, bar } from 'k6/secrets'
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_4.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_4.js
@@ -1,0 +1,19 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+// Right now k6/secrets exports a single thing, secrets, but just in case that changes in the future, test with multiple identifiers.
+import { secrets, foo } from "k6/secrets"
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_5.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_5.js
@@ -1,0 +1,19 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+// Right now k6/secrets exports a single thing, secrets, but just in case that changes in the future, test with multiple identifiers.
+import { foo, secrets } from "k6/secrets"
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_6.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_named_import_multi_6.js
@@ -1,0 +1,19 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+// Right now k6/secrets exports a single thing, secrets, but just in case that changes in the future, test with multiple identifiers.
+import { foo, secrets, bar } from "k6/secrets"
+
+export default async () => {
+	const my_secret = await secrets.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_namespace_import_1.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_namespace_import_1.js
@@ -1,0 +1,18 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+import * as s from 'k6/secrets'
+
+export default async () => {
+	const my_secret = await s.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}

--- a/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_namespace_import_2.js
+++ b/pkg/pb/synthetic_monitoring/testdata/script_using_secrets_namespace_import_2.js
@@ -1,0 +1,18 @@
+import { check, fail } from 'k6'
+import http from 'k6/http'
+import * as s from "k6/secrets"
+
+export default async () => {
+	const my_secret = await s.get('secret_name');
+	const result = http.get('https://grafana.com/', {
+		headers: { 'X-My-Header': my_secret },
+	});
+
+	const pass = check(result, {
+		'is status 200': (r) => r.status === 200,
+	});
+
+	if (!pass) {
+		fail(`non 200 result ${result.status}`);
+	}
+}


### PR DESCRIPTION
This method provides a single way to determine whether a check is using secrets or not. For some types, this will be straighforward (either because they do not support secrets, or because using secrets in that case is very explicit). In other cases, this involves some guesswork, and the extra scripts in this commit are mostly about validating that guesswork.