### PR TITLE
fix: Fail earlier if sm-k6 isn't on path

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -203,8 +203,7 @@ func run(args []string, stdout io.Writer) error {
 	if features.IsSet(feature.K6) {
 		newUri, err := validateK6URI(config.K6URI)
 		if err != nil {
-			config.K6URI = ""
-			zl.Warn().Str("k6URI", config.K6URI).Err(err).Msg("invalid k6 URI")
+			return err
 		} else if newUri != config.K6URI {
 			config.K6URI = newUri
 		}


### PR DESCRIPTION
Exit from the main func if
1. k6 is enabled
2. k6uri is set to `sm-k6`
3. `sm-k6` is not on the path

Previously, main would log out that this is problematic, but would would wait until later in the application to return an error and halt the agent.
This was confusing and took me a bit of time following the codebase to realize it was problematic.

Here's an example output when all of the conditions above exist:

```bash
{"level":"info","program":"synthetic-monitoring-agent","version":"v0.41.4-0.20250905023333-90ab79056c11+dirty","commit":"90ab79056c112fe8c165fa9528610156ab99bc9b","buildstamp":"2025-09-05T02:33:33Z","features":"k6","config":{"DevMode":true,"Debug":true,"Verbose":true,"ReportVersion":false,"GrpcApiServerAddr":"localhost:4031","GrpcInsecure":true,"ApiToken":"<redacted>","EnableChangeLogLevel":true,"EnableDisconnect":true,"EnablePProf":true,"HttpListenAddr":"localhost:4050","K6URI":"sm-k6","K6BlacklistedIP":"10.0.0.0/8","SelectedPublisher":"v2","TelemetryTimeSpan":5,"AutoMemLimit":true,"MemLimitRatio":0.9,"DisableK6":false,"DisableUsageReports":false},"time":1757095838552,"caller":"github.com/grafana/synthetic-monitoring-agent/cmd/synthetic-monitoring-agent/main.go:199","message":"starting"}
{"level":"info","program":"synthetic-monitoring-agent","time":1757095838552,"caller":"github.com/grafana/synthetic-monitoring-agent/cmd/synthetic-monitoring-agent/main.go:450","message":"the `k6` feature is now permanently enabled in the agent, you can remove it from the -features flag without loss of functionality"}
E: exec: "sm-k6": executable file not found in $PATH
```