### PR TITLE
fix: make log `duration_seconds` the same as the namesake metric

### DIFF
--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -674,10 +674,11 @@ func runProber(
 
 	success, duration := prober.Probe(checkCtx, target, registry, logger)
 
-	probeDuration := time.Since(start).Seconds()
+	wallDuration := time.Since(start).Seconds()
 
-	if duration == 0 { // If the prober did not provide their own duration, fallback to probeDuration.
-		duration = probeDuration
+	if duration == 0 {
+		// If the prober did not provide their own duration, fallback to the wall time the scraper took to run.
+		duration = wallDuration
 	}
 
 	probeSuccessGauge := prometheus.NewGauge(prometheus.GaugeOpts{
@@ -702,10 +703,10 @@ func runProber(
 
 	if success {
 		probeSuccessGauge.Set(1)
-		_ = level.Info(logger).Log("msg", "Check succeeded", "duration_seconds", probeDuration)
+		_ = level.Info(logger).Log("msg", "Check succeeded", "duration_seconds", duration, "walltime_seconds", wallDuration)
 	} else {
 		probeSuccessGauge.Set(0)
-		_ = level.Error(logger).Log("msg", "Check failed", "duration_seconds", probeDuration)
+		_ = level.Error(logger).Log("msg", "Check failed", "duration_seconds", duration, "walltime_seconds", wallDuration)
 	}
 
 	smCheckInfo.Set(1)

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1545,7 +1545,7 @@ func TestScraperCollectData(t *testing.T) {
 					key := string(dec.Key())
 					val := string(dec.Value())
 					switch key {
-					case "level", "msg", "timeout_seconds", "duration_seconds":
+					case "level", "msg", "timeout_seconds", "duration_seconds", "walltime_seconds":
 					case "target":
 						require.Equal(t, s.target, val)
 					case "type":


### PR DESCRIPTION
The agent defers into implementation-specific probers to report what is the "latency" of whatever they're reporting. If they don't report one, then the agent falls back to the wall time it took to run the prober.

Prior to this commit, that wall time was used unconditionally for logging, but not for the metric, creating inconsistencies. This commit changes that, so the reported value if used for both things if available, and the wall time is also used for both things if not.

Additionally, the wall time is included as a separate attribute in the logs, for completeness sake.

Closes https://github.com/grafana/synthetic-monitoring-agent/issues/1508