### PR TITLE
Add explicit darwin/arm64 platform support

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -3,4 +3,4 @@
 
 DOCKER_TAG = grafana/synthetic-monitoring-agent
 
-PLATFORMS = $(sort $(HOST_OS)/$(HOST_ARCH) linux/amd64 linux/arm64)
+PLATFORMS = $(sort $(HOST_OS)/$(HOST_ARCH) linux/amd64 linux/arm64 darwin/arm64)


### PR DESCRIPTION
- Add darwin/arm64 to PLATFORMS in config.mk to ensure it's built and published
- This enables ARM64 macOS builds in GitHub Actions workflows
- Cross-compilation from Linux runners will produce darwin-arm64 binaries