### PR TITLE
fix: Change default logging level to WarnLevel

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -183,7 +183,7 @@ func run(args []string, stdout io.Writer) error {
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 
 	default:
-		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+		zerolog.SetGlobalLevel(zerolog.WarnLevel)
 	}
 
 	g.Go(func() error {


### PR DESCRIPTION
Closes https://github.com/grafana/synthetic-monitoring-agent/issues/586

Lowers the default severity level of logs which are outputted by the application to Warn from Error.

This includes warning logs as a default item of interest for operators, and addresses an issue with adhoc checks on private probes wherein the success message is not published to Loki due to its log level.