### PR TITLE
feat: Apply jitter to tenants cache

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -299,7 +299,7 @@ func run(args []string, stdout io.Writer) error {
 		ctx,
 		synthetic_monitoring.NewTenantsClient(conn),
 		tenantCh,
-		15*time.Minute, // Default timeout for tenant information caching
+		tenants.DefaultCacheTimeout,
 		zl.With().Str("subsystem", "tenant_manager").Logger(),
 	)
 


### PR DESCRIPTION
Tenant data is mostly requested from scrapers when a check execution happens. The actual scraper start time has a jitter to randomize checks start up, as most checks are received as a bulk on initial connection. However that jitter is kept small on purpose in order to not delay checks, that makes more sense particularly for new checks.

Therefore this commit applies a jitter at the tenants cache level of up to 25% of the entry timeout (currently 15m). This is only applied when there are no expiration considerations tied to the secrets functionality.

Updates grafana/synthetic-monitoring/issues/378

---
If we take a look at the requests to fetch tenant data that are made from probes, looking per cluster level we can see a certain pattern that matches the current default timeout ([query](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22uvt%22:%7B%22datasource%22:%22000000134%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22sum%20by%28cluster%29%28rate%28server_tenant_request_duration_seconds_count%7Bcluster%3D~%5C%22pop-prod-.%2A%5C%22,%20job%3D%5C%22sm-proxy%2Fsm-proxy%5C%22%7D%5B$__rate_interval%5D%29%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22000000134%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%221761710482733%22,%22to%22:%221761732023692%22%7D,%22compact%22:false%7D%7D&orgId=1)):
<img width="3557" height="528" alt="Screenshot from 2025-10-29 11-03-12" src="https://github.com/user-attachments/assets/48300cb0-3b07-410c-9ff4-52635b0704d5" />
This change aims to randomize and spread that distribution.
