### PR TITLE
test: Use ErrorIs instead of string comparison

### DIFF
--- a/internal/adhoc/adhoc_test.go
+++ b/internal/adhoc/adhoc_test.go
@@ -416,7 +416,7 @@ func TestIdleTimeoutHandling(t *testing.T) {
 
 	runErr := h.Run(ctx)
 	require.Error(t, runErr)
-	require.Contains(t, runErr.Error(), "context deadline exceeded")
+	require.ErrorIs(t, runErr, context.DeadlineExceeded)
 
 	// Should not publish anything for idle timeout
 	select {


### PR DESCRIPTION
Addresses review feedback from #1578. Replaces string comparison with ErrorIs for better error handling.