### PR TITLE
fix: Remove old +build directives

### DIFF
--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -1,5 +1,4 @@
 //go:build ruleguard
-// +build ruleguard
 
 package gorules
 

--- a/pkg/accounting/generate-active-series-counts.go
+++ b/pkg/accounting/generate-active-series-counts.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 


### PR DESCRIPTION
Go 1.17 (?) added support for `go:build` directives to replace `+build` ones. That's ~ 4 years ago. We've moved past the point were we need to support those older things (see
8e7fee2f5383df5c3666120fbc6351f718a008eb), so remove them.

(an updated golangci-lint is complaining about this)