### PR TITLE
fix: Prevent datarace in telemetry tests

### DIFF
--- a/internal/telemetry/region_pusher_test.go
+++ b/internal/telemetry/region_pusher_test.go
@@ -497,7 +497,9 @@ func (tc *testTelemetryClient) PushTelemetry(
 ) (*sm.PushTelemetryResponse, error) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
-	defer tc.wg.Done()
+	if tc.wg != nil {
+		defer tc.wg.Done()
+	}
 
 	tc.mm = append(tc.mm, *in)
 


### PR DESCRIPTION
This is a followup to 9f4e479ce46fb2e729ced943ce01febb321bb69d. Another datarace showed up similar to the one that that commit had fixed.