### PR TITLE
fix: prober/multihttp: fix updated headers being carried over

### DIFF
--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -107,7 +107,8 @@ func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.R
 // for 'reserved' headers.
 func augmentHttpHeaders(check *sm.Check, reservedHeaders http.Header) {
 	for _, entry := range check.Settings.Multihttp.Entries {
-		updatedHeaders := []*sm.HttpHeader{}
+		updatedHeaders := make([]*sm.HttpHeader, 0, len(reservedHeaders)+len(entry.Request.Headers))
+
 		for key, values := range reservedHeaders {
 			updatedHeaders = append(updatedHeaders, &sm.HttpHeader{Name: key, Value: strings.Join(values, ",")})
 		}

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -106,12 +106,12 @@ func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.R
 // Overrides any user-provided headers with our own augmented values
 // for 'reserved' headers.
 func augmentHttpHeaders(check *sm.Check, reservedHeaders http.Header) {
-	updatedHeaders := []*sm.HttpHeader{}
-	for key, values := range reservedHeaders {
-		updatedHeaders = append(updatedHeaders, &sm.HttpHeader{Name: key, Value: strings.Join(values, ",")})
-	}
-
 	for _, entry := range check.Settings.Multihttp.Entries {
+		updatedHeaders := []*sm.HttpHeader{}
+		for key, values := range reservedHeaders {
+			updatedHeaders = append(updatedHeaders, &sm.HttpHeader{Name: key, Value: strings.Join(values, ",")})
+		}
+
 		heads := entry.Request.Headers
 		for _, headerPtr := range heads {
 			_, present := reservedHeaders[http.CanonicalHeaderKey(headerPtr.Name)]


### PR DESCRIPTION
We've got a report where, for multihttp checks, http headers set by users for one request are being carried over to the next request. After some debugging, I think I've found the root cause: A variable is being reused in the `augmentHttpHeaders`'s function main loop, causing headers from being copied over.

This PR adds some tests for `augmentHttpHeaders` and fixes this behavior.