### PR TITLE
k6runner: propagate k6 version manifest to remote runners

### DIFF
--- a/internal/k6runner/http.go
+++ b/internal/k6runner/http.go
@@ -69,6 +69,11 @@ func (r HttpRunner) Run(ctx context.Context, script Script, secretStore SecretSt
 		panic("zero backoff, runner is misconfigured, refusing to DoS")
 	}
 
+	// FIXME: Make this an error after we fully roll out k6 versioning.
+	if script.K6ChannelManifest == "" || script.K6ChannelManifest == "*" {
+		r.logger.Debug().Msg("Check does not define a channel, latest k6 version will be used and it may change without warning")
+	}
+
 	if deadline, hasDeadline := ctx.Deadline(); !hasDeadline {
 		defaultAllRetriesTimeout := time.Duration(script.Settings.Timeout) * time.Millisecond * 2
 		r.logger.Error().

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -29,9 +29,12 @@ type Script struct {
 	Settings Settings `json:"settings"`
 	// CheckInfo holds information about the SM check that triggered this script.
 	CheckInfo CheckInfo `json:"check"`
-	// SecretStore holds the location and token for accessing secrets
+	// K6ChannelManifest is the manifest for the k6 channel associated with this script. This must be a semver
+	// constraint, that is used in runtime to figure which k6 binary, of those available, is used to run the script.
+	K6ChannelManifest string `json:"k6ChannelManifest"`
 }
 
+// SecretStore holds the location and token for accessing secrets
 type SecretStore struct {
 	Url   string `json:"url"`
 	Token string `json:"token"`

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -38,6 +38,11 @@ func (r Local) WithLogger(logger *zerolog.Logger) Runner {
 func (r Local) Run(ctx context.Context, script Script, secretStore SecretStore) (*RunResponse, error) {
 	logger := r.logger.With().Object("checkInfo", &script.CheckInfo).Logger()
 
+	// FIXME: Remove after implementing version management for local runners.
+	if script.K6ChannelManifest != "" {
+		logger.Warn().Msg("This probe does not support k6 versioning, the included version will be used.")
+	}
+
 	afs := afero.Afero{Fs: r.fs}
 
 	checkTimeout := time.Duration(script.Settings.Timeout) * time.Millisecond

--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -45,6 +45,18 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 				Timeout: check.Timeout,
 			},
 			CheckInfo: k6runner.CheckInfoFromSM(check),
+			K6ChannelManifest: func(ch *sm.Channels) string {
+				if ch == nil || ch.K6 == nil {
+					checkInfo := k6runner.CheckInfoFromSM(check)
+					logger.Warn().
+						Object("checkInfo", &checkInfo).
+						Msg("Channel manifest unexpectedly empty for check. Please select a version for it.")
+
+					return ""
+				}
+
+				return ch.K6.Manifest
+			}(check.Channels),
 		},
 	}
 

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -52,6 +52,8 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 		return p, err
 	}
 
+	const multiHTTPManifest = "^1.0.0" // From v1 and up to, but _not_ including, v2.
+
 	p.module = Module{
 		Prober: sm.CheckTypeMultiHttp.String(),
 		Script: k6runner.Script{
@@ -59,7 +61,8 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 			Settings: k6runner.Settings{
 				Timeout: check.Timeout,
 			},
-			CheckInfo: k6runner.CheckInfoFromSM(check),
+			CheckInfo:         k6runner.CheckInfoFromSM(check),
+			K6ChannelManifest: multiHTTPManifest,
 		},
 	}
 

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -45,6 +45,18 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 				Timeout: check.Timeout,
 			},
 			CheckInfo: k6runner.CheckInfoFromSM(check),
+			K6ChannelManifest: func(ch *sm.Channels) string {
+				if ch == nil || ch.K6 == nil {
+					checkInfo := k6runner.CheckInfoFromSM(check)
+					logger.Warn().
+						Object("checkInfo", &checkInfo).
+						Msg("Channel manifest unexpectedly empty for check. Please select a version for it.")
+
+					return ""
+				}
+
+				return ch.K6.Manifest
+			}(check.Channels),
 		},
 	}
 


### PR DESCRIPTION
This PR adds the plumbing bits that propagate the k6 channel manifest down the call stack to runners. For now, the local runner does not do anything with this information (that will come in a separate PR), but the HTTP runner does propagate this information.

Part of: https://github.com/grafana/synthetic-monitoring/issues/416