### PR TITLE
feat: Add support for xk6-sm v2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,12 +16,25 @@
         "ghcr.io/grafana/chromium-swiftshader-alpine"
       ],
       "versioning": "loose"
+    },
+    {
+      "matchDepNames": [
+        "grafana/xk6-sm-v1"
+      ],
+      "allowedVersions": "<2.0.0"
+    },
+    {
+      "matchDepNames": [
+        "grafana/xk6-sm-v2"
+      ],
+      "allowedVersions": ">=2.0.0 <3.0.0"
     }
   ],
   "customManagers": [
     {
       "customType": "regex",
-      "depNameTemplate": "grafana/xk6-sm",
+      "depNameTemplate": "grafana/xk6-sm-v1",
+      "packageNameTemplate": "grafana/xk6-sm",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
       "managerFilePatterns": [
@@ -30,7 +43,22 @@
         "**/*.mk"
       ],
       "matchStrings": [
-        "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/"
+        "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/[^\\s]+\\s.*k6-v1"
+      ]
+    },
+    {
+      "customType": "regex",
+      "depNameTemplate": "grafana/xk6-sm-v2",
+      "packageNameTemplate": "grafana/xk6-sm",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "managerFilePatterns": [
+        "**/Dockerfile",
+        "**/Dockerfile.*",
+        "**/*.mk"
+      ],
+      "matchStrings": [
+        "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/[^\\s]+\\s.*k6-v2"
       ]
     }
   ]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,7 +43,7 @@
         "**/*.mk"
       ],
       "matchStrings": [
-        "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/[^\\s]+\\s.*k6-v1"
+        "K6_V1_VERSION=(?<currentValue>\\S+)"
       ]
     },
     {
@@ -58,7 +58,7 @@
         "**/*.mk"
       ],
       "matchStrings": [
-        "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/[^\\s]+\\s.*k6-v2"
+        "K6_V2_VERSION=(?<currentValue>\\S+)"
       ]
     }
   ]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,13 +19,22 @@
       // versioning which is pretty much an alphabetical sort.
       "matchPackageNames": ["ghcr.io/grafana/chromium-swiftshader-alpine"],
       "versioning": "loose"
+    },
+    {
+      "matchDepNames": ["grafana/xk6-sm-v1"],
+      "allowedVersions": "<2.0.0"
+    },
+    {
+      "matchDepNames": ["grafana/xk6-sm-v2"],
+      "allowedVersions": ">=2.0.0 <3.0.0"
     }
   ],
   "customManagers": [
     {
-      // Update xk6-sm
+      // Update xk6-sm v1
       "customType": "regex",
-      "depNameTemplate": "grafana/xk6-sm",
+      "depNameTemplate": "grafana/xk6-sm-v1",
+      "packageNameTemplate": "grafana/xk6-sm",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver",
       "managerFilePatterns": [
@@ -34,7 +43,23 @@
         "**/*.mk"
       ],
       "matchStrings": [
-        "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/"
+        "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/[^\\s]+\\s.*k6-v1"
+      ]
+    },
+    {
+      // Update xk6-sm v2
+      "customType": "regex",
+      "depNameTemplate": "grafana/xk6-sm-v2",
+      "packageNameTemplate": "grafana/xk6-sm",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "managerFilePatterns": [
+        "**/Dockerfile",
+        "**/Dockerfile.*",
+        "**/*.mk"
+      ],
+      "matchStrings": [
+        "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/[^\\s]+\\s.*k6-v2"
       ]
     }
   ]

--- a/.github/renovate.yaml
+++ b/.github/renovate.yaml
@@ -23,10 +23,18 @@ packageRules:
       - "ghcr.io/grafana/chromium-swiftshader-alpine"
     versioning: loose
 
+  - matchDepNames:
+      - "grafana/xk6-sm-v1"
+    allowedVersions: "<2.0.0"
+
+  - matchDepNames:
+      - "grafana/xk6-sm-v2"
+    allowedVersions: ">=2.0.0 <3.0.0"
+
 customManagers:
-  - # Update xk6-sm
-    customType: "regex"
-    depNameTemplate: "grafana/xk6-sm"
+  - customType: "regex"
+    depNameTemplate: "grafana/xk6-sm-v1"
+    packageNameTemplate: "grafana/xk6-sm"
     datasourceTemplate: "github-releases"
     versioningTemplate: "semver"
     managerFilePatterns:
@@ -34,4 +42,16 @@ customManagers:
       - "**/Dockerfile.*"
       - "**/*.mk"
     matchStrings:
-      - "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/"
+      - "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/[^\\s]+\\s.*k6-v1"
+
+  - customType: "regex"
+    depNameTemplate: "grafana/xk6-sm-v2"
+    packageNameTemplate: "grafana/xk6-sm"
+    datasourceTemplate: "github-releases"
+    versioningTemplate: "semver"
+    managerFilePatterns:
+      - "**/Dockerfile"
+      - "**/Dockerfile.*"
+      - "**/*.mk"
+    matchStrings:
+      - "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/[^\\s]+\\s.*k6-v2"

--- a/.github/renovate.yaml
+++ b/.github/renovate.yaml
@@ -42,7 +42,7 @@ customManagers:
       - "**/Dockerfile.*"
       - "**/*.mk"
     matchStrings:
-      - "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/[^\\s]+\\s.*k6-v1"
+      - "K6_V1_VERSION=(?<currentValue>\\S+)"
 
   - customType: "regex"
     depNameTemplate: "grafana/xk6-sm-v2"
@@ -54,4 +54,4 @@ customManagers:
       - "**/Dockerfile.*"
       - "**/*.mk"
     matchStrings:
-      - "https://github.com/grafana/xk6-sm/releases/download/(?<currentValue>[^/]+)/[^\\s]+\\s.*k6-v2"
+      - "K6_V2_VERSION=(?<currentValue>\\S+)"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,9 @@ archives:
       - src: "{{dir .ArtifactPath}}/k6-v1"
         dst: k6-v1
         strip_parent: true
+      - src: "{{dir .ArtifactPath}}/k6-v2"
+        dst: k6-v2
+        strip_parent: true
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -55,6 +58,8 @@ nfpms:
 
       - src: ./dist/synthetic-monitoring-agent_{{.Os}}_{{.Arch}}{{ with .Amd64 }}_{{ . }}{{ end}}/k6-v1
         dst: /usr/libexec/sm-k6/k6-v1
+      - src: ./dist/synthetic-monitoring-agent_{{.Os}}_{{.Arch}}{{ with .Amd64 }}_{{ . }}{{ end}}/k6-v2
+        dst: /usr/libexec/sm-k6/k6-v2
     rpm:
       signature:
         # Also set ${NFPM_DEFAULT_PASSPHRASE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ARG HOST_DIST=$TARGETOS-$TARGETARCH
 RUN adduser -D -u 12345 -g 12345 sm
 
 ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.6.20/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v2.0.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v2
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
@@ -39,6 +40,7 @@ RUN adduser -D -u 12345 -g 12345 sm
 
 COPY --from=release --chown=sm:sm /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release --chown=sm:sm /usr/libexec/sm-k6/k6-v1 /usr/libexec/sm-k6/k6-v1
+COPY --from=release --chown=sm:sm /usr/libexec/sm-k6/k6-v2 /usr/libexec/sm-k6/k6-v2
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ARG HOST_DIST=$TARGETOS-$TARGETARCH
 RUN adduser -D -u 12345 -g 12345 sm
 
 ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v1.1.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v2.0.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v2
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
@@ -39,6 +40,7 @@ RUN adduser -D -u 12345 -g 12345 sm
 
 COPY --from=release --chown=sm:sm /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release --chown=sm:sm /usr/libexec/sm-k6/k6-v1 /usr/libexec/sm-k6/k6-v1
+COPY --from=release --chown=sm:sm /usr/libexec/sm-k6/k6-v2 /usr/libexec/sm-k6/k6-v2
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,13 @@ FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a
 ARG TARGETOS
 ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH
+ARG K6_V1_VERSION=v1.1.0
+ARG K6_V2_VERSION=v2.0.0
 
 RUN adduser -D -u 12345 -g 12345 sm
 
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v1.1.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v2.0.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v2
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/${K6_V1_VERSION}/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/${K6_V2_VERSION}/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v2
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -24,6 +24,7 @@ ARG HOST_DIST=$TARGETOS-$TARGETARCH
 RUN adduser -D -u 12345 -g 12345 sm
 
 ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.6.20/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v2.0.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v2
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
@@ -39,6 +40,7 @@ RUN adduser -D -u 12345 -g 12345 sm
 
 COPY --from=release --chown=sm:sm /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release --chown=sm:sm /usr/libexec/sm-k6/k6-v1 /usr/libexec/sm-k6/k6-v1
+COPY --from=release --chown=sm:sm /usr/libexec/sm-k6/k6-v2 /usr/libexec/sm-k6/k6-v2
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -24,6 +24,7 @@ ARG HOST_DIST=$TARGETOS-$TARGETARCH
 RUN adduser -D -u 12345 -g 12345 sm
 
 ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v1.1.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v2.0.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v2
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
@@ -39,6 +40,7 @@ RUN adduser -D -u 12345 -g 12345 sm
 
 COPY --from=release --chown=sm:sm /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --from=release --chown=sm:sm /usr/libexec/sm-k6/k6-v1 /usr/libexec/sm-k6/k6-v1
+COPY --from=release --chown=sm:sm /usr/libexec/sm-k6/k6-v2 /usr/libexec/sm-k6/k6-v2
 COPY --from=release /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -20,11 +20,13 @@ FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a
 ARG TARGETOS
 ARG TARGETARCH
 ARG HOST_DIST=$TARGETOS-$TARGETARCH
+ARG K6_V1_VERSION=v1.1.0
+ARG K6_V2_VERSION=v2.0.0
 
 RUN adduser -D -u 12345 -g 12345 sm
 
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v1.1.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v2.0.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v2
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/${K6_V1_VERSION}/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/${K6_V2_VERSION}/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v2
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -849,6 +849,12 @@ func TestSettingsToScript(t *testing.T) {
 
 	for _, k6path := range testhelper.K6Paths(t) {
 		t.Run(filepath.Base(k6path), func(t *testing.T) {
+			// TODO: By now, multiHTTP are forced to run with xk6-sm v1.
+			// See https://github.com/grafana/synthetic-monitoring-agent/blob/26438a93be8af6523fb38a9d0affd1cfc07f438a/internal/prober/multihttp/multihttp.go#L55
+			if strings.Contains(k6path, "v2") {
+				t.Skip("multihttp checks are forced to run with xk6-sm v1")
+			}
+
 			ctx, cancel := testhelper.Context(context.Background(), t)
 			t.Cleanup(cancel)
 

--- a/scripts/make/950_release.mk
+++ b/scripts/make/950_release.mk
@@ -42,7 +42,7 @@ package-rpm-$(1)-$(2) : $(DISTDIR)/$(1)-$(2)/nfpm.yaml $(DISTDIR)/changelog.yaml
 		--packager rpm \
 		--target $(DISTDIR)/$(1)-$(2)/
 
-package-tgz-$(1)-$(2) : $(DISTDIR)/$(1)-$(2)/k6-v1 $(DISTDIR)/$(1)-$(2)/synthetic-monitoring-agent $(ROOTDIR)/CHANGELOG.md $(ROOTDIR)/README.md $(ROOTDIR)/LICENSE
+package-tgz-$(1)-$(2) : $(DISTDIR)/$(1)-$(2)/k6-v1 $(DISTDIR)/$(1)-$(2)/k6-v2 $(DISTDIR)/$(1)-$(2)/synthetic-monitoring-agent $(ROOTDIR)/CHANGELOG.md $(ROOTDIR)/README.md $(ROOTDIR)/LICENSE
 	# Create a tarball including the binaries, changelog, and readme. --transform is used to place all files at the root
 	# of the tarball. The built-in make variable dollar-caret is escaped with two dollars so it survives package_template.
 	$(S) tar --transform 's|.*/||' -zcf $(DISTDIR)/$(1)-$(2)/synthetic-monitoring-agent-$(firstword $(subst -, ,$(BUILD_VERSION)))-$(1)-$(2).tar.gz $$^

--- a/scripts/make/960_sm-k6.mk
+++ b/scripts/make/960_sm-k6.mk
@@ -4,18 +4,31 @@ XK6_PLATFORMS := $(filter-out linux/arm,$(PLATFORMS)) darwin/arm64 darwin/amd64
 sm-k6:
 	@true
 
-define sm-k6-binary
+define sm-k6-v1-binary
 $(DISTDIR)/$(1)-$(2)/k6-v1:
 	mkdir -p "$(DISTDIR)/$(1)-$(2)"
 	# Renovate updates the following line. Keep its syntax as it is.
-	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v0.6.20/sm-k6-$(1)-$(2) -o "$$@"
+	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v0.6.20/sm-k6-$(1)-$(2) -o "$$@" # k6-v1
 	chmod +x "$$@"
 
 sm-k6: $(DISTDIR)/$(1)-$(2)/k6-v1
 endef
 
+define sm-k6-v2-binary
+$(DISTDIR)/$(1)-$(2)/k6-v2:
+	mkdir -p "$(DISTDIR)/$(1)-$(2)"
+	# Renovate updates the following line. Keep its syntax as it is.
+	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v2.0.0/sm-k6-$(1)-$(2) -o "$$@" # k6-v2
+	chmod +x "$$@"
+
+sm-k6: $(DISTDIR)/$(1)-$(2)/k6-v2
+endef
+
 $(foreach BUILD_PLATFORM,$(XK6_PLATFORMS), \
-	$(eval $(call sm-k6-binary,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
+	$(eval $(call sm-k6-v1-binary,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
+
+$(foreach BUILD_PLATFORM,$(XK6_PLATFORMS), \
+	$(eval $(call sm-k6-v2-binary,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
 
 .PHONY: sm-k6-native
-sm-k6-native: $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/k6-v1
+sm-k6-native: $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/k6-v1 $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/k6-v2

--- a/scripts/make/960_sm-k6.mk
+++ b/scripts/make/960_sm-k6.mk
@@ -4,18 +4,31 @@ XK6_PLATFORMS := $(filter-out linux/arm,$(PLATFORMS)) darwin/arm64 darwin/amd64
 sm-k6:
 	@true
 
-define sm-k6-binary
+define sm-k6-v1-binary
 $(DISTDIR)/$(1)-$(2)/k6-v1:
 	mkdir -p "$(DISTDIR)/$(1)-$(2)"
 	# Renovate updates the following line. Keep its syntax as it is.
-	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v1.1.0/sm-k6-$(1)-$(2) -o "$$@"
+	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v1.1.0/sm-k6-$(1)-$(2) -o "$$@" # k6-v1
 	chmod +x "$$@"
 
 sm-k6: $(DISTDIR)/$(1)-$(2)/k6-v1
 endef
 
+define sm-k6-v2-binary
+$(DISTDIR)/$(1)-$(2)/k6-v2:
+	mkdir -p "$(DISTDIR)/$(1)-$(2)"
+	# Renovate updates the following line. Keep its syntax as it is.
+	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v2.0.0/sm-k6-$(1)-$(2) -o "$$@" # k6-v2
+	chmod +x "$$@"
+
+sm-k6: $(DISTDIR)/$(1)-$(2)/k6-v2
+endef
+
 $(foreach BUILD_PLATFORM,$(XK6_PLATFORMS), \
-	$(eval $(call sm-k6-binary,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
+	$(eval $(call sm-k6-v1-binary,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
+
+$(foreach BUILD_PLATFORM,$(XK6_PLATFORMS), \
+	$(eval $(call sm-k6-v2-binary,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
 
 .PHONY: sm-k6-native
-sm-k6-native: $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/k6-v1
+sm-k6-native: $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/k6-v1 $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/k6-v2

--- a/scripts/make/960_sm-k6.mk
+++ b/scripts/make/960_sm-k6.mk
@@ -1,34 +1,36 @@
 XK6_PLATFORMS := $(filter-out linux/arm,$(PLATFORMS)) darwin/arm64 darwin/amd64
 
+K6_V1_VERSION=v1.1.0
+K6_V2_VERSION=v2.0.0
+
 .PHONY: sm-k6
 sm-k6:
 	@true
 
-define sm-k6-v1-binary
-$(DISTDIR)/$(1)-$(2)/k6-v1:
-	mkdir -p "$(DISTDIR)/$(1)-$(2)"
-	# Renovate updates the following line. Keep its syntax as it is.
-	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v1.1.0/sm-k6-$(1)-$(2) -o "$$@" # k6-v1
-	chmod +x "$$@"
-
-sm-k6: $(DISTDIR)/$(1)-$(2)/k6-v1
-endef
-
-define sm-k6-v2-binary
-$(DISTDIR)/$(1)-$(2)/k6-v2:
-	mkdir -p "$(DISTDIR)/$(1)-$(2)"
-	# Renovate updates the following line. Keep its syntax as it is.
-	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v2.0.0/sm-k6-$(1)-$(2) -o "$$@" # k6-v2
-	chmod +x "$$@"
-
-sm-k6: $(DISTDIR)/$(1)-$(2)/k6-v2
-endef
-
-$(foreach BUILD_PLATFORM,$(XK6_PLATFORMS), \
-	$(eval $(call sm-k6-v1-binary,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
-
-$(foreach BUILD_PLATFORM,$(XK6_PLATFORMS), \
-	$(eval $(call sm-k6-v2-binary,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))))))
-
 .PHONY: sm-k6-native
-sm-k6-native: $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/k6-v1 $(DISTDIR)/$(HOST_OS)-$(HOST_ARCH)/k6-v2
+sm-k6-native:
+	@true
+
+# Args:
+# 1: OS
+# 2: Arch
+# 3: Tag
+# 4: Version
+define sm-k6-binary
+$(DISTDIR)/$(1)-$(2)/k6-$(3):
+	mkdir -p "$(DISTDIR)/$(1)-$(2)"
+	curl -sSL https://github.com/grafana/xk6-sm/releases/download/$(4)/sm-k6-$(1)-$(2) -o "$$@"
+	chmod +x "$$@"
+
+sm-k6: $(DISTDIR)/$(1)-$(2)/k6-$(3)
+
+ifeq ($(HOST_OS)-$(HOST_ARCH),$(1)-$(2))
+sm-k6-native: $(DISTDIR)/$(1)-$(2)/k6-$(3)
+endif
+endef
+
+$(foreach BUILD_PLATFORM,$(XK6_PLATFORMS), \
+	$(eval $(call sm-k6-binary,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))),v1,$(K6_V1_VERSION))))
+
+$(foreach BUILD_PLATFORM,$(XK6_PLATFORMS), \
+	$(eval $(call sm-k6-binary,$(word 1,$(subst /, ,$(BUILD_PLATFORM))),$(word 2,$(subst /, ,$(BUILD_PLATFORM))),v2,$(K6_V2_VERSION))))

--- a/scripts/package/nfpm.yaml.template
+++ b/scripts/package/nfpm.yaml.template
@@ -22,5 +22,7 @@ contents:
 
 - src: {{.DISTDIR}}/{{.Os}}-{{.Arch}}/k6-v1
   dst: /usr/libexec/sm-k6/k6-v1
+- src: {{.DISTDIR}}/{{.Os}}-{{.Arch}}/k6-v2
+  dst: /usr/libexec/sm-k6/k6-v2
 rpm:
 deb:


### PR DESCRIPTION
Updates build and release files in order to include xk6-sm v2 binary bundled within the same directory as v1.
Also updates renovate configuration in order to keep both dependencies up to date.

Depends on: grafana/xk6-sm/pull/397
Updates grafana/synthetic-monitoring/issues/491

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes build/release packaging and Docker image contents by adding a second `k6` binary, which can break artifacts or image size/paths if misconfigured; runtime probe logic is largely unchanged (multihttp still pins v1).
> 
> **Overview**
> Adds bundling of **xk6-sm v2** alongside v1 across release artifacts and container images.
> 
> Updates Dockerfiles, `goreleaser`/`nfpm`, and packaging Make targets to download/build and ship both `/usr/libexec/sm-k6/k6-v1` and `k6-v2` (and include `k6-v2` in archives/tarballs). Renovate config is split into two tracked deps (`grafana/xk6-sm-v1` and `grafana/xk6-sm-v2`) with version ranges and regex managers that update `K6_V1_VERSION`/`K6_V2_VERSION` variables.
> 
> Tests are adjusted to skip running multiHTTP probes against the v2 binary since multiHTTP is currently forced to use v1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23893e94a0c2d6506aa59a4f5e27e95e0c2fbd5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->