### PR TITLE
fix: Parse BBE log timestamps with RFC3339Nano

### DIFF
--- a/internal/prober/logger/adapter.go
+++ b/internal/prober/logger/adapter.go
@@ -25,7 +25,7 @@ func (h slogHandler) Handle(ctx context.Context, r slog.Record) error {
 	attrs := make([]any, 0)
 	attrs = append(attrs, "level", r.Level.String())
 	attrs = append(attrs, "msg", r.Message)
-	attrs = append(attrs, "time", r.Time.Format(time.RFC3339))
+	attrs = append(attrs, "time", r.Time.Format(time.RFC3339Nano))
 
 	r.Attrs(func(attr slog.Attr) bool {
 		attrs = append(attrs, attr.Key, attr.Value.String())

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -849,10 +849,12 @@ RECORD:
 					continue RECORD
 				}
 
-			// k6 sets a 'time' field on its logs using RFC3339; if present, report it instead of the default timestamp
+			// k6 sets a 'time' field on its logs using RFC3339; if present, report it instead of the default timestamp.
+			// The slogHandler adapter (used for BBE probers) also emits a 'time' field using RFC3339Nano.
+			// RFC3339Nano is a strict superset of RFC3339; use it to parse either 'time' value.`
 			case "time":
 				var err error
-				t, err = time.Parse(time.RFC3339, string(value))
+				t, err = time.Parse(time.RFC3339Nano, string(value))
 				if err != nil {
 					s.logger.Warn().Err(err).Bytes("value", value).Msg("invalid timestamp scanning logs")
 					continue RECORD

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -2168,6 +2168,26 @@ func TestExtractLogsK6TimeOverridesDefaultTimestamp(t *testing.T) {
 			},
 		},
 		{
+			name: "BBE adapter time field with nanosecond precision is used as timestamp",
+			logs: `ts=2023-06-01T20:00:00.500000000Z level=INFO msg="Making HTTP request" time=2023-06-01T20:00:00.600000000Z url=https://example.com host=example.com`,
+			sharedLabels: []labelPair{
+				{name: "probe", value: "test-probe"},
+			},
+			expected: func(t *testing.T, streams Streams) {
+				require.Len(t, streams, 1)
+				require.Len(t, streams[0].Entries, 1)
+				entry := streams[0].Entries[0]
+
+				// time= (600ms) should win over ts= (500ms), and must preserve nanosecond precision.
+				expectedTime, _ := time.Parse(time.RFC3339Nano, "2023-06-01T20:00:00.600000000Z")
+				require.Equal(t, expectedTime, entry.Timestamp, "should use nanosecond-precision time= field")
+				// url= and host= should be in the body; time= should not.
+				require.Contains(t, entry.Line, "url=https://example.com")
+				require.Contains(t, entry.Line, "host=example.com")
+				require.NotContains(t, entry.Line, "time=")
+			},
+		},
+		{
 			name: "ts field only (no k6 time)",
 			logs: `ts=2023-06-01T20:00:00Z level=info msg="normal message"`,
 			sharedLabels: []labelPair{
@@ -2196,5 +2216,80 @@ func TestExtractLogsK6TimeOverridesDefaultTimestamp(t *testing.T) {
 			streams := s.extractLogs(time.Now(), []byte(tc.logs), tc.sharedLabels)
 			tc.expected(t, streams)
 		})
+	}
+}
+
+func TestHTTPCheckLogTimestampsAreNonDecreasing(t *testing.T) {
+	ctx := context.Background()
+
+	p, check, cleanup := setupHTTPProbe(ctx, t)
+	defer cleanup()
+
+	s := Scraper{
+		checkName: check.Check.Settings.Http.String(),
+		target:    check.Check.Target,
+		logger:    testhelper.Logger(t),
+		prober:    p,
+		labelsLimiter: testLabelsLimiter{
+			maxMetricLabels: 20,
+			maxLogLabels:    15,
+		},
+		summaries:  make(map[uint64]prometheus.Summary),
+		histograms: make(map[uint64]prometheus.Histogram),
+		check:      check,
+		probe: sm.Probe{
+			Name:   "test-probe",
+			Region: "test-region",
+		},
+	}
+
+	data, _, err := s.collectData(ctx, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	streams := data.Streams()
+	require.NotEmpty(t, streams, "expected at least one log stream")
+
+	for _, stream := range streams {
+		entries := stream.Entries
+		require.NotEmpty(t, entries, "expected log entries in stream")
+
+		// All 7 expected messages must be present.
+		msgs := make([]string, 0, len(entries))
+		for _, e := range entries {
+			dec := logfmt.NewDecoder(strings.NewReader(e.Line))
+			for dec.ScanRecord() {
+				for dec.ScanKeyval() {
+					if string(dec.Key()) == "msg" {
+						msgs = append(msgs, string(dec.Value()))
+					}
+				}
+			}
+		}
+
+		expectedMsgs := []string{
+			"Beginning check",
+			"Resolving target address",
+			"Resolved target address",
+			"Making HTTP request",
+			"Received HTTP response",
+			"Response timings for roundtrip",
+			"Check succeeded",
+		}
+		for _, expected := range expectedMsgs {
+			require.Contains(t, msgs, expected, "missing log entry: %q", expected)
+		}
+
+		// Entry timestamps must be non-decreasing (Loki stream ordering requirement).
+		for i := 1; i < len(entries); i++ {
+			require.False(t,
+				entries[i].Timestamp.Before(entries[i-1].Timestamp),
+				"entry[%d] timestamp %v is before entry[%d] timestamp %v (out-of-order)\nentry[%d] msg: %s\nentry[%d] msg: %s",
+				i, entries[i].Timestamp,
+				i-1, entries[i-1].Timestamp,
+				i-1, entries[i-1].Line,
+				i, entries[i].Line,
+			)
+		}
 	}
 }

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -2226,8 +2226,8 @@ func TestHTTPCheckLogTimestampsAreNonDecreasing(t *testing.T) {
 	defer cleanup()
 
 	s := Scraper{
-		checkName: check.Check.Settings.Http.String(),
-		target:    check.Check.Target,
+		checkName: check.Settings.Http.String(),
+		target:    check.Target,
 		logger:    testhelper.Logger(t),
 		prober:    p,
 		labelsLimiter: testLabelsLimiter{


### PR DESCRIPTION
Addresses https://github.com/grafana/support-escalations/issues/21744

I believe f890931 introduced an unintended effect where the 'time' logfmt field for BBE logs was getting parsed with RFC3339, using seconds precision, and being used as the log timestamp for Loki. This caused logs from BBE to predate the actual `Beginning check` log for the execution because they typically occur in the same second as the initial 'Beginning check' log - when truncated to seconds, it appears as though they predate the initial log and are out-of-order.

The out-of-order appearance of BBE logs was causing them not to show up in Timepoint Explorer, which uses the `Beginning check` log as a starting point to group logs for the execution. Thus only 'Beginning check' and 'Check succeeded' are showing up in that UI.