### PR TITLE
feat: Set k6 ref. id for browser checks run by local runner

### DIFF
--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -447,7 +447,7 @@ func (h *Handler) defaultRunnerFactory(ctx context.Context, req *sm.AdHocRequest
 		},
 	}
 
-	p, target, err := h.proberFactory.New(ctx, h.logger, check)
+	p, target, err := h.proberFactory.New(ctx, h.logger, check, h.probe.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -477,7 +477,7 @@ func (testProber) Probe(ctx context.Context, target string, registry *prometheus
 
 type testProbeFactory struct{}
 
-func (f testProbeFactory) New(ctx context.Context, logger zerolog.Logger, check model.Check) (prober.Prober, string, error) {
+func (f testProbeFactory) New(ctx context.Context, logger zerolog.Logger, check model.Check, probeName string) (prober.Prober, string, error) {
 	return testProber{}, check.Target, nil
 }
 

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -60,6 +60,10 @@ type Settings struct {
 type CheckInfo struct {
 	// Type is the string representation of the check type this script belongs to (browser, scripted, multihttp, etc.)
 	Type string `json:"type"`
+	// Job is the check's job label.
+	Job string `json:"job"`
+	// Instance is the check's instance label.
+	Instance string `json:"instance"`
 	// Metadata is a collection of key/value pairs containing information about this check, such as check and tenant ID.
 	// It is loosely typed on purpose: Metadata should only be used for informational properties that will make its way
 	// into telemetry, and not for making decision on it.
@@ -73,6 +77,8 @@ func CheckInfoFromSM(smc smmodel.Check) CheckInfo {
 	}
 
 	ci.Type = smc.Type().String()
+	ci.Job = smc.Job
+	ci.Instance = smc.Target
 	ci.Metadata["id"] = smc.Id
 	ci.Metadata["tenantID"] = smc.TenantId
 	ci.Metadata["regionID"] = smc.RegionId
@@ -85,6 +91,8 @@ func CheckInfoFromSM(smc smmodel.Check) CheckInfo {
 // MarshalZerologObject implements zerolog.LogObjectMarshaler so it can be logged in a friendly way.
 func (ci *CheckInfo) MarshalZerologObject(e *zerolog.Event) {
 	e.Str("type", ci.Type)
+	e.Str("job", ci.Job)
+	e.Str("instance", ci.Instance)
 	for k, v := range ci.Metadata {
 		e.Any(k, v)
 	}

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -64,14 +64,16 @@ type CheckInfo struct {
 	Job string `json:"job"`
 	// Instance is the check's instance label.
 	Instance string `json:"instance"`
+	// Probe is the name of the probe executing the check.
+	Probe string `json:"probe"`
 	// Metadata is a collection of key/value pairs containing information about this check, such as check and tenant ID.
 	// It is loosely typed on purpose: Metadata should only be used for informational properties that will make its way
 	// into telemetry, and not for making decision on it.
 	Metadata map[string]any `json:"metadata"`
 }
 
-// CheckInfoFromSM returns a CheckInfo from the information of the given SM check.
-func CheckInfoFromSM(smc smmodel.Check) CheckInfo {
+// CheckInfoFromSM returns a CheckInfo from the information of the given SM check and probe name.
+func CheckInfoFromSM(smc smmodel.Check, probeName string) CheckInfo {
 	ci := CheckInfo{
 		Metadata: map[string]any{},
 	}
@@ -79,6 +81,7 @@ func CheckInfoFromSM(smc smmodel.Check) CheckInfo {
 	ci.Type = smc.Type().String()
 	ci.Job = smc.Job
 	ci.Instance = smc.Target
+	ci.Probe = probeName
 	ci.Metadata["id"] = smc.Id
 	ci.Metadata["tenantID"] = smc.TenantId
 	ci.Metadata["regionID"] = smc.RegionId
@@ -93,6 +96,7 @@ func (ci *CheckInfo) MarshalZerologObject(e *zerolog.Event) {
 	e.Str("type", ci.Type)
 	e.Str("job", ci.Job)
 	e.Str("instance", ci.Instance)
+	e.Str("probe", ci.Probe)
 	for k, v := range ci.Metadata {
 		e.Any(k, v)
 	}

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -113,6 +113,8 @@ func TestCheckInfoFromSM(t *testing.T) {
 			TenantId: 1234,
 			Created:  1234.5,
 			Modified: 12345.6,
+			Job:      "my-job",
+			Target:   "https://example.com",
 			Settings: sm.CheckSettings{
 				Browser: &sm.BrowserSettings{}, // Make it non-nil so type is Browser.
 			},
@@ -122,6 +124,8 @@ func TestCheckInfoFromSM(t *testing.T) {
 	ci := CheckInfoFromSM(check)
 
 	require.Equal(t, sm.CheckTypeBrowser.String(), ci.Type)
+	require.Equal(t, "my-job", ci.Job)
+	require.Equal(t, "https://example.com", ci.Instance)
 	require.Equal(t, map[string]any{
 		"id":       check.Id,
 		"tenantID": check.TenantId,

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -121,11 +121,12 @@ func TestCheckInfoFromSM(t *testing.T) {
 		},
 	}
 
-	ci := CheckInfoFromSM(check)
+	ci := CheckInfoFromSM(check, "probe-a")
 
 	require.Equal(t, sm.CheckTypeBrowser.String(), ci.Type)
 	require.Equal(t, "my-job", ci.Job)
 	require.Equal(t, "https://example.com", ci.Instance)
+	require.Equal(t, "probe-a", ci.Probe)
 	require.Equal(t, map[string]any{
 		"id":       check.Id,
 		"tenantID": check.TenantId,

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -18,6 +18,13 @@ import (
 	"github.com/spf13/afero"
 )
 
+// k6CloudPushRefIDEnvVar is the name of the k6 runtime environment variable used to
+// tag browser tests as originated from Synthetic Monitoring. It contains a reference
+// to the check's job, instance, and probe associated with the execution.
+// k6 will propagate this data to the window.k6 property, which is parsed by FE O11y
+// as a means to correlate between a specific browser session and a check execution.
+const k6CloudPushRefIDEnvVar = "K6_CLOUD_PUSH_REF_ID"
+
 // secretSourceConfig represents the configuration for the secrets store
 type secretSourceConfig struct {
 	URL   string `json:"url"`
@@ -291,7 +298,14 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFil
 		r.logger.Debug().Msg("No secret source configuration to add to k6")
 	}
 
-	if script.CheckInfo.Type != synthetic_monitoring.CheckTypeBrowser.String() {
+	// For browser checks, set K6_CLOUD_PUSH_REF_ID env variable for FE O11y correlation.
+	if script.CheckInfo.Type == synthetic_monitoring.CheckTypeBrowser.String() {
+		if k6RefID, err := buildK6RefID(script.CheckInfo); err != nil {
+			r.logger.Warn().Err(err).Msg("error building k6RefID")
+		} else {
+			args = append(args, "-e", k6CloudPushRefIDEnvVar+"="+k6RefID)
+		}
+	} else {
 		args = append(args,
 			"--vus", "1",
 			"--iterations", "1",
@@ -301,6 +315,19 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFil
 	args = append(args, scriptFn)
 
 	return args, nil
+}
+
+type k6RefID struct {
+	Job      string `json:"job"`
+	Instance string `json:"instance"`
+}
+
+func buildK6RefID(ci CheckInfo) (string, error) {
+	b, err := json.Marshal(k6RefID{Job: ci.Job, Instance: ci.Instance})
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 func mktemp(fs afero.Fs, dir, pattern string) (string, error) {

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -308,7 +308,11 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFil
 
 	// For browser checks, set K6_CLOUD_PUSH_REF_ID env variable for FE O11y correlation.
 	if script.CheckInfo.Type == synthetic_monitoring.CheckTypeBrowser.String() {
-		if k6RefID, err := buildK6RefID(script.CheckInfo); err != nil {
+		if script.CheckInfo.Job == "" {
+			// This branch should identify ad-hoc browser checks.
+			// By now avoid setting the k6RefID for that case.
+			logger.Debug().Msg("Skipping k6RefID: check has no job")
+		} else if k6RefID, err := buildK6RefID(script.CheckInfo); err != nil {
 			logger.Warn().Err(err).Msg("error building k6RefID")
 		} else {
 			args = append(args, "-e", k6CloudPushRefIDEnvVar+"="+k6RefID)

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -317,14 +317,12 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFil
 	return args, nil
 }
 
-type k6RefID struct {
-	Job      string `json:"job"`
-	Instance string `json:"instance"`
-	Probe    string `json:"probe"`
-}
-
 func buildK6RefID(ci CheckInfo) (string, error) {
-	b, err := json.Marshal(k6RefID{Job: ci.Job, Instance: ci.Instance, Probe: ci.Probe})
+	b, err := json.Marshal(struct {
+		Job      string `json:"job"`
+		Instance string `json:"instance"`
+		Probe    string `json:"probe"`
+	}{ci.Job, ci.Instance, ci.Probe})
 	if err != nil {
 		return "", err
 	}

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -263,6 +263,16 @@ func (r Local) Versions(ctx context.Context) <-chan []string {
 }
 
 func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFile string) ([]string, error) {
+	var (
+		logger    *zerolog.Logger
+		nopLogger = zerolog.Nop()
+	)
+	if r.logger != nil {
+		logger = r.logger
+	} else {
+		logger = &nopLogger
+	}
+
 	args := []string{
 		"run",
 		"--out", "sm=" + metricsFn,
@@ -289,19 +299,17 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFil
 	// Add secretStore configuration if available
 	if configFile != "" {
 		args = append(args, "--secret-source", "grafanasecrets=config="+configFile)
-		if r.logger != nil {
-			r.logger.Debug().
-				Str("configFile", configFile).
-				Msg("Adding secret source configuration to k6")
-		}
-	} else if r.logger != nil {
-		r.logger.Debug().Msg("No secret source configuration to add to k6")
+		logger.Debug().Str("configFile", configFile).Msg(
+			"Adding secret source configuration to k6",
+		)
+	} else {
+		logger.Debug().Msg("No secret source configuration to add to k6")
 	}
 
 	// For browser checks, set K6_CLOUD_PUSH_REF_ID env variable for FE O11y correlation.
 	if script.CheckInfo.Type == synthetic_monitoring.CheckTypeBrowser.String() {
 		if k6RefID, err := buildK6RefID(script.CheckInfo); err != nil {
-			r.logger.Warn().Err(err).Msg("error building k6RefID")
+			logger.Warn().Err(err).Msg("error building k6RefID")
 		} else {
 			args = append(args, "-e", k6CloudPushRefIDEnvVar+"="+k6RefID)
 		}

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -320,10 +320,11 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFil
 type k6RefID struct {
 	Job      string `json:"job"`
 	Instance string `json:"instance"`
+	Probe    string `json:"probe"`
 }
 
 func buildK6RefID(ci CheckInfo) (string, error) {
-	b, err := json.Marshal(k6RefID{Job: ci.Job, Instance: ci.Instance})
+	b, err := json.Marshal(k6RefID{Job: ci.Job, Instance: ci.Instance, Probe: ci.Probe})
 	if err != nil {
 		return "", err
 	}

--- a/internal/k6runner/local_test.go
+++ b/internal/k6runner/local_test.go
@@ -152,12 +152,13 @@ func TestBuildK6ArgsK6RefID(t *testing.T) {
 		scriptFn  = "/tmp/script.js"
 	)
 
-	browserScript := func(job, instance string) Script {
+	browserScript := func(job, instance, probe string) Script {
 		return Script{
 			CheckInfo: CheckInfo{
 				Type:     synthetic_monitoring.CheckTypeBrowser.String(),
 				Job:      job,
 				Instance: instance,
+				Probe:    probe,
 			},
 		}
 	}
@@ -166,9 +167,9 @@ func TestBuildK6ArgsK6RefID(t *testing.T) {
 		script     Script
 		expK6RefID string // empty means the flag must be absent
 	}{
-		"browser check with job and instance": {
-			script:     browserScript("my-job", "https://example.com"),
-			expK6RefID: `{"job":"my-job","instance":"https://example.com"}`,
+		"browser check with job, instance and probe": {
+			script:     browserScript("my-job", "https://example.com", "probe-a"),
+			expK6RefID: `{"job":"my-job","instance":"https://example.com","probe":"probe-a"}`,
 		},
 		"non-browser check with job and instance": {
 			script: Script{
@@ -176,6 +177,7 @@ func TestBuildK6ArgsK6RefID(t *testing.T) {
 					Type:     synthetic_monitoring.CheckTypeScripted.String(),
 					Job:      "my-job",
 					Instance: "https://example.com",
+					Probe:    "probe-a",
 				},
 			},
 		},

--- a/internal/k6runner/local_test.go
+++ b/internal/k6runner/local_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"slices"
 	"testing"
+
+	"github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
 func TestCreateSecretConfigFile(t *testing.T) {
@@ -138,6 +140,74 @@ func TestBuildK6Args(t *testing.T) {
 				if !slices.Contains(args, want) {
 					t.Errorf("buildK6Args() missing expected argument got \n%v\nwant \n%v", args, want)
 				}
+			}
+		})
+	}
+}
+
+func TestBuildK6ArgsK6RefID(t *testing.T) {
+	const (
+		metricsFn = "/tmp/metrics.json"
+		logsFn    = "/tmp/logs.log"
+		scriptFn  = "/tmp/script.js"
+	)
+
+	browserScript := func(job, instance string) Script {
+		return Script{
+			CheckInfo: CheckInfo{
+				Type:     synthetic_monitoring.CheckTypeBrowser.String(),
+				Job:      job,
+				Instance: instance,
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		script     Script
+		expK6RefID string // empty means the flag must be absent
+	}{
+		"browser check with job and instance": {
+			script:     browserScript("my-job", "https://example.com"),
+			expK6RefID: `{"job":"my-job","instance":"https://example.com"}`,
+		},
+		"non-browser check with job and instance": {
+			script: Script{
+				CheckInfo: CheckInfo{
+					Type:     synthetic_monitoring.CheckTypeScripted.String(),
+					Job:      "my-job",
+					Instance: "https://example.com",
+				},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := Local{}
+			args, err := r.buildK6Args(tt.script, metricsFn, logsFn, scriptFn, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var (
+				idx        = slices.Index(args, "-e")
+				expPresent = tt.expK6RefID != ""
+				expK6RefID = k6CloudPushRefIDEnvVar + "=" + tt.expK6RefID
+			)
+
+			if expPresent {
+				if idx == -1 || idx+1 >= len(args) {
+					t.Fatalf("buildK6Args() expected -e flag, got args: %v", args)
+				}
+				if args[idx+1] != expK6RefID {
+					t.Fatalf("buildK6Args() -e value = %q, want %q", args[idx+1], expK6RefID)
+				}
+
+				return
+			}
+
+			if idx != -1 {
+				t.Errorf("buildK6Args() unexpected -e flag in args: %v", args)
 			}
 		})
 	}

--- a/internal/k6runner/local_test.go
+++ b/internal/k6runner/local_test.go
@@ -171,6 +171,10 @@ func TestBuildK6ArgsK6RefID(t *testing.T) {
 			script:     browserScript("my-job", "https://example.com", "probe-a"),
 			expK6RefID: `{"job":"my-job","instance":"https://example.com","probe":"probe-a"}`,
 		},
+		"ad-hoc browser check": {
+			script:     browserScript("", "https://example.com", "probe-a"), // empty job
+			expK6RefID: "",
+		},
 		"non-browser check with job and instance": {
 			script: Script{
 				CheckInfo: CheckInfo{

--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -30,7 +30,7 @@ type Prober struct {
 	secretsRetriever func(context.Context) (k6runner.SecretStore, error)
 }
 
-func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, store secrets.SecretProvider) (Prober, error) {
+func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, store secrets.SecretProvider, probeName string) (Prober, error) {
 	var p Prober
 
 	if check.Settings.Browser == nil {
@@ -44,7 +44,7 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 			Settings: k6runner.Settings{
 				Timeout: check.Timeout,
 			},
-			CheckInfo: k6runner.CheckInfoFromSM(check),
+			CheckInfo: k6runner.CheckInfoFromSM(check, probeName),
 		},
 	}
 

--- a/internal/prober/browser/browser_test.go
+++ b/internal/prober/browser/browser_test.go
@@ -59,7 +59,7 @@ func TestNewProber(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var runner noopRunner
 			var store testhelper.NoopSecretStore
-			p, err := NewProber(ctx, tc.check, logger, runner, store)
+			p, err := NewProber(ctx, tc.check, logger, runner, store, "probe-a")
 			if tc.expectFailure {
 				require.Error(t, err)
 				return
@@ -69,6 +69,7 @@ func TestNewProber(t *testing.T) {
 			require.Equal(t, proberName, p.module.Prober)
 			require.Equal(t, 10*time.Second, time.Duration(p.module.Script.Settings.Timeout)*time.Millisecond)
 			require.Equal(t, tc.check.Settings.Browser.Script, p.module.Script.Script)
+			require.Equal(t, "probe-a", p.module.Script.CheckInfo.Probe)
 		})
 	}
 }

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -32,7 +32,7 @@ type Prober struct {
 	secretsRetriever func(context.Context) (k6runner.SecretStore, error)
 }
 
-func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, reservedHeaders http.Header, store secrets.SecretProvider) (Prober, error) {
+func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, reservedHeaders http.Header, store secrets.SecretProvider, probeName string) (Prober, error) {
 	var p Prober
 
 	if check.Settings.Multihttp == nil {
@@ -61,7 +61,7 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 			Settings: k6runner.Settings{
 				Timeout: check.Timeout,
 			},
-			CheckInfo:         k6runner.CheckInfoFromSM(check),
+			CheckInfo:         k6runner.CheckInfoFromSM(check, probeName),
 			K6ChannelManifest: multiHTTPManifest,
 		},
 	}

--- a/internal/prober/multihttp/multihttp_test.go
+++ b/internal/prober/multihttp/multihttp_test.go
@@ -128,7 +128,7 @@ func TestNewProber(t *testing.T) {
 			reservedHeaders := http.Header{}
 			reservedHeaders.Add("x-sm-id", fmt.Sprintf("%d-%d", checkId, checkId))
 
-			p, err := NewProber(ctx, tc.check, logger, runner, reservedHeaders, store)
+			p, err := NewProber(ctx, tc.check, logger, runner, reservedHeaders, store, "probe-a")
 			if tc.expectFailure {
 				require.Error(t, err)
 				return
@@ -143,6 +143,7 @@ func TestNewProber(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, proberName, p.module.Prober)
 			require.Equal(t, 10*time.Second, time.Duration(p.module.Script.Settings.Timeout)*time.Millisecond)
+			require.Equal(t, "probe-a", p.module.Script.CheckInfo.Probe)
 			// TODO: check script
 		})
 	}

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -863,7 +863,7 @@ func TestSettingsToScript(t *testing.T) {
 			require.NoError(t, err)
 
 			logger := testhelper.Logger(t)
-			prober, err := NewProber(ctx, check, logger, runner, http.Header{}, &store)
+			prober, err := NewProber(ctx, check, logger, runner, http.Header{}, &store, "")
 			require.NoError(t, err)
 
 			reg := prometheus.NewPedanticRegistry()

--- a/internal/prober/prober.go
+++ b/internal/prober/prober.go
@@ -38,7 +38,7 @@ func Run(ctx context.Context, p Prober, target string, registry *prometheus.Regi
 }
 
 type ProberFactory interface {
-	New(ctx context.Context, logger zerolog.Logger, check model.Check) (Prober, string, error)
+	New(ctx context.Context, logger zerolog.Logger, check model.Check, probeName string) (Prober, string, error)
 }
 
 type proberFactory struct {
@@ -57,7 +57,7 @@ func NewProberFactory(runner k6runner.Runner, probeId int64, features feature.Co
 	}
 }
 
-func (f proberFactory) New(ctx context.Context, logger zerolog.Logger, check model.Check) (Prober, string, error) {
+func (f proberFactory) New(ctx context.Context, logger zerolog.Logger, check model.Check, probeName string) (Prober, string, error) {
 	var (
 		p      Prober
 		target string
@@ -92,7 +92,7 @@ func (f proberFactory) New(ctx context.Context, logger zerolog.Logger, check mod
 
 	case sm.CheckTypeScripted:
 		if f.runner != nil {
-			p, err = scripted.NewProber(ctx, check, logger, f.runner, f.secretStore)
+			p, err = scripted.NewProber(ctx, check, logger, f.runner, f.secretStore, probeName)
 			target = check.Target
 		} else {
 			err = fmt.Errorf("k6 checks are not enabled")
@@ -103,7 +103,7 @@ func (f proberFactory) New(ctx context.Context, logger zerolog.Logger, check mod
 		// we know that the runner is actually able to handle browser
 		// checks.
 		if f.runner != nil {
-			p, err = browser.NewProber(ctx, check, logger, f.runner, f.secretStore)
+			p, err = browser.NewProber(ctx, check, logger, f.runner, f.secretStore, probeName)
 			target = check.Target
 		} else {
 			err = fmt.Errorf("k6 checks are not enabled")
@@ -112,7 +112,7 @@ func (f proberFactory) New(ctx context.Context, logger zerolog.Logger, check mod
 	case sm.CheckTypeMultiHttp:
 		if f.runner != nil {
 			reservedHeaders := f.getReservedHeaders(&check)
-			p, err = multihttp.NewProber(ctx, check, logger, f.runner, reservedHeaders, f.secretStore)
+			p, err = multihttp.NewProber(ctx, check, logger, f.runner, reservedHeaders, f.secretStore, probeName)
 			target = check.Target
 		} else {
 			err = fmt.Errorf("k6 checks are not enabled")

--- a/internal/prober/prober_test.go
+++ b/internal/prober/prober_test.go
@@ -25,7 +25,7 @@ func TestProberFactoryCoverage(t *testing.T) {
 		var check model.Check
 		require.NoError(t, check.FromSM(sm.GetCheckInstance(checkType)))
 
-		_, _, err := pf.New(ctx, testLogger, check)
+		_, _, err := pf.New(ctx, testLogger, check, "")
 		require.NotErrorIs(t, err, errUnsupportedCheckType)
 	}
 }

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -30,7 +30,7 @@ type Prober struct {
 	secretsRetriever func(context.Context) (k6runner.SecretStore, error)
 }
 
-func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, store secrets.SecretProvider) (Prober, error) {
+func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, runner k6runner.Runner, store secrets.SecretProvider, probeName string) (Prober, error) {
 	var p Prober
 
 	if check.Settings.Scripted == nil {
@@ -44,7 +44,7 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 			Settings: k6runner.Settings{
 				Timeout: check.Timeout,
 			},
-			CheckInfo: k6runner.CheckInfoFromSM(check),
+			CheckInfo: k6runner.CheckInfoFromSM(check, probeName),
 		},
 	}
 

--- a/internal/prober/scripted/scripted_test.go
+++ b/internal/prober/scripted/scripted_test.go
@@ -59,7 +59,7 @@ func TestNewProber(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var runner noopRunner
 			var store testhelper.NoopSecretStore
-			p, err := NewProber(ctx, tc.check, logger, runner, store)
+			p, err := NewProber(ctx, tc.check, logger, runner, store, "probe-a")
 			if tc.expectFailure {
 				require.Error(t, err)
 				return
@@ -69,6 +69,7 @@ func TestNewProber(t *testing.T) {
 			require.Equal(t, proberName, p.module.Prober)
 			require.Equal(t, 10*time.Second, time.Duration(p.module.Script.Settings.Timeout)*time.Millisecond)
 			require.Equal(t, tc.check.Settings.Scripted.Script, p.module.Script.Script)
+			require.Equal(t, "probe-a", p.module.Script.CheckInfo.Probe)
 		})
 	}
 }

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -175,7 +175,7 @@ func NewWithOpts(ctx context.Context, check model.Check, opts ScraperOpts) (*Scr
 		Logger()
 
 	sctx, cancel := context.WithCancel(ctx)
-	smProber, target, err := opts.ProbeFactory.New(sctx, logger, check)
+	smProber, target, err := opts.ProbeFactory.New(sctx, logger, check, opts.Probe.Name)
 	if err != nil {
 		cancel()
 		return nil, err

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -482,6 +482,7 @@ func setupScriptedProbe(ctx context.Context, t *testing.T) (prober.Prober, model
 		zerolog.New(zerolog.NewTestWriter(t)),
 		runner,
 		store,
+		"",
 	)
 	if err != nil {
 		t.Fatalf("cannot create scripted prober: %s", err)
@@ -538,6 +539,7 @@ func setupMultiHTTPProbe(ctx context.Context, t *testing.T) (prober.Prober, mode
 		runner,
 		http.Header{},
 		testhelper.NoopSecretStore{},
+		"",
 	)
 	if err != nil {
 		t.Fatalf("cannot create MultiHTTP prober: %s", err)
@@ -586,6 +588,7 @@ func setupBrowserProbe(ctx context.Context, t *testing.T) (prober.Prober, model.
 		zerolog.New(zerolog.NewTestWriter(t)),
 		runner,
 		testhelper.NoopSecretStore{},
+		"",
 	)
 	if err != nil {
 		t.Fatalf("cannot create scripted prober: %s", err)
@@ -1850,10 +1853,12 @@ func (p *testProberB) Probe(ctx context.Context, target string, registry *promet
 }
 
 type testProbeFactory struct {
-	builder func() prober.Prober
+	builder      func() prober.Prober
+	gotProbeName string // captures the probe name received by the most recent New call
 }
 
-func (f testProbeFactory) New(ctx context.Context, logger zerolog.Logger, check model.Check) (prober.Prober, string, error) {
+func (f *testProbeFactory) New(ctx context.Context, logger zerolog.Logger, check model.Check, probeName string) (prober.Prober, string, error) {
+	f.gotProbeName = probeName
 	return f.builder(), check.Target, nil
 }
 
@@ -1901,9 +1906,12 @@ func TestScraperRun(t *testing.T) {
 
 	metrics := NewMetrics(&counter, &errCounter)
 
+	probeFactory := &testProbeFactory{builder: func() prober.Prober { return testProber }}
+
 	s, err := NewWithOpts(ctx, check, ScraperOpts{
+		Probe:        sm.Probe{Name: "my-probe"},
 		Metrics:      metrics,
-		ProbeFactory: testProbeFactory{builder: func() prober.Prober { return testProber }},
+		ProbeFactory: probeFactory,
 		Logger:       zerolog.New(zerolog.NewTestWriter(t)),
 		Publisher:    &testPublisher{},
 		LabelsLimiter: testLabelsLimiter{
@@ -1918,6 +1926,7 @@ func TestScraperRun(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, s)
+	require.Equal(t, "my-probe", probeFactory.gotProbeName, "scraper must forward opts.Probe.Name to the prober factory")
 
 	s.Run(ctx)
 


### PR DESCRIPTION
Sets the `K6_CLOUD_PUSH_REF_ID` environment variable within the k6 test script runtime for browser checks, referencing the check's _job_, _instance_, and _probe_ (by now as a JSON object serialization). This variable is automatically parsed by k6 runtime and set as `window.k6` property within the web page DOM for every page visited by the browser check execution.

The purpose of this is to establish a correlation between a FE O11y browser session and Synthetic Monitoring check execution.

This PR also propagates the updated `CheckInfo`, containing the check's `job`, `instance`, and `probe` to the remote HTTP runner.

Depends on grafana/synthetic-monitoring/issues/505
Updates grafana/synthetic-monitoring/issues/506

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `ProberFactory`/`NewProber` call chain and the k6 local runner invocation, so regressions could prevent checks (especially k6-backed ones) from starting or could change runner behavior for browser executions.
> 
> **Overview**
> Adds probe/job/instance context to k6 executions by extending `k6runner.CheckInfo` and threading a `probeName` parameter through `ProberFactory.New` and all k6-backed probers (scripted, multihttp, browser), including scraper and ad-hoc flows.
> 
> For **local** k6 browser checks, `Local.buildK6Args` now injects `K6_CLOUD_PUSH_REF_ID` (JSON containing `job`, `instance`, `probe`) via `-e`, enabling frontend observability correlation; non-browser checks keep the existing single-iteration flags. Tests are updated/added to validate the new fields and argument behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3df23f580c723869f81d6643d93306052ec9ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->