### PR TITLE
chore: Update dependency grafana/xk6-sm to v1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG HOST_DIST=$TARGETOS-$TARGETARCH
 
 RUN adduser -D -u 12345 -g 12345 sm
 
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.6.20/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v1.0.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -23,7 +23,7 @@ ARG HOST_DIST=$TARGETOS-$TARGETARCH
 
 RUN adduser -D -u 12345 -g 12345 sm
 
-ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v0.6.20/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
+ADD --chown=sm:sm --chmod=0500 https://github.com/grafana/xk6-sm/releases/download/v1.0.0/sm-k6-${TARGETOS}-${TARGETARCH} /usr/libexec/sm-k6/k6-v1
 COPY --chown=sm:sm --chmod=0500 --from=setcapper /usr/local/bin/synthetic-monitoring-agent /usr/local/bin/synthetic-monitoring-agent
 COPY --chown=sm:sm scripts/pre-stop.sh /usr/local/lib/synthetic-monitoring-agent/pre-stop.sh
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/scripts/make/960_sm-k6.mk
+++ b/scripts/make/960_sm-k6.mk
@@ -8,7 +8,7 @@ define sm-k6-binary
 $(DISTDIR)/$(1)-$(2)/k6-v1:
 	mkdir -p "$(DISTDIR)/$(1)-$(2)"
 	# Renovate updates the following line. Keep its syntax as it is.
-	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v0.6.20/sm-k6-$(1)-$(2) -o "$$@"
+	curl -sSL https://github.com/grafana/xk6-sm/releases/download/v1.0.0/sm-k6-$(1)-$(2) -o "$$@"
 	chmod +x "$$@"
 
 sm-k6: $(DISTDIR)/$(1)-$(2)/k6-v1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrades the bundled `sm-k6` binary to a new major version, which could change runtime behavior of synthetic checks despite being a small, localized build-time change.
> 
> **Overview**
> Updates the packaged `sm-k6`/`xk6-sm` binary download URL from `v0.6.20` to `v1.0.0` in both `Dockerfile`/`Dockerfile.build` and the `sm-k6` Makefile target, so builds and images ship the new major release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dec6e18718fe42ae4926c8386047507e0cebabf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->