### PR TITLE
fix: Replace deprecated k6 `--no-summary` option

### DIFF
--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -272,7 +272,7 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFil
 		"--no-thresholds",
 		"--no-usage-report",
 		"--no-color",
-		"--no-summary",
+		"--summary-mode", "disabled",
 		"--verbose",
 		"--throw", // Abort with an exception on certain abnormal cases: https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/#throw
 	}


### PR DESCRIPTION
Replaces the k6 `--no-summary` option for the equivalent `--summary-mode=disabled`.
Reference: https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/#summary-mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single CLI flag change that should preserve existing behavior while improving compatibility with newer k6 versions.
> 
> **Overview**
> Updates `internal/k6runner/local.go` to stop passing the deprecated k6 `--no-summary` flag and instead disable summaries via `--summary-mode disabled`, keeping the runner compatible with current k6 option names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7162f3c45d6a45e74e8bbe66b138dd10c3b096f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->