### PR TITLE
feat: Reject k6 scripts containing pragma directives

### DIFF
--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -20,6 +20,7 @@ package synthetic_monitoring
 //go:generate ../../../scripts/enumer -type=MultiHttpEntryAssertionType,MultiHttpEntryAssertionSubjectVariant,MultiHttpEntryAssertionConditionVariant,MultiHttpEntryVariableType -trimprefix=MultiHttpEntryAssertionType_,MultiHttpEntryAssertionSubjectVariant_,MultiHttpEntryAssertionConditionVariant_,MultiHttpEntryVariableType_ -transform=upper -output=multihttp_string.go
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -89,7 +90,8 @@ var (
 
 	ErrInvalidTracerouteHostname = errors.New("invalid traceroute hostname")
 
-	ErrInvalidK6Script = errors.New("invalid K6 script")
+	ErrInvalidK6Script        = errors.New("invalid K6 script")
+	ErrK6ScriptContainsPragma = errors.New("k6 script contains unsupported pragma")
 
 	ErrInvalidMultiHttpTargets = errors.New("invalid multi-http targets")
 
@@ -177,6 +179,22 @@ const (
 // to create special internal checks or metrics that are distinct from user-defined ones.
 // User-provided checks with this marker will be rejected during validation.
 const internalMarker = "__internal__"
+
+// k6 pragma detection patterns, sourced from github.com/grafana/k6deps (dependencies.go).
+const (
+	k6PragmaName       = `(?:k6|k6/[^/]{2}.*|k6/[^x]/.*|k6/x/[/0-9a-zA-Z_-]+|(?:@[a-zA-Z0-9-_]+/)?xk6-(?:[a-zA-Z0-9-_]+)(?:/[a-zA-Z0-9-_]+)*)`
+	k6PragmaConstraint = `=?v?0\.0\.0\+[0-9A-Za-z-]+|[vxX*|,&\^0-9.+-><=, ~]+`
+)
+
+var (
+	// matches any sequence of characters enclosed by '/*' and '*/' including new lines and '*' not followed by '/'
+	reK6MultiLineComment = regexp.MustCompile(`\/\*(?:[^\*]|\*[^\/]|\n)*(\*)+\/`)
+	// matches '//' and any character until end of line skips the '//' sequence in urls (preceded by ':')
+	reK6CommentLine = regexp.MustCompile(`(^|\s|[^:])(//.*)`)
+	reK6Pragma      = regexp.MustCompile(
+		`"use +k6(( with ` + k6PragmaName + `( *(?:` + k6PragmaConstraint + `))?)|(( *(?:` + k6PragmaConstraint + `)?)))"`,
+	)
+)
 
 // MaxAgentMetricLabels returns the maximum number of labels set by the agent
 // to any metric.
@@ -709,6 +727,10 @@ func (s *ScriptedSettings) Validate() error {
 		return ErrInvalidK6Script
 	}
 
+	if scriptContainsK6Pragma(s.Script) {
+		return ErrK6ScriptContainsPragma
+	}
+
 	return nil
 }
 
@@ -737,7 +759,18 @@ func (s *BrowserSettings) Validate() error {
 		return ErrInvalidK6Script
 	}
 
+	if scriptContainsK6Pragma(s.Script) {
+		return ErrK6ScriptContainsPragma
+	}
+
 	return nil
+}
+
+func scriptContainsK6Pragma(script []byte) bool {
+	clean := bytes.ReplaceAll(script, []byte("\r\n"), []byte("\n"))
+	clean = reK6MultiLineComment.ReplaceAll(clean, []byte(""))
+	clean = reK6CommentLine.ReplaceAll(clean, []byte("$1"))
+	return reK6Pragma.Match(clean)
 }
 
 func hasUniqueValues[U any, V comparable](slice []U, fn func(U) V) bool {

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -1075,7 +1075,7 @@ func TestValidateHttpUrl(t *testing.T) {
 			expectError: true,
 		},
 		"with username and password": {
-			input:       "http://user:password@example.org/",
+			input:       "http://user:password@example.org/", // trufflehog:ignore
 			expectError: true,
 		},
 

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -2075,3 +2075,113 @@ func TestRemoteInfoMarshalJSON(t *testing.T) {
 	actual := strings.TrimSpace(buf.String())
 	require.Equal(t, expected, actual, "JSON encoding of RemoteInfo did not match expected output")
 }
+
+func TestScriptedSettingsValidate(t *testing.T) {
+	testcases := map[string]struct {
+		input    ScriptedSettings
+		expError error
+	}{
+		"empty script": {
+			input:    ScriptedSettings{},
+			expError: ErrInvalidK6Script,
+		},
+		"valid script": {
+			input:    ScriptedSettings{Script: []byte(`export default function() {}`)},
+			expError: nil,
+		},
+		"k6 version pragma": {
+			input:    ScriptedSettings{Script: []byte("\"use k6 > 0.54\";\nexport default function() {}")},
+			expError: ErrK6ScriptContainsPragma,
+		},
+		"k6 extension pragma": {
+			input:    ScriptedSettings{Script: []byte("\"use k6 with k6/x/faker > 0.4.0\";\nexport default function() {}")},
+			expError: ErrK6ScriptContainsPragma,
+		},
+		"bare k6 pragma": {
+			input:    ScriptedSettings{Script: []byte("\"use k6\";\nexport default function() {}")},
+			expError: ErrK6ScriptContainsPragma,
+		},
+		"pragma in multiline comment": {
+			input:    ScriptedSettings{Script: []byte("/* \"use k6 > 0.54\"; */\nexport default function() {}")},
+			expError: nil,
+		},
+		"pragma in single-line comment": {
+			input:    ScriptedSettings{Script: []byte("// \"use k6 > 0.54\";\nexport default function() {}")},
+			expError: nil,
+		},
+		"use strict is not a pragma": {
+			input:    ScriptedSettings{Script: []byte("\"use strict\";\nexport default function() {}")},
+			expError: nil,
+		},
+		"k6 import without pragma": {
+			input:    ScriptedSettings{Script: []byte("import http from \"k6/http\";\nexport default function() {}")},
+			expError: nil,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.input.Validate()
+			if tc.expError != nil {
+				require.ErrorIs(t, err, tc.expError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBrowserSettingsValidate(t *testing.T) {
+	testcases := map[string]struct {
+		input    BrowserSettings
+		expError error
+	}{
+		"empty script": {
+			input:    BrowserSettings{},
+			expError: ErrInvalidK6Script,
+		},
+		"valid script": {
+			input:    BrowserSettings{Script: []byte(`export default function() {}`)},
+			expError: nil,
+		},
+		"k6 version pragma": {
+			input:    BrowserSettings{Script: []byte("\"use k6 > 0.54\";\nexport default function() {}")},
+			expError: ErrK6ScriptContainsPragma,
+		},
+		"k6 extension pragma": {
+			input:    BrowserSettings{Script: []byte("\"use k6 with k6/x/faker > 0.4.0\";\nexport default function() {}")},
+			expError: ErrK6ScriptContainsPragma,
+		},
+		"bare k6 pragma": {
+			input:    BrowserSettings{Script: []byte("\"use k6\";\nexport default function() {}")},
+			expError: ErrK6ScriptContainsPragma,
+		},
+		"pragma in multiline comment": {
+			input:    BrowserSettings{Script: []byte("/* \"use k6 > 0.54\"; */\nexport default function() {}")},
+			expError: nil,
+		},
+		"pragma in single-line comment": {
+			input:    BrowserSettings{Script: []byte("// \"use k6 > 0.54\";\nexport default function() {}")},
+			expError: nil,
+		},
+		"use strict is not a pragma": {
+			input:    BrowserSettings{Script: []byte("\"use strict\";\nexport default function() {}")},
+			expError: nil,
+		},
+		"k6 import without pragma": {
+			input:    BrowserSettings{Script: []byte("import http from \"k6/http\";\nexport default function() {}")},
+			expError: nil,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			err := tc.input.Validate()
+			if tc.expError != nil {
+				require.ErrorIs(t, err, tc.expError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/pb/synthetic_monitoring/checks_extra_test.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra_test.go
@@ -2076,111 +2076,67 @@ func TestRemoteInfoMarshalJSON(t *testing.T) {
 	require.Equal(t, expected, actual, "JSON encoding of RemoteInfo did not match expected output")
 }
 
-func TestScriptedSettingsValidate(t *testing.T) {
+// TestK6ScriptSettingsValidate validates common restrictions fro k6 scripts in
+// scripted and browser settings.
+func TestK6ScriptSettingsValidate(t *testing.T) {
 	testcases := map[string]struct {
-		input    ScriptedSettings
+		script   []byte
 		expError error
 	}{
 		"empty script": {
-			input:    ScriptedSettings{},
+			script:   nil,
 			expError: ErrInvalidK6Script,
 		},
 		"valid script": {
-			input:    ScriptedSettings{Script: []byte(`export default function() {}`)},
+			script:   []byte(`export default function() {}`),
 			expError: nil,
 		},
 		"k6 version pragma": {
-			input:    ScriptedSettings{Script: []byte("\"use k6 > 0.54\";\nexport default function() {}")},
+			script:   []byte("\"use k6 > 0.54\";\nexport default function() {}"),
 			expError: ErrK6ScriptContainsPragma,
 		},
 		"k6 extension pragma": {
-			input:    ScriptedSettings{Script: []byte("\"use k6 with k6/x/faker > 0.4.0\";\nexport default function() {}")},
+			script:   []byte("\"use k6 with k6/x/faker > 0.4.0\";\nexport default function() {}"),
 			expError: ErrK6ScriptContainsPragma,
 		},
 		"bare k6 pragma": {
-			input:    ScriptedSettings{Script: []byte("\"use k6\";\nexport default function() {}")},
+			script:   []byte("\"use k6\";\nexport default function() {}"),
 			expError: ErrK6ScriptContainsPragma,
 		},
-		"pragma in multiline comment": {
-			input:    ScriptedSettings{Script: []byte("/* \"use k6 > 0.54\"; */\nexport default function() {}")},
+		"pragma in multiline comment is allowed": {
+			script:   []byte("/* \"use k6 > 0.54\"; */\nexport default function() {}"),
 			expError: nil,
 		},
-		"pragma in single-line comment": {
-			input:    ScriptedSettings{Script: []byte("// \"use k6 > 0.54\";\nexport default function() {}")},
+		"pragma in single-line comment is allowed": {
+			script:   []byte("// \"use k6 > 0.54\";\nexport default function() {}"),
 			expError: nil,
 		},
 		"use strict is not a pragma": {
-			input:    ScriptedSettings{Script: []byte("\"use strict\";\nexport default function() {}")},
+			script:   []byte("\"use strict\";\nexport default function() {}"),
 			expError: nil,
 		},
 		"k6 import without pragma": {
-			input:    ScriptedSettings{Script: []byte("import http from \"k6/http\";\nexport default function() {}")},
+			script:   []byte("import http from \"k6/http\";\nexport default function() {}"),
 			expError: nil,
 		},
 	}
 
-	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			err := tc.input.Validate()
-			if tc.expError != nil {
-				require.ErrorIs(t, err, tc.expError)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestBrowserSettingsValidate(t *testing.T) {
-	testcases := map[string]struct {
-		input    BrowserSettings
-		expError error
-	}{
-		"empty script": {
-			input:    BrowserSettings{},
-			expError: ErrInvalidK6Script,
-		},
-		"valid script": {
-			input:    BrowserSettings{Script: []byte(`export default function() {}`)},
-			expError: nil,
-		},
-		"k6 version pragma": {
-			input:    BrowserSettings{Script: []byte("\"use k6 > 0.54\";\nexport default function() {}")},
-			expError: ErrK6ScriptContainsPragma,
-		},
-		"k6 extension pragma": {
-			input:    BrowserSettings{Script: []byte("\"use k6 with k6/x/faker > 0.4.0\";\nexport default function() {}")},
-			expError: ErrK6ScriptContainsPragma,
-		},
-		"bare k6 pragma": {
-			input:    BrowserSettings{Script: []byte("\"use k6\";\nexport default function() {}")},
-			expError: ErrK6ScriptContainsPragma,
-		},
-		"pragma in multiline comment": {
-			input:    BrowserSettings{Script: []byte("/* \"use k6 > 0.54\"; */\nexport default function() {}")},
-			expError: nil,
-		},
-		"pragma in single-line comment": {
-			input:    BrowserSettings{Script: []byte("// \"use k6 > 0.54\";\nexport default function() {}")},
-			expError: nil,
-		},
-		"use strict is not a pragma": {
-			input:    BrowserSettings{Script: []byte("\"use strict\";\nexport default function() {}")},
-			expError: nil,
-		},
-		"k6 import without pragma": {
-			input:    BrowserSettings{Script: []byte("import http from \"k6/http\";\nexport default function() {}")},
-			expError: nil,
-		},
+	validators := map[string]func([]byte) validatable{
+		"scripted": func(s []byte) validatable { return &ScriptedSettings{Script: s} },
+		"browser":  func(s []byte) validatable { return &BrowserSettings{Script: s} },
 	}
 
-	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			err := tc.input.Validate()
-			if tc.expError != nil {
-				require.ErrorIs(t, err, tc.expError)
-			} else {
-				require.NoError(t, err)
+	for checkType, newSettings := range validators {
+		t.Run(checkType, func(t *testing.T) {
+			for name, tc := range testcases {
+				t.Run(name, func(t *testing.T) {
+					err := newSettings(tc.script).Validate()
+					if tc.expError != nil {
+						require.ErrorIs(t, err, tc.expError)
+					} else {
+						require.NoError(t, err)
+					}
+				})
 			}
 		})
 	}


### PR DESCRIPTION
Pragma directives are not supported by Synthetic Monitoring, and frobidden by the Grafana Cloud app. This commits includes validation for the backend.

Updates grafana/synthetic-monitoring/issues/566

---
#### Notes for reviewer
The implementation uses the same regex and comment-stripping logic from [github.com/grafana/k6deps](https://github.com/grafana/k6deps/blob/d300092847f3f53239a89dfe32a0271df46c4802/dependencies.go#L13-L37).

The regex definitions are copied here rather than imported for two reasons:
- The k6deps UnmarshalJS API parses both _imports_ and _pragmas_ into the same `Dependencies` map without distinguishing them. So we can't reliably detect all pragma forms.
- The k6deps module transitively depends on esbuild (used for JS bundling in its Analyze() path). Since we only need a regex match, importing the module would add ~40MB to the module cache for no compiled benefit. The practical cost is small (cached download, no binary size impact), but unnecessary.

The `use k6 ...` pragma syntax is a stable part of the k6 spec, so drift risk from the copied regex is low.

An alternative would be adding an exported `ContainsPragma()` function to k6deps and importing it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens validation on user-supplied k6 scripts and can cause previously accepted scripted/browser checks to be rejected if they include pragmas; risk is limited to these validation paths and is covered by new tests.
> 
> **Overview**
> **Scripted and browser checks now reject k6 pragma directives.** `ScriptedSettings.Validate` and `BrowserSettings.Validate` fail with a new `ErrK6ScriptContainsPragma` when the script contains `"use k6 ..."` pragmas.
> 
> This introduces regex-based pragma detection (with normalization and comment stripping) to avoid false positives in `//` and `/* */` comments, and adds unit tests covering valid scripts, multiple pragma forms, and comment-handling behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4577b0ca78bb85ca87db7c0058fabdb013663a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->