### PR TITLE
fix: Include channels when running adhoc checks

### DIFF
--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -430,6 +430,7 @@ func (h *Handler) defaultRunnerFactory(ctx context.Context, req *sm.AdHocRequest
 			Target:   req.AdHocCheck.Target,
 			Timeout:  req.AdHocCheck.Timeout,
 			Settings: req.AdHocCheck.Settings,
+			Channels: req.AdHocCheck.Channels,
 
 			// All the following fields are not used for ad-hoc checks.
 			Id:               0, // ad-hoc checks don't have an ID in this sense.


### PR DESCRIPTION
Fixes the default runner factory for adhoc checks by including the channels definition sent by the API in the actual check that will be run by the probe.

This supports adhoc checks running with particularly specified channel versions.

Follow-up to #1750
Related: grafana/synthetic-monitoring-api/pull/2018
Updates: grafana/synthetic-monitoring/issues/493

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small data-mapping fix that only affects how ad-hoc check requests are translated into the internal `sm.Check` before execution.
> 
> **Overview**
> Ensures ad-hoc checks honor the `channels` specified by the API by copying `req.AdHocCheck.Channels` into the constructed `sm.Check` in `defaultRunnerFactory`.
> 
> This fixes ad-hoc runs that need to target specific channel versions, without changing execution flow beyond the additional field propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac942f3a986cec6f26837bd1d2f46e95677a64ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->