### PR TITLE
fix: Fix k6 version resolve log timestamp

### DIFF
--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -175,8 +175,10 @@ func (r Local) Run(ctx context.Context, script Script, secretStore SecretStore) 
 
 	// Pre-fill logs buffer with k6 versioning info.
 	logsBuf := &bytes.Buffer{}
-	_, _ = fmt.Fprintf(logsBuf,
-		`level=info k6ChannelManifest=%q k6version=%q k6Path=%q msg="Check will be run with resolved k6 version"`+"\n",
+	_, _ = fmt.Fprintf(
+		logsBuf,
+		`time=%q level=info k6ChannelManifest=%q k6version=%q k6Path=%q msg="Check will be run with resolved k6 version"`+"\n",
+		start.Format(time.RFC3339Nano),
 		script.K6ChannelManifest, k6Version.Version.String(), k6Version.Path,
 	)
 


### PR DESCRIPTION
Include an explicit timestamp in the log line that informs for the k6 resolved version. Set the timestamp to reference `start` time, corresponding to the moment right before running k6 command, so the log line appears right before any k6 execution logs.

Updates grafana/synthetic-monitoring/issues/416

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes formatting of a single preamble log line by adding a timestamp, with no impact on execution flow or data handling.
> 
> **Overview**
> Ensures the synthetic k6 log preamble includes an explicit `time` field so it sorts correctly alongside k6’s own log output.
> 
> The “resolved k6 version” line is now timestamped using the `start` time captured immediately before running the k6 command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa9636df34f5881989e4e455c8bb140317a29e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->