### PR TITLE
fix(workflows): add id-token: write to release-please and publish_images jobs

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -181,6 +181,7 @@ jobs:
     runs-on: ubuntu-x64
     permissions:
       contents: read
+      id-token: write
     outputs:
       image_name: ${{ steps.extract-image-metadata.outputs.image }}
       image_tag: ${{ steps.extract-image-metadata.outputs.tag }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
       - name: Get GitHub App token


### PR DESCRIPTION
create-github-app-token requires id-token: write to mint the OIDC assertion exchanged with GATB.