### PR TITLE
fix(ci): Fix build_and_publish publish images permissions

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -181,6 +181,7 @@ jobs:
     runs-on: ubuntu-x64
     permissions:
       contents: read
+      id-token: write # Needed for push-to-gar
     outputs:
       image_name: ${{ steps.extract-image-metadata.outputs.image }}
       image_tag: ${{ steps.extract-image-metadata.outputs.tag }}


### PR DESCRIPTION
Restore `id-token` permissions, required for push-to-gar.

Updates grafana/synthetic-monitoring/issues/587