### PR TITLE
feat: Run multihttp checks with k6 v2

### DIFF
--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -52,7 +52,10 @@ func NewProber(ctx context.Context, check model.Check, logger zerolog.Logger, ru
 		return p, err
 	}
 
-	const multiHTTPManifest = "^1.0.0" // From v1 and up to, but _not_ including, v2.
+	// Use latest k6 version available.
+	// TestSettingsToScript verifies that multihttp implementation is
+	// compatible with each supported k6 version.
+	const multiHTTPManifest = "*"
 
 	p.module = Module{
 		Prober: sm.CheckTypeMultiHttp.String(),

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -847,14 +847,9 @@ func TestSettingsToScript(t *testing.T) {
 		},
 	}
 
+	// Run tests for each supported k6 version.
 	for _, k6path := range testhelper.K6Paths(t) {
 		t.Run(filepath.Base(k6path), func(t *testing.T) {
-			// TODO: By now, multiHTTP are forced to run with xk6-sm v1.
-			// See https://github.com/grafana/synthetic-monitoring-agent/blob/26438a93be8af6523fb38a9d0affd1cfc07f438a/internal/prober/multihttp/multihttp.go#L55
-			if strings.Contains(k6path, "v2") {
-				t.Skip("multihttp checks are forced to run with xk6-sm v1")
-			}
-
 			ctx, cancel := testhelper.Context(context.Background(), t)
 			t.Cleanup(cancel)
 


### PR DESCRIPTION
Sets the multihttp k6 channel manifest to `*`, which will force the agent and runners to use the latest available k6 version.

This allows us to avoid having to update the manifest for each new k6 version. It does introduce the risk that a new version breaks the multihttp implementation, however that should be caught by `TestSettingsToScript` which now runs test cases for every supported k6 version by the agent. This does not cover specifically the k6 runner's path, but arguably that upgrade will be performed within the same process as the agent k6 version upgrade, which will allow us to catch it without relying on external tests to this repo, even if these also exist in the form of e2e tests.

Closes grafana/synthetic-monitoring/issues/538