### PR TITLE
fix: Make curl fail if it cannot download k6

### DIFF
--- a/scripts/make/960_sm-k6.mk
+++ b/scripts/make/960_sm-k6.mk
@@ -19,7 +19,7 @@ sm-k6-native:
 define sm-k6-binary
 $(DISTDIR)/$(1)-$(2)/k6-$(3):
 	mkdir -p "$(DISTDIR)/$(1)-$(2)"
-	curl -sSL https://github.com/grafana/xk6-sm/releases/download/$(4)/sm-k6-$(1)-$(2) -o "$$@"
+	curl -fsSL https://github.com/grafana/xk6-sm/releases/download/$(4)/sm-k6-$(1)-$(2) -o "$$@"
 	chmod +x "$$@"
 
 sm-k6: $(DISTDIR)/$(1)-$(2)/k6-$(3)


### PR DESCRIPTION
curl defaults to not failing when it cannot download the target. You have to pass --fail (or -f).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single build-script flag change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> The **sm-k6** Makefile target now passes **`curl -f`** when fetching platform binaries from GitHub releases, so failed downloads (404, etc.) stop the build instead of writing an error page and continuing.
> 
> This is a one-flag change on the existing **`curl -fsSL`** invocation in `scripts/make/960_sm-k6.mk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ed1e3ba89b6de44efed930679f4fd0c3bf516a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->