### PR TITLE
feat: Set k6 ref. id as check execution ID for browser checks run by local runner

### DIFF
--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	prompb "github.com/prometheus/prometheus/prompb"
 	"github.com/rs/zerolog"
@@ -517,9 +518,12 @@ func (l *jsonLogger) Log(keyvals ...any) error {
 func (r *runner) Run(ctx context.Context, tenantId model.GlobalID, publisher pusher.Publisher) {
 	r.logger.Info().Msg("running ad-hoc check")
 
-	registry := prometheus.NewRegistry()
-
-	logger := &jsonLogger{}
+	var (
+		logger   = &jsonLogger{}
+		registry = prometheus.NewRegistry()
+		// This is the execution ID for the check run.
+		executionID = uuid.New().String()
+	)
 
 	// TODO(mem): decide what to do with these metrics.
 	successGauge := prometheus.NewGauge(prometheus.GaugeOpts{
@@ -586,6 +590,9 @@ func (r *runner) Run(ctx context.Context, tenantId model.GlobalID, publisher pus
 					{
 						Timestamp: start,
 						Line:      buf.String(),
+						StructuredMetadata: logproto.LabelsAdapter{
+							{Name: "execution_id", Value: executionID},
+						},
 					},
 				},
 			},

--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -545,7 +545,7 @@ func (r *runner) Run(ctx context.Context, tenantId model.GlobalID, publisher pus
 	rCtx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
 
-	success, duration := r.prober.Probe(rCtx, r.target, registry, logger)
+	success, duration := r.prober.Probe(rCtx, r.target, registry, logger, executionID)
 
 	if success {
 		successGauge.Set(1)

--- a/internal/adhoc/adhoc_test.go
+++ b/internal/adhoc/adhoc_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/google/uuid"
 	"github.com/grafana/synthetic-monitoring-agent/internal/feature"
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober"
@@ -139,8 +140,12 @@ func TestHandlerRun(t *testing.T) {
 	require.Len(t, payload.Metrics(), 0)
 	require.Len(t, payload.Streams(), 1)
 
-	logBody := payload.Streams()[0].Entries[0].Line
-	require.Contains(t, logBody, "ad-hoc check done") // log must publish even when verbose is disabled for check tests
+	entry := payload.Streams()[0].Entries[0]
+	require.Contains(t, entry.Line, "ad-hoc check done") // log must publish even when verbose is disabled for check tests
+	require.Len(t, entry.StructuredMetadata, 1)
+	require.Equal(t, "execution_id", entry.StructuredMetadata[0].Name)
+	_, err = uuid.Parse(entry.StructuredMetadata[0].Value)
+	require.NoError(t, err, "execution_id should be a valid UUID")
 }
 
 type channelPublisher chan pusher.Payload

--- a/internal/adhoc/adhoc_test.go
+++ b/internal/adhoc/adhoc_test.go
@@ -709,7 +709,7 @@ func (r *testK6Runner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (r *testK6Runner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
+func (r *testK6Runner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore, _ string) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }
 

--- a/internal/adhoc/adhoc_test.go
+++ b/internal/adhoc/adhoc_test.go
@@ -410,7 +410,7 @@ func (p *testProber) Name() string {
 	return "test"
 }
 
-func (p *testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+func (p *testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
 	p.logger.Info().Str("func", "Probe").Caller(0).Send()
 	g := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "test",

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -533,7 +533,7 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
+func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore, _ string) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }
 

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -471,7 +471,7 @@ func (testProber) Name() string {
 	return "test-prober"
 }
 
-func (testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+func (testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
 	return false, 0
 }
 

--- a/internal/k6runner/http.go
+++ b/internal/k6runner/http.go
@@ -52,6 +52,7 @@ type HTTPRunRequest struct {
 	Script      `json:",inline"`
 	SecretStore SecretStore `json:",inline"`
 	NotAfter    time.Time   `json:"notAfter"`
+	ExecutionID string      `json:"executionId"`
 }
 
 type RunResponse struct {
@@ -84,7 +85,7 @@ func (r HttpRunner) WithLogger(logger *zerolog.Logger) Runner {
 
 var ErrUnexpectedStatus = errors.New("unexpected status code")
 
-func (r HttpRunner) Run(ctx context.Context, script Script, secretStore SecretStore, _ string) (*RunResponse, error) {
+func (r HttpRunner) Run(ctx context.Context, script Script, secretStore SecretStore, executionID string) (*RunResponse, error) {
 	if r.backoff == 0 {
 		panic("zero backoff, runner is misconfigured, refusing to DoS")
 	}
@@ -119,7 +120,7 @@ func (r HttpRunner) Run(ctx context.Context, script Script, secretStore SecretSt
 
 		attempts += 1
 		var err error
-		response, err = r.request(ctx, script, secretStore)
+		response, err = r.request(ctx, script, secretStore, executionID)
 		if err == nil {
 			r.logger.Debug().Bytes("metrics", response.Metrics).Bytes("logs", response.Logs).Msg("script result")
 			r.metrics.Requests.With(map[string]string{metricLabelSuccess: "1", metricLabelRetriable: ""}).Inc()
@@ -163,7 +164,7 @@ func (r HttpRunner) Run(ctx context.Context, script Script, secretStore SecretSt
 // errRetryable indicates that an error is retryable. It is typically joined with another error.
 var errRetryable = errors.New("retryable")
 
-func (r HttpRunner) request(ctx context.Context, script Script, secretStore SecretStore) (*RunResponse, error) {
+func (r HttpRunner) request(ctx context.Context, script Script, secretStore SecretStore, executionID string) (*RunResponse, error) {
 	checkTimeout := time.Duration(script.Settings.Timeout) * time.Millisecond
 	if checkTimeout == 0 {
 		return nil, ErrNoTimeout
@@ -191,6 +192,7 @@ func (r HttpRunner) request(ctx context.Context, script Script, secretStore Secr
 		Script:      script,
 		SecretStore: secretStore,
 		NotAfter:    notAfter,
+		ExecutionID: executionID,
 	}
 
 	reqBody, err := json.Marshal(runRequest)

--- a/internal/k6runner/http.go
+++ b/internal/k6runner/http.go
@@ -84,7 +84,7 @@ func (r HttpRunner) WithLogger(logger *zerolog.Logger) Runner {
 
 var ErrUnexpectedStatus = errors.New("unexpected status code")
 
-func (r HttpRunner) Run(ctx context.Context, script Script, secretStore SecretStore) (*RunResponse, error) {
+func (r HttpRunner) Run(ctx context.Context, script Script, secretStore SecretStore, _ string) (*RunResponse, error) {
 	if r.backoff == 0 {
 		panic("zero backoff, runner is misconfigured, refusing to DoS")
 	}

--- a/internal/k6runner/http_test.go
+++ b/internal/k6runner/http_test.go
@@ -44,6 +44,7 @@ func TestHttpRunnerRun(t *testing.T) {
 			Settings          Settings  `json:"settings"`
 			NotAfter          time.Time `json:"notAfter"`
 			K6ChannelManifest string    `json:"k6ChannelManifest"`
+			ExecutionID       string    `json:"executionId"`
 		}
 
 		err := json.NewDecoder(r.Body).Decode(&req)
@@ -65,6 +66,13 @@ func TestHttpRunnerRun(t *testing.T) {
 			t.Log("Unexpected empty channel manifest")
 			t.Fail()
 			w.WriteHeader(400) // Use 400 as the client won't retry this failure.
+			return
+		}
+
+		if req.ExecutionID != "test-execution-id" {
+			t.Logf("unexpected executionID: got %q, want %q", req.ExecutionID, "test-execution-id")
+			t.Fail()
+			w.WriteHeader(400)
 			return
 		}
 

--- a/internal/k6runner/http_test.go
+++ b/internal/k6runner/http_test.go
@@ -92,7 +92,7 @@ func TestHttpRunnerRun(t *testing.T) {
 	ctx, cancel := testhelper.Context(ctx, t)
 	t.Cleanup(cancel)
 
-	_, err = runner.Run(ctx, script, SecretStore{})
+	_, err = runner.Run(ctx, script, SecretStore{}, "test-execution-id")
 	require.NoError(t, err)
 }
 
@@ -142,7 +142,7 @@ func TestHttpRunnerRunError(t *testing.T) {
 	ctx, cancel = testhelper.Context(ctx, t)
 	t.Cleanup(cancel)
 
-	_, err = runner.Run(ctx, script, SecretStore{})
+	_, err = runner.Run(ctx, script, SecretStore{}, "test-execution-id")
 	require.ErrorIs(t, err, ErrUnexpectedStatus)
 }
 
@@ -333,7 +333,7 @@ func TestScriptHTTPRun(t *testing.T) {
 				zlogger  = testhelper.Logger(t)
 			)
 
-			success, _, err := script.Run(ctx, registry, logger, zlogger, SecretStore{})
+			success, _, err := script.Run(ctx, registry, logger, zlogger, SecretStore{}, "test-execution-id")
 			require.Equal(t, tc.expectSuccess, success)
 			require.Equal(t, tc.expectLogs, logger.buf.String())
 			if tc.expectErrorAs == nil {
@@ -466,7 +466,7 @@ func TestHTTPProcessorRetries(t *testing.T) {
 					logger   testLogger
 					zlogger  = zerolog.New(io.Discard)
 				)
-				success, _, err := processor.Run(ctx, registry, &logger, zlogger, SecretStore{})
+				success, _, err := processor.Run(ctx, registry, &logger, zlogger, SecretStore{}, "test-execution-id")
 				require.ErrorIs(t, err, tc.expectError)
 				require.Equal(t, tc.expectError == nil, success)
 				require.Equal(t, tc.expectRequests, requests.Load())
@@ -512,7 +512,7 @@ func TestHTTPProcessorRetries(t *testing.T) {
 			logger   testLogger
 			zlogger  = zerolog.New(io.Discard)
 		)
-		success, _, err := processor.Run(ctx, registry, &logger, zlogger, SecretStore{})
+		success, _, err := processor.Run(ctx, registry, &logger, zlogger, SecretStore{}, "test-execution-id")
 		require.NoError(t, err)
 		require.True(t, success)
 	})

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -97,7 +97,7 @@ type Runner interface {
 	// WithLogger returns a copy of the runner configured to use the specified logger.
 	WithLogger(logger *zerolog.Logger) Runner
 	// Run makes the runner run the script.
-	Run(ctx context.Context, script Script, secretStore SecretStore) (*RunResponse, error)
+	Run(ctx context.Context, script Script, secretStore SecretStore, executionID string) (*RunResponse, error)
 	// Versions returns a channel to which the list of versions supported by this runner are pushed. Runner
 	// implementations that have a predictable list of versions over time may push a single list to the channel and then
 	// close it, while others may push lists of versions regularly as a result of polling a decoupled system.
@@ -170,11 +170,11 @@ var (
 	ErrFromRunner  = errors.New("runner reported an error")
 )
 
-func (r Processor) Run(ctx context.Context, registry *prometheus.Registry, logger logger.Logger, internalLogger zerolog.Logger, secretStore SecretStore) (bool, time.Duration, error) {
+func (r Processor) Run(ctx context.Context, registry *prometheus.Registry, logger logger.Logger, internalLogger zerolog.Logger, secretStore SecretStore, executionID string) (bool, time.Duration, error) {
 	k6runner := r.runner.WithLogger(&internalLogger)
 
 	// TODO: This error message is okay to be Debug for local k6 execution, but should be Error for remote runners.
-	result, err := k6runner.Run(ctx, r.script, secretStore)
+	result, err := k6runner.Run(ctx, r.script, secretStore, executionID)
 	if err != nil {
 		internalLogger.Debug().
 			Err(err).

--- a/internal/k6runner/k6runner_test.go
+++ b/internal/k6runner/k6runner_test.go
@@ -97,7 +97,7 @@ func TestScriptRun(t *testing.T) {
 	// We already know tha parsing the metrics and the logs is working, so
 	// we are only interested in verifying that the script runs without
 	// errors.
-	success, duration, err := processor.Run(ctx, registry, &logger, zlogger, SecretStore{})
+	success, duration, err := processor.Run(ctx, registry, &logger, zlogger, SecretStore{}, "test-execution-id")
 	require.NoError(t, err)
 	require.True(t, success)
 	require.Equal(t, 500*time.Millisecond, duration)
@@ -138,7 +138,7 @@ type testRunner struct {
 
 var _ Runner = &testRunner{}
 
-func (r *testRunner) Run(ctx context.Context, script Script, secretStore SecretStore) (*RunResponse, error) {
+func (r *testRunner) Run(ctx context.Context, script Script, secretStore SecretStore, _ string) (*RunResponse, error) {
 	return &RunResponse{
 		Metrics: r.metrics,
 		Logs:    r.logs,

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -18,6 +18,13 @@ import (
 	"github.com/spf13/afero"
 )
 
+// k6CloudPushRefIDEnvVar is the name of the k6 runtime environment variable used to
+// tag browser tests as originated from Synthetic Monitoring. It contains a reference
+// to the check's execution ID. k6 will propagate this data to the window.k6 property,
+// which is parsed by FE O11y as a means to correlate between a specific browser session
+// and a check execution.
+const k6CloudPushRefIDEnvVar = "K6_CLOUD_PUSH_REF_ID"
+
 // secretSourceConfig represents the configuration for the secrets store
 type secretSourceConfig struct {
 	URL   string `json:"url"`
@@ -36,7 +43,7 @@ func (r Local) WithLogger(logger *zerolog.Logger) Runner {
 	return r
 }
 
-func (r Local) Run(ctx context.Context, script Script, secretStore SecretStore, _ string) (*RunResponse, error) {
+func (r Local) Run(ctx context.Context, script Script, secretStore SecretStore, executionID string) (*RunResponse, error) {
 	logger := r.logger.With().
 		Object("checkInfo", &script.CheckInfo).
 		Str("k6ChannelManifest", script.K6ChannelManifest).
@@ -118,7 +125,7 @@ func (r Local) Run(ctx context.Context, script Script, secretStore SecretStore, 
 		logger.Warn().Msg("No secret store configuration available")
 	}
 
-	args, err := r.buildK6Args(script, metricsFn, logsFn, scriptFn, configFile)
+	args, err := r.buildK6Args(script, metricsFn, logsFn, scriptFn, configFile, executionID)
 	if err != nil {
 		return nil, fmt.Errorf("building k6 arguments: %w", err)
 	}
@@ -255,7 +262,17 @@ func (r Local) Versions(ctx context.Context) <-chan []string {
 	return ch
 }
 
-func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFile string) ([]string, error) {
+func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFile, executionID string) ([]string, error) {
+	var (
+		logger    *zerolog.Logger
+		nopLogger = zerolog.Nop()
+	)
+	if r.logger != nil {
+		logger = r.logger
+	} else {
+		logger = &nopLogger
+	}
+
 	args := []string{
 		"run",
 		"--out", "sm=" + metricsFn,
@@ -282,16 +299,20 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFil
 	// Add secretStore configuration if available
 	if configFile != "" {
 		args = append(args, "--secret-source", "grafanasecrets=config="+configFile)
-		if r.logger != nil {
-			r.logger.Debug().
-				Str("configFile", configFile).
-				Msg("Adding secret source configuration to k6")
-		}
-	} else if r.logger != nil {
-		r.logger.Debug().Msg("No secret source configuration to add to k6")
+		logger.Debug().Str("configFile", configFile).Msg(
+			"Adding secret source configuration to k6",
+		)
+	} else {
+		logger.Debug().Msg("No secret source configuration to add to k6")
 	}
 
-	if script.CheckInfo.Type != synthetic_monitoring.CheckTypeBrowser.String() {
+	if script.CheckInfo.Type == synthetic_monitoring.CheckTypeBrowser.String() {
+		if k6RefID, err := buildK6RefID(executionID); err != nil {
+			logger.Warn().Err(err).Msg("error building k6RefID")
+		} else {
+			args = append(args, "-e", k6CloudPushRefIDEnvVar+"="+k6RefID)
+		}
+	} else {
 		args = append(args,
 			"--vus", "1",
 			"--iterations", "1",
@@ -301,6 +322,15 @@ func (r Local) buildK6Args(script Script, metricsFn, logsFn, scriptFn, configFil
 	args = append(args, scriptFn)
 
 	return args, nil
+}
+
+// buildK6RefID builds the K6 Cloud Ref. ID by prefixing the
+// Synthetic Monitoring check executionID with "sm:".
+func buildK6RefID(executionID string) (string, error) {
+	if executionID == "" {
+		return "", fmt.Errorf("executionID is empty")
+	}
+	return "sm:" + executionID, nil
 }
 
 func mktemp(fs afero.Fs, dir, pattern string) (string, error) {

--- a/internal/k6runner/local.go
+++ b/internal/k6runner/local.go
@@ -36,7 +36,7 @@ func (r Local) WithLogger(logger *zerolog.Logger) Runner {
 	return r
 }
 
-func (r Local) Run(ctx context.Context, script Script, secretStore SecretStore) (*RunResponse, error) {
+func (r Local) Run(ctx context.Context, script Script, secretStore SecretStore, _ string) (*RunResponse, error) {
 	logger := r.logger.With().
 		Object("checkInfo", &script.CheckInfo).
 		Str("k6ChannelManifest", script.K6ChannelManifest).

--- a/internal/k6runner/local_test.go
+++ b/internal/k6runner/local_test.go
@@ -95,7 +95,9 @@ func TestBuildK6Args(t *testing.T) {
 		scriptFn      string
 		blacklistedIP string
 		configFile    string
+		executionID   string
 		wantArgs      []string
+		wantAbsent    []string
 	}{
 		"script without secrets": {
 			metricsFn:     "/tmp/metrics.json",
@@ -103,11 +105,14 @@ func TestBuildK6Args(t *testing.T) {
 			scriptFn:      "/tmp/script.js",
 			blacklistedIP: "127.0.0.1",
 			configFile:    "",
+			executionID:   "test-exec-id",
 			wantArgs: []string{
 				"--out", "sm=/tmp/metrics.json",
 				"--log-output", "file=/tmp/logs.log",
 				"--blacklist-ip", "127.0.0.1",
+				"--vus", "--iterations",
 			},
+			wantAbsent: []string{k6CloudPushRefIDEnvVar},
 		},
 		"script with secrets": {
 			script:        Script{},
@@ -116,19 +121,47 @@ func TestBuildK6Args(t *testing.T) {
 			scriptFn:      "/tmp/script.js",
 			blacklistedIP: "127.0.0.1",
 			configFile:    configFilename,
+			executionID:   "test-exec-id",
 			wantArgs: []string{
 				"--out", "sm=/tmp/metrics.json",
 				"--log-output", "file=/tmp/logs.log",
 				"--blacklist-ip", "127.0.0.1",
 				"--secret-source", "grafanasecrets=config=" + configFilename,
+				"--vus", "--iterations",
 			},
+			wantAbsent: []string{k6CloudPushRefIDEnvVar},
+		},
+		"browser check sets K6_CLOUD_PUSH_REF_ID": {
+			script: Script{
+				CheckInfo: CheckInfo{Type: "browser"},
+			},
+			metricsFn:     "/tmp/metrics.json",
+			logsFn:        "/tmp/logs.log",
+			scriptFn:      "/tmp/script.js",
+			blacklistedIP: "127.0.0.1",
+			executionID:   "abc-123",
+			wantArgs: []string{
+				"-e", k6CloudPushRefIDEnvVar + "=sm:abc-123",
+			},
+			wantAbsent: []string{"--vus", "--iterations"},
+		},
+		"browser check with empty executionID omits K6_CLOUD_PUSH_REF_ID": {
+			script: Script{
+				CheckInfo: CheckInfo{Type: "browser"},
+			},
+			metricsFn:     "/tmp/metrics.json",
+			logsFn:        "/tmp/logs.log",
+			scriptFn:      "/tmp/script.js",
+			blacklistedIP: "127.0.0.1",
+			executionID:   "",
+			wantAbsent:    []string{k6CloudPushRefIDEnvVar, "--vus", "--iterations"},
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			r := Local{blacklistedIP: tt.blacklistedIP}
-			args, err := r.buildK6Args(tt.script, tt.metricsFn, tt.logsFn, tt.scriptFn, tt.configFile)
+			args, err := r.buildK6Args(tt.script, tt.metricsFn, tt.logsFn, tt.scriptFn, tt.configFile, tt.executionID)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
@@ -139,6 +172,32 @@ func TestBuildK6Args(t *testing.T) {
 					t.Errorf("buildK6Args() missing expected argument got \n%v\nwant \n%v", args, want)
 				}
 			}
+			for _, absent := range tt.wantAbsent {
+				if slices.Contains(args, absent) {
+					t.Errorf("buildK6Args() should not contain %q, got \n%v", absent, args)
+				}
+			}
 		})
 	}
+}
+
+func TestBuildK6RefID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid executionID", func(t *testing.T) {
+		got, err := buildK6RefID("abc-123-def")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "sm:abc-123-def" {
+			t.Errorf("buildK6RefID() = %q, want %q", got, "sm:abc-123-def")
+		}
+	})
+
+	t.Run("empty executionID returns error", func(t *testing.T) {
+		_, err := buildK6RefID("")
+		if err == nil {
+			t.Fatal("expected error for empty executionID, got nil")
+		}
+	})
 }

--- a/internal/k6version/k6version_test.go
+++ b/internal/k6version/k6version_test.go
@@ -21,7 +21,7 @@ var _ k6runner.Runner = (*fakeRunner)(nil)
 
 func (r *fakeRunner) WithLogger(_ *zerolog.Logger) k6runner.Runner { return r }
 
-func (r *fakeRunner) Run(_ context.Context, _ k6runner.Script, _ k6runner.SecretStore) (*k6runner.RunResponse, error) {
+func (r *fakeRunner) Run(_ context.Context, _ k6runner.Script, _ k6runner.SecretStore, _ string) (*k6runner.RunResponse, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -77,14 +77,14 @@ func (p Prober) Name() string {
 	return proberName
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, executionID string) (bool, float64) {
 	secretStore, err := p.secretsRetriever(ctx)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("failed to retrieve secret store")
 		return false, 0
 	}
 
-	success, duration, err := p.processor.Run(ctx, registry, logger, p.logger, secretStore)
+	success, duration, err := p.processor.Run(ctx, registry, logger, p.logger, secretStore, executionID)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0

--- a/internal/prober/browser/browser.go
+++ b/internal/prober/browser/browser.go
@@ -77,7 +77,7 @@ func (p Prober) Name() string {
 	return proberName
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
 	secretStore, err := p.secretsRetriever(ctx)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("failed to retrieve secret store")

--- a/internal/prober/browser/browser_test.go
+++ b/internal/prober/browser/browser_test.go
@@ -80,7 +80,7 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
+func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore, _ string) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }
 

--- a/internal/prober/dns/dns.go
+++ b/internal/prober/dns/dns.go
@@ -51,7 +51,7 @@ func (p Prober) Name() string {
 	return "dns"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
 	cfg := p.config
 
 	if p.experimental {

--- a/internal/prober/dns/dns_test.go
+++ b/internal/prober/dns/dns_test.go
@@ -257,7 +257,7 @@ func TestProberRetries(t *testing.T) {
 	logger := log.NewLogfmtLogger(&buf)
 
 	t0 := time.Now()
-	success, duration := p.Probe(ctx, p.target, registry, logger)
+	success, duration := p.Probe(ctx, p.target, registry, logger, "test-execution-id")
 	t.Log(success, time.Since(t0))
 	require.True(t, success)
 	require.Equal(t, 0, duration)

--- a/internal/prober/grpc/grpc.go
+++ b/internal/prober/grpc/grpc.go
@@ -42,7 +42,7 @@ func (p Prober) Name() string {
 	return "grpc"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, l logger.Logger) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, l logger.Logger, _ string) (bool, float64) {
 	slogger := logger.ToSlog(l)
 	return bbeprober.ProbeGRPC(ctx, target, p.config, registry, slogger), 0
 }

--- a/internal/prober/http/http.go
+++ b/internal/prober/http/http.go
@@ -71,7 +71,7 @@ func (p Prober) Name() string {
 	return "http"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, l logger.Logger) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, l logger.Logger, _ string) (bool, float64) {
 	slogger := logger.ToSlog(l)
 	if p.cacheBustingQueryParamName != "" {
 		// FIXME(mem): the second target argument should be the probe's name

--- a/internal/prober/http/http_test.go
+++ b/internal/prober/http/http_test.go
@@ -238,7 +238,7 @@ func TestProbe(t *testing.T) {
 			prober, err := NewProber(ctx, check, zl, http.Header{}, nil)
 			require.NoError(t, err)
 
-			success, duration := prober.Probe(ctx, check.Target, registry, kl)
+			success, duration := prober.Probe(ctx, check.Target, registry, kl, "test-execution-id")
 			require.Equal(t, tc.expectFailure, !success)
 			require.Equal(t, float64(0), duration)
 

--- a/internal/prober/icmp/icmp.go
+++ b/internal/prober/icmp/icmp.go
@@ -48,7 +48,7 @@ func (p Prober) Name() string {
 	return "ping"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, l logger.Logger) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, l logger.Logger, _ string) (bool, float64) {
 	return probeICMP(ctx, target, p.config, registry, l)
 }
 

--- a/internal/prober/icmp/icmp_test.go
+++ b/internal/prober/icmp/icmp_test.go
@@ -245,7 +245,7 @@ func TestProber(t *testing.T) {
 	logger := log.NewLogfmtLogger(os.Stdout)
 	require.NotNil(t, logger)
 
-	success, duration := prober.Probe(ctx, "127.0.0.1", registry, logger)
+	success, duration := prober.Probe(ctx, "127.0.0.1", registry, logger, "test-execution-id")
 	require.True(t, success)
 	require.Greater(t, duration, float64(0))
 }

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -90,14 +90,14 @@ func (p Prober) Name() string {
 	return proberName
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, executionID string) (bool, float64) {
 	secretStore, err := p.secretsRetriever(ctx)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0
 	}
 
-	success, duration, err := p.processor.Run(ctx, registry, logger, p.logger, secretStore)
+	success, duration, err := p.processor.Run(ctx, registry, logger, p.logger, secretStore, executionID)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0

--- a/internal/prober/multihttp/multihttp.go
+++ b/internal/prober/multihttp/multihttp.go
@@ -90,7 +90,7 @@ func (p Prober) Name() string {
 	return proberName
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
 	secretStore, err := p.secretsRetriever(ctx)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")

--- a/internal/prober/multihttp/multihttp_test.go
+++ b/internal/prober/multihttp/multihttp_test.go
@@ -155,7 +155,7 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
+func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore, _ string) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }
 

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -873,7 +873,7 @@ func TestSettingsToScript(t *testing.T) {
 			userLogger := level.NewFilter(kitlog.NewLogfmtLogger(&buf), level.AllowInfo(), level.SquelchNoLevel(false))
 			require.NotNil(t, userLogger)
 
-			success, duration := prober.Probe(ctx, check.Target, reg, userLogger)
+			success, duration := prober.Probe(ctx, check.Target, reg, userLogger, "test-execution-id")
 
 			t.Log("Log entries:\n" + buf.String())
 

--- a/internal/prober/prober.go
+++ b/internal/prober/prober.go
@@ -30,11 +30,11 @@ const errUnsupportedCheckType = error_types.BasicError("unsupported check type")
 
 type Prober interface {
 	Name() string
-	Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64)
+	Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, executionID string) (bool, float64)
 }
 
-func Run(ctx context.Context, p Prober, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
-	return p.Probe(ctx, target, registry, logger)
+func Run(ctx context.Context, p Prober, target string, registry *prometheus.Registry, logger logger.Logger, executionID string) (bool, float64) {
+	return p.Probe(ctx, target, registry, logger, executionID)
 }
 
 type ProberFactory interface {

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -77,7 +77,7 @@ func (p Prober) Name() string {
 	return proberName
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, executionID string) (bool, float64) {
 	secretStore, err := p.secretsRetriever(ctx)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("failed to retrieve secret store")
@@ -91,7 +91,7 @@ func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.R
 		Bool("hasSecretStoreToken", secretStore.Token != "").
 		Msg("secret store retrieved for scripted probe")
 
-	success, duration, err := p.processor.Run(ctx, registry, logger, p.logger, secretStore)
+	success, duration, err := p.processor.Run(ctx, registry, logger, p.logger, secretStore, executionID)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("running probe")
 		return false, 0

--- a/internal/prober/scripted/scripted.go
+++ b/internal/prober/scripted/scripted.go
@@ -77,7 +77,7 @@ func (p Prober) Name() string {
 	return proberName
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
 	secretStore, err := p.secretsRetriever(ctx)
 	if err != nil {
 		p.logger.Error().Err(err).Msg("failed to retrieve secret store")

--- a/internal/prober/scripted/scripted_test.go
+++ b/internal/prober/scripted/scripted_test.go
@@ -80,7 +80,7 @@ func (noopRunner) WithLogger(logger *zerolog.Logger) k6runner.Runner {
 	return r
 }
 
-func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
+func (noopRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore, _ string) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{}, nil
 }
 

--- a/internal/prober/tcp/tcp.go
+++ b/internal/prober/tcp/tcp.go
@@ -42,7 +42,7 @@ func (p Prober) Name() string {
 	return "tcp"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, l logger.Logger) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, l logger.Logger, _ string) (bool, float64) {
 	slogger := logger.ToSlog(l)
 	return bbeprober.ProbeTCP(ctx, target, p.config, registry, slogger), 0
 }

--- a/internal/prober/traceroute/traceroute.go
+++ b/internal/prober/traceroute/traceroute.go
@@ -56,7 +56,7 @@ func (p Prober) Name() string {
 	return "traceroute"
 }
 
-func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+func (p Prober) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
 	m, ch, err := mtr.NewMTR(
 		target,
 		p.config.srcAddr,

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -570,6 +570,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 		s.summaries, s.histograms,
 		sl,
 		s.check.BasicMetricsOnly,
+		executionID,
 	)
 	if err != nil {
 		return nil, 0, err
@@ -689,10 +690,11 @@ func getProbeMetrics(
 	histograms map[uint64]prometheus.Histogram,
 	logger kitlog.Logger,
 	basicMetricsOnly bool,
+	executionID string,
 ) (bool, []*dto.MetricFamily, error) {
 	registry := prometheus.NewRegistry()
 
-	success := runProber(ctx, prober, target, timeout, registry, checkInfoLabels, logger)
+	success := runProber(ctx, prober, target, timeout, registry, checkInfoLabels, logger, executionID)
 
 	mfs, err := registry.Gather()
 	if err != nil {
@@ -723,6 +725,7 @@ func runProber(
 	registry *prometheus.Registry,
 	checkInfoLabels map[string]string,
 	logger kitlog.Logger,
+	executionID string,
 ) bool {
 	start := time.Now()
 
@@ -731,7 +734,7 @@ func runProber(
 	checkCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	success, duration := prober.Probe(checkCtx, target, registry, logger)
+	success, duration := prober.Probe(checkCtx, target, registry, logger, executionID)
 
 	wallDuration := time.Since(start).Seconds()
 

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -12,11 +12,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/synthetic-monitoring-agent/internal/secrets"
-
 	kitlog "github.com/go-kit/kit/log" //nolint:staticcheck // TODO(mem): replace in BBE
 	"github.com/go-kit/kit/log/level"  //nolint:staticcheck // TODO(mem): replace in BBE
 	"github.com/go-logfmt/logfmt"
+	"github.com/google/uuid"
 	"github.com/mmcloughlin/geohash"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -30,6 +29,7 @@ import (
 	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/prober"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
+	"github.com/grafana/synthetic-monitoring-agent/internal/secrets"
 	"github.com/grafana/synthetic-monitoring-agent/internal/telemetry"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
@@ -508,6 +508,8 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 		userLabels = s.buildUserLabels()
 		// These labels are applied to the sm_check_info metric.
 		checkInfoLabels = s.buildCheckInfoLabels(userLabels)
+		// This is the execution ID for the check run.
+		executionID = uuid.New().String()
 	)
 
 	maxMetricLabels, err := s.labelsLimiter.MetricLabels(ctx, s.check.GlobalTenantID())
@@ -604,9 +606,8 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 	}
 	logLabels = append(logLabels, labelPair{name: ProbeSuccessMetricName, value: successValue}) // identify log lines that are failures
 
-	// streams need to have all the labels applied to them because
-	// loki does not support joins
-	streams := s.extractLogs(t, logs.Bytes(), logLabels)
+	// streams need to have all the labels applied to them because loki does not support joins
+	streams := s.extractLogs(t, logs.Bytes(), logLabels, executionID)
 
 	return &probeData{ts: ts, streams: streams, tenantId: s.check.GlobalTenantID()}, duration, err
 }
@@ -817,7 +818,7 @@ func getDerivedMetrics(mfs []*dto.MetricFamily, summaries map[uint64]prometheus.
 	return nil
 }
 
-func (s Scraper) extractLogs(t time.Time, logs []byte, sharedLabels []labelPair) Streams {
+func (s Scraper) extractLogs(t time.Time, logs []byte, sharedLabels []labelPair, executionID string) Streams {
 	var line strings.Builder
 
 	dec := logfmt.NewDecoder(bytes.NewReader(logs))
@@ -880,6 +881,9 @@ RECORD:
 		entries = append(entries, logproto.Entry{
 			Timestamp: t,
 			Line:      line.String(),
+			StructuredMetadata: logproto.LabelsAdapter{
+				{Name: "execution_id", Value: executionID},
+			},
 		})
 	}
 

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1798,7 +1798,7 @@ type testRunner struct {
 
 var _ k6runner.Runner = &testRunner{}
 
-func (r *testRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore) (*k6runner.RunResponse, error) {
+func (r *testRunner) Run(ctx context.Context, script k6runner.Script, secretStore k6runner.SecretStore, _ string) (*k6runner.RunResponse, error) {
 	return &k6runner.RunResponse{
 		Metrics: r.metrics,
 		Logs:    r.logs,

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -167,6 +167,7 @@ func verifyProberMetrics(
 		histograms,
 		logger,
 		basicMetricsOnly,
+		"test-execution-id",
 	)
 
 	require.NoError(t, err, "probe failed")
@@ -1310,7 +1311,7 @@ func (p testProber) Name() string {
 	return "test prober"
 }
 
-func (p testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+func (p testProber) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
 	counter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "test_counter",
 	})
@@ -1845,7 +1846,7 @@ func (p testProberB) Name() string {
 	return "test prober"
 }
 
-func (p *testProberB) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger) (bool, float64) {
+func (p *testProberB) Probe(ctx context.Context, target string, registry *prometheus.Registry, logger logger.Logger, _ string) (bool, float64) {
 	p.execCount++
 
 	if p.failureCount < p.wantedFailures {

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/go-logfmt/logfmt"
+	"github.com/google/uuid"
 	logproto "github.com/grafana/loki/pkg/push"
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
 	"github.com/grafana/synthetic-monitoring-agent/internal/model"
@@ -1590,6 +1591,12 @@ func TestScraperCollectData(t *testing.T) {
 				require.Equal(t, len(tc.expectedLogEntries), labelsFound)
 			}
 			require.NoError(t, dec.Err())
+
+			// Verify that the execution_id is present in the structured metadata.
+			require.Len(t, entry.StructuredMetadata, 1)
+			require.Equal(t, "execution_id", entry.StructuredMetadata[0].Name)
+			_, err := uuid.Parse(entry.StructuredMetadata[0].Value)
+			require.NoError(t, err, "execution_id should be a valid UUID")
 		}
 	}
 
@@ -2221,7 +2228,7 @@ func TestExtractLogsK6TimeOverridesDefaultTimestamp(t *testing.T) {
 				logger: testhelper.Logger(t),
 			}
 
-			streams := s.extractLogs(time.Now(), []byte(tc.logs), tc.sharedLabels)
+			streams := s.extractLogs(time.Now(), []byte(tc.logs), tc.sharedLabels, "test-execution-id")
 			tc.expected(t, streams)
 		})
 	}


### PR DESCRIPTION
Sets the `K6_CLOUD_PUSH_REF_ID` environment variable within the k6 test script runtime for browser checks, referencing the check's _execution ID_ . This variable is automatically parsed by k6 runtime and set as `window.k6 property` within the web page DOM for every page visited by the browser check execution.

Introduces a new check _execution ID_, an UUID that identifies each check execution, included as [structured metadata](https://grafana.com/docs/loki/latest/get-started/labels/structured-metadata/). This execution ID allows grouping all logs for each check execution.

The purpose of this is to establish a correlation between a FE O11y browser session and Synthetic Monitoring check execution. By including the execution ID, FE O11y can query

This PR also propagates the check's _execution ID_ to the remote HTTP runner.

Depends on https://github.com/grafana/synthetic-monitoring/issues/505
Updates https://github.com/grafana/synthetic-monitoring/issues/506
Alternative to https://github.com/grafana/synthetic-monitoring-agent/pull/1783

----
#### Pros and Cons
Compared to #1783, using a _check execution ID_ allows for better identification of the check execution logs associated with the FE O11y session without relying on timing. This implies also an additional side benefit to our current _Timepoint Explorer_ implementation, which can now do the same without relying on specific "log lines as sentinels".

The concern with this approach is whether some tenant's volume might be too much in order to rely only on structured metadata.
Fe O11y will only have this reference in order to query logs, therefore not using any labels to reduce the log stream results. Synthetic Monitoring volumes are small, but for tenants with tenths of thousands of checks total log size can reach significant volumes. Theoretically, structured metadata should allow the Loki query to select particular streams before retrieval, therefore reducing volume. We should understand and guarantee that this solution will be appropriate, even for big tenants.
How will Loki behave on a query for _execution ID_ for big tenants given a time window of 1/2/..4 weeks? Will Loki give up on the query due to total volume?

The alternative here could imply having a merge of both approaches, so the k6 ref. id includes a reference to `job` and `instance` along with the _execution ID_, keeping this last one as structured metadata. In this case FE o11y could use `job` and `instance` labels as part of the LogQL query.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad interface change across probers and k6 runners touches all check execution paths; browser checks depend on correct k6 env propagation and remote runners must accept executionId.
> 
> **Overview**
> Each check run now gets a new **UUID execution ID** that flows through scheduled scrapes, ad-hoc runs, and all k6-based probes.
> 
> Published Loki log entries attach that ID as **`execution_id` structured metadata** (not a stream label), so logs for one run can be grouped and queried without relying on timing alone.
> 
> The **`Prober.Probe`** and **`k6runner.Runner.Run`** APIs take an **`executionID`** argument end-to-end. Remote k6 runs send it as **`executionId`** on the HTTP run payload; the local runner sets **`K6_CLOUD_PUSH_REF_ID=sm:<executionID>`** for **browser** checks (and skips `--vus`/`--iterations` for those), so FE O11y can tie a browser session to a specific SM execution via `window.k6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a38ee07d4f8ac174b9912e854cbe592e320405a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->