### PR TITLE
fix: Remove usage of deprecated grpc.DialContex()

### DIFF
--- a/cmd/synthetic-monitoring-agent/grpc.go
+++ b/cmd/synthetic-monitoring-agent/grpc.go
@@ -13,11 +13,13 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-func dialAPIServer(ctx context.Context, addr string, allowInsecure bool, apiToken string) (*grpc.ClientConn, error) {
+// newAPIServerClient creates a client connection to an API server. It does not
+// block: grpc.NewClient returns immediately with the connection in IDLE and
+// connects lazily in the background on the first RPC.
+func newAPIServerClient(addr string, allowInsecure bool, apiToken string) (*grpc.ClientConn, error) {
 	apiCreds := creds{Token: apiToken}
 
 	opts := []grpc.DialOption{
-		grpc.WithBlock(), //nolint:staticcheck,nolintlint // Will be removed in v2. TODO: Migrate to NewClient.
 		grpc.WithPerRPCCredentials(apiCreds),
 		// Keep-alive is necessary to detect network failures in absence of writes from the client.
 		// Without it, the agent would hang if the server disappears while waiting for a response.
@@ -40,7 +42,7 @@ func dialAPIServer(ctx context.Context, addr string, allowInsecure bool, apiToke
 	}
 	opts = append(opts, grpc.WithTransportCredentials(transportCreds))
 
-	return grpc.DialContext(ctx, addr, opts...) //nolint:staticcheck,nolintlint // Will be removed in v2. TODO: Migrate to NewClient.
+	return grpc.NewClient(addr, opts...)
 }
 
 func grpcApiHost(addr string) string {

--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -298,7 +298,7 @@ func run(args []string, stdout io.Writer) error {
 
 	tenantCh := make(chan synthetic_monitoring.Tenant)
 
-	conn, err := dialAPIServer(ctx, config.GrpcApiServerAddr, config.GrpcInsecure, string(config.ApiToken))
+	conn, err := newAPIServerClient(config.GrpcApiServerAddr, config.GrpcInsecure, string(config.ApiToken))
 	if err != nil {
 		return fmt.Errorf("dialing GRPC server %s: %w", config.GrpcApiServerAddr, err)
 	}


### PR DESCRIPTION
Replaces the blocking dial (`dialAPIServer()`) with non-blocking `newAPIServerClient()` (`grpc.NewClient()`).

Behavior changes:
- The connection setup no longer blocks. `NewClient()` returns immediately with the connection in IDLE; the transport connects lazily in the background on the first RPC.
- Error flow: connectivity errors (DNS, refused, TLS) no longer surface at dial time. `NewClient()` only errors on invalid arguments. Connectivity failures now surface on the first RPC, where the agent's existing reconnect/backoff logic handles them. gRPC's own state machine drives transport-level reconnection underneath.

Closes #738

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shifts when connectivity failures appear (first RPC vs startup), which can change readiness timing and error messages, though reconnect/backoff paths already exist in the updater.
> 
> **Overview**
> **Replaces the deprecated blocking gRPC API setup** with the modern non-blocking client API. `dialAPIServer` is renamed to **`newAPIServerClient`**, drops the **`context`** parameter, removes **`grpc.WithBlock`**, and uses **`grpc.NewClient`** instead of **`grpc.DialContext`**.
> 
> **Startup behavior changes:** the agent no longer waits for a live connection to the API server before continuing. The client returns immediately in **IDLE** and the transport connects lazily on the first RPC. **`NewClient`** only fails on invalid dial options; DNS, refused connections, and TLS problems surface on the first RPC rather than at process startup.
> 
> **`main.go`** is updated to call **`newAPIServerClient`** with the same address, insecure flag, and token. Existing **`checksUpdater`** / **`adhoc`** backoff and readiness handling are expected to cover connectivity failures after startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e3000daff3013415dd51e03df93d7667ee00aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->