### PR TITLE
feat: Implement label mode behaviour

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/grafana/synthetic-monitoring-agent/internal/http"
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6version"
+	"github.com/grafana/synthetic-monitoring-agent/internal/labelmode"
 	"github.com/grafana/synthetic-monitoring-agent/internal/limits"
 	"github.com/grafana/synthetic-monitoring-agent/internal/metamonitoring"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
@@ -370,6 +371,7 @@ func run(args []string, stdout io.Writer) error {
 		Telemeter:               telemetry,
 		UsageReporter:           usageReporter,
 		CostAttributionLabels:   cals,
+		LabellingMode:           labelmode.New(tm),
 		SupportsProtocolSecrets: config.EnableProtocolSecrets,
 	})
 	if err != nil {

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/synthetic-monitoring-agent/internal/error_types"
 	"github.com/grafana/synthetic-monitoring-agent/internal/feature"
 	"github.com/grafana/synthetic-monitoring-agent/internal/k6runner"
+	"github.com/grafana/synthetic-monitoring-agent/internal/labelmode"
 	"github.com/grafana/synthetic-monitoring-agent/internal/limits"
 	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
@@ -90,6 +91,7 @@ type Updater struct {
 	telemeter               *telemetry.Telemeter
 	usageReporter           usage.Reporter
 	tenantCals              *cals.CostAttributionLabels
+	tenantLabellingMode     *labelmode.LabelMode
 	supportsProtocolSecrets bool
 }
 
@@ -129,6 +131,7 @@ type UpdaterOptions struct {
 	Telemeter               *telemetry.Telemeter
 	UsageReporter           usage.Reporter
 	CostAttributionLabels   *cals.CostAttributionLabels
+	LabellingMode           *labelmode.LabelMode
 	SupportsProtocolSecrets bool
 }
 
@@ -264,8 +267,9 @@ func NewUpdater(opts UpdaterOptions) (*Updater, error) {
 			scrapeErrorCounter:  scrapeErrorCounter,
 			scrapesCounter:      scrapesCounter,
 		},
-		usageReporter: opts.UsageReporter,
-		tenantCals:    opts.CostAttributionLabels,
+		usageReporter:       opts.UsageReporter,
+		tenantCals:          opts.CostAttributionLabels,
+		tenantLabellingMode: opts.LabellingMode,
 	}, nil
 }
 
@@ -960,7 +964,7 @@ func (c *Updater) addAndStartScraperWithLock(ctx context.Context, check model.Ch
 		c.logger,
 		metrics,
 		c.k6Runner,
-		c.tenantLimits, c.telemeter, c.tenantSecrets, c.tenantCals,
+		c.tenantLimits, c.telemeter, c.tenantSecrets, c.tenantCals, c.tenantLabellingMode,
 	)
 	if err != nil {
 		return fmt.Errorf("cannot create new scraper: %w", err)

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -494,6 +494,12 @@ func (l testLabelsLimiter) LogLabels(ctx context.Context, tenantID model.GlobalI
 	return l.logLabelsLimit, nil
 }
 
+type testLabellingMode struct{}
+
+func (l testLabellingMode) ForTenant(ctx context.Context, tenantID model.GlobalID) (sm.LabelMode, error) {
+	return sm.LabelMode_LABEL_MODE_PREFIXED, nil
+}
+
 func testScraperFactory(ctx context.Context, check model.Check, publisher pusher.Publisher, _ sm.Probe,
 	_ feature.Collection,
 	logger zerolog.Logger,
@@ -503,6 +509,7 @@ func testScraperFactory(ctx context.Context, check model.Check, publisher pusher
 	telemeter *telemetry.Telemeter,
 	secretStore secrets.SecretProvider,
 	cals scraper.TenantCals,
+	labellingMode scraper.TenantLabelMode,
 ) (*scraper.Scraper, error) {
 	return scraper.NewWithOpts(
 		ctx,
@@ -513,6 +520,7 @@ func testScraperFactory(ctx context.Context, check model.Check, publisher pusher
 			Publisher:     publisher,
 			Metrics:       metrics,
 			LabelsLimiter: testLabelsLimiter{},
+			LabellingMode: testLabellingMode{},
 			Telemeter:     telemeter,
 		},
 	)

--- a/internal/labelmode/labelmode.go
+++ b/internal/labelmode/labelmode.go
@@ -28,6 +28,12 @@ func New(provider TenantProvider) *LabelMode {
 
 // ForTenant returns the label mode for the given tenant, defaulting to
 // LABEL_MODE_PREFIXED if the tenant cannot be fetched.
+//
+// The default value is never actually used - the LabelMode is fetched
+// during the scraper's `collectData` operation, which aborts overall
+// if the tenant is not able to be retrieved as the tenant's limits
+// are necessary to the scraper's operation. The default path is therefore
+// irrelevant for scrapes which report telemetry.
 func (lm *LabelMode) ForTenant(ctx context.Context, tenantID model.GlobalID) (sm.LabelMode, error) {
 	tenant, err := lm.provider.GetTenant(ctx, &sm.TenantInfo{Id: int64(tenantID)})
 	if err != nil {

--- a/internal/labelmode/labelmode.go
+++ b/internal/labelmode/labelmode.go
@@ -27,7 +27,7 @@ func New(provider TenantProvider) *LabelMode {
 }
 
 // ForTenant returns the label mode for the given tenant, defaulting to
-// LABEL_MODE_PREFIXED if the tenant cannot be fetched.
+// LABEL_MODE_UNPREFIXED if the tenant cannot be fetched.
 //
 // The default value is never actually used - the LabelMode is fetched
 // during the scraper's `collectData` operation, which aborts overall
@@ -37,7 +37,7 @@ func New(provider TenantProvider) *LabelMode {
 func (lm *LabelMode) ForTenant(ctx context.Context, tenantID model.GlobalID) (sm.LabelMode, error) {
 	tenant, err := lm.provider.GetTenant(ctx, &sm.TenantInfo{Id: int64(tenantID)})
 	if err != nil {
-		return sm.LabelMode_LABEL_MODE_PREFIXED, fmt.Errorf("fetching tenant label mode: %w", err)
+		return sm.LabelMode_LABEL_MODE_UNPREFIXED, fmt.Errorf("fetching tenant label mode: %w", err)
 	}
 	return tenant.LabelMode, nil
 }

--- a/internal/labelmode/labelmode.go
+++ b/internal/labelmode/labelmode.go
@@ -1,0 +1,37 @@
+package labelmode
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+// TenantProvider is the subset of the tenant manager interface required to
+// look up a tenant's current label mode.
+type TenantProvider interface {
+	GetTenant(context.Context, *sm.TenantInfo) (*sm.Tenant, error)
+}
+
+// LabelMode provides the tenant's current label migration mode
+// (PREFIXED / DUAL_WRITE / UNPREFIXED) by reading it from the GetTenant
+// response, which is cached with a 15-minute TTL by the tenant manager.
+type LabelMode struct {
+	provider TenantProvider
+}
+
+// New creates a LabelMode provider backed by the given TenantProvider.
+func New(provider TenantProvider) *LabelMode {
+	return &LabelMode{provider: provider}
+}
+
+// ForTenant returns the label mode for the given tenant, defaulting to
+// LABEL_MODE_PREFIXED if the tenant cannot be fetched.
+func (lm *LabelMode) ForTenant(ctx context.Context, tenantID model.GlobalID) (sm.LabelMode, error) {
+	tenant, err := lm.provider.GetTenant(ctx, &sm.TenantInfo{Id: int64(tenantID)})
+	if err != nil {
+		return sm.LabelMode_LABEL_MODE_PREFIXED, fmt.Errorf("fetching tenant label mode: %w", err)
+	}
+	return tenant.LabelMode, nil
+}

--- a/internal/labelmode/labelmode_test.go
+++ b/internal/labelmode/labelmode_test.go
@@ -1,0 +1,43 @@
+package labelmode
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+type fakeTenantProvider struct {
+	tenant *sm.Tenant
+	err    error
+}
+
+func (f fakeTenantProvider) GetTenant(context.Context, *sm.TenantInfo) (*sm.Tenant, error) {
+	return f.tenant, f.err
+}
+
+// TestForTenantReturnsTenantMode verifies the tenant's configured label mode is
+// returned when the lookup succeeds.
+func TestForTenantReturnsTenantMode(t *testing.T) {
+	lm := New(fakeTenantProvider{
+		tenant: &sm.Tenant{LabelMode: sm.LabelMode_LABEL_MODE_DUAL_WRITE},
+	})
+
+	mode, err := lm.ForTenant(context.Background(), model.GlobalID(1))
+	require.NoError(t, err)
+	require.Equal(t, sm.LabelMode_LABEL_MODE_DUAL_WRITE, mode)
+}
+
+// TestForTenantFallsBackToPrefixedOnError verifies that a lookup failure returns
+// PREFIXED alongside the error, so callers can degrade gracefully.
+func TestForTenantFallsBackToPrefixedOnError(t *testing.T) {
+	lm := New(fakeTenantProvider{err: errors.New("boom")})
+
+	mode, err := lm.ForTenant(context.Background(), model.GlobalID(1))
+	require.Error(t, err)
+	require.Equal(t, sm.LabelMode_LABEL_MODE_PREFIXED, mode)
+}

--- a/internal/labelmode/labelmode_test.go
+++ b/internal/labelmode/labelmode_test.go
@@ -32,12 +32,12 @@ func TestForTenantReturnsTenantMode(t *testing.T) {
 	require.Equal(t, sm.LabelMode_LABEL_MODE_DUAL_WRITE, mode)
 }
 
-// TestForTenantFallsBackToPrefixedOnError verifies that a lookup failure returns
-// PREFIXED alongside the error, so callers can degrade gracefully.
-func TestForTenantFallsBackToPrefixedOnError(t *testing.T) {
+// TestForTenantFallsBackToUnprefixedOnError verifies that a lookup failure
+// returns UNPREFIXED alongside the error, so callers can degrade gracefully.
+func TestForTenantFallsBackToUnprefixedOnError(t *testing.T) {
 	lm := New(fakeTenantProvider{err: errors.New("boom")})
 
 	mode, err := lm.ForTenant(context.Background(), model.GlobalID(1))
 	require.Error(t, err)
-	require.Equal(t, sm.LabelMode_LABEL_MODE_PREFIXED, mode)
+	require.Equal(t, sm.LabelMode_LABEL_MODE_UNPREFIXED, mode)
 }

--- a/internal/scraper/catalogue_fixture_test.go
+++ b/internal/scraper/catalogue_fixture_test.go
@@ -41,6 +41,7 @@ func collectFixtureCatalogueWithLogger(t *testing.T, name string, spec fixtureSp
 		logger:        logger,
 		prober:        probeImpl,
 		labelsLimiter: testLabelsLimiter{maxMetricLabels: 100, maxLogLabels: 100},
+		labellingMode: testLabellingMode{},
 		summaries:     make(map[uint64]prometheus.Summary),
 		histograms:    make(map[uint64]prometheus.Histogram),
 		check:         check,

--- a/internal/scraper/labels_test.go
+++ b/internal/scraper/labels_test.go
@@ -144,3 +144,27 @@ func TestBuildUserLabels_DualWrite_ReservedNamePassthrough(t *testing.T) {
 	assert.Equal(t, "probe", result[2].name)
 	assert.Equal(t, "env", result[3].name)
 }
+
+// TestBuildUserLabels_Unprefixed_Basic: single label env=prod produces only env=prod.
+func TestBuildUserLabels_Unprefixed_Basic(t *testing.T) {
+	result := buildUserLabels(
+		nil,
+		labels("env", "prod"),
+		sm.LabelMode_LABEL_MODE_UNPREFIXED,
+	)
+	require.Len(t, result, 1)
+	assert.Equal(t, "env", result[0].name)
+	assert.Equal(t, "prod", result[0].value)
+}
+
+// TestBuildUserLabels_Unprefixed_ReservedNamePassthrough: reserved names are NOT dropped.
+func TestBuildUserLabels_Unprefixed_ReservedNamePassthrough(t *testing.T) {
+	result := buildUserLabels(
+		nil,
+		labels("probe", "myprobe", "env", "prod"),
+		sm.LabelMode_LABEL_MODE_UNPREFIXED,
+	)
+	require.Len(t, result, 2)
+	findLabel(t, result, "probe")
+	findLabel(t, result, "env")
+}

--- a/internal/scraper/labels_test.go
+++ b/internal/scraper/labels_test.go
@@ -232,3 +232,47 @@ func TestUserLabelsForExecution_CheckOverridesProbe(t *testing.T) {
 	require.Len(t, result, 1)
 	require.Equal(t, "prod", result[0].value, "check label should override probe label")
 }
+
+// ── mergeLogLabels tests ─────────────────────────────────────────────────────
+
+// TestMergeLogLabels_UserWinsSystemOrderingPreserved verifies that user labels
+// override colliding system labels in place (user value wins), system labels
+// keep their leading positions (so they survive stream-label overflow), and
+// non-colliding user labels are appended after the system set. The input system
+// slice must not be mutated.
+func TestMergeLogLabels_UserWinsSystemOrderingPreserved(t *testing.T) {
+	system := []labelPair{
+		{name: "probe", value: "p"},
+		{name: "job", value: "sysjob"},
+		{name: "region", value: "r"},
+	}
+	user := []labelPair{
+		{name: "job", value: "userjob"}, // collides with system "job"
+		{name: "env", value: "prod"},    // new
+	}
+
+	got := mergeLogLabels(system, user)
+
+	require.Equal(t, []labelPair{
+		{name: "probe", value: "p"},
+		{name: "job", value: "userjob"}, // user value wins, position preserved
+		{name: "region", value: "r"},
+		{name: "env", value: "prod"}, // appended after the system labels
+	}, got)
+
+	// The input system slice must be left untouched.
+	require.Equal(t, "sysjob", system[1].value)
+}
+
+// TestMergeLogLabels_NoUserLabels verifies the system labels pass through
+// unchanged when there are no user labels.
+func TestMergeLogLabels_NoUserLabels(t *testing.T) {
+	system := []labelPair{
+		{name: "probe", value: "p"},
+		{name: "job", value: "sysjob"},
+	}
+
+	got := mergeLogLabels(system, nil)
+
+	require.Equal(t, system, got)
+}

--- a/internal/scraper/labels_test.go
+++ b/internal/scraper/labels_test.go
@@ -168,11 +168,11 @@ func TestBuildUserLabels_Unprefixed_ReservedNamePassthrough(t *testing.T) {
 	findLabel(t, result, "env")
 }
 
-// ── userLabelsForExecution tests ─────────────────────────────────────────────
+// ── customMetricLabels tests ─────────────────────────────────────────────
 
 // TestUserLabelsForExecution_Prefixed: PREFIXED mode returns nil — no user labels on execution metrics.
 func TestUserLabelsForExecution_Prefixed(t *testing.T) {
-	result := userLabelsForExecution(
+	result := customMetricLabels(
 		makeLabels("env", "prod"),
 		makeLabels("team", "platform"),
 		sm.LabelMode_LABEL_MODE_PREFIXED,
@@ -182,7 +182,7 @@ func TestUserLabelsForExecution_Prefixed(t *testing.T) {
 
 // TestUserLabelsForExecution_DualWrite: DUAL_WRITE returns only un-prefixed form.
 func TestUserLabelsForExecution_DualWrite(t *testing.T) {
-	result := userLabelsForExecution(
+	result := customMetricLabels(
 		nil,
 		makeLabels("env", "prod", "team", "platform"),
 		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
@@ -196,7 +196,7 @@ func TestUserLabelsForExecution_DualWrite(t *testing.T) {
 
 // TestUserLabelsForExecution_Unprefixed: UNPREFIXED returns un-prefixed form.
 func TestUserLabelsForExecution_Unprefixed(t *testing.T) {
-	result := userLabelsForExecution(
+	result := customMetricLabels(
 		nil,
 		makeLabels("env", "prod"),
 		sm.LabelMode_LABEL_MODE_UNPREFIXED,
@@ -211,7 +211,7 @@ func TestUserLabelsForExecution_Unprefixed(t *testing.T) {
 // and the user-defined value should win to avoid breaking existing behaviour.
 func TestUserLabelsForExecution_ReservedNamePassthrough(t *testing.T) {
 	for _, mode := range []sm.LabelMode{sm.LabelMode_LABEL_MODE_DUAL_WRITE, sm.LabelMode_LABEL_MODE_UNPREFIXED} {
-		result := userLabelsForExecution(
+		result := customMetricLabels(
 			nil,
 			makeLabels("probe", "myprobe", "env", "prod"),
 			mode,
@@ -224,7 +224,7 @@ func TestUserLabelsForExecution_ReservedNamePassthrough(t *testing.T) {
 
 // TestUserLabelsForExecution_CheckOverridesProbe: check label wins over probe label for the same name.
 func TestUserLabelsForExecution_CheckOverridesProbe(t *testing.T) {
-	result := userLabelsForExecution(
+	result := customMetricLabels(
 		makeLabels("env", "staging"),
 		makeLabels("env", "prod"),
 		sm.LabelMode_LABEL_MODE_DUAL_WRITE,

--- a/internal/scraper/labels_test.go
+++ b/internal/scraper/labels_test.go
@@ -3,13 +3,12 @@ package scraper
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
-func labels(pairs ...string) []sm.Label {
+func makeLabels(pairs ...string) []sm.Label {
 	if len(pairs)%2 != 0 {
 		panic("labels: pairs must be even")
 	}
@@ -44,28 +43,28 @@ func assertNoLabel(t *testing.T, lps []labelPair, name string) {
 // Result should be only label_env=prod (check wins, prefixed).
 func TestBuildUserLabels_Prefixed_CheckOverridesProbe(t *testing.T) {
 	result := buildUserLabels(
-		labels("env", "dev"),
-		labels("env", "prod"),
+		makeLabels("env", "dev"),
+		makeLabels("env", "prod"),
 		sm.LabelMode_LABEL_MODE_PREFIXED,
 	)
 	require.Len(t, result, 1)
-	assert.Equal(t, "label_env", result[0].name)
-	assert.Equal(t, "prod", result[0].value)
+	require.Equal(t, "label_env", result[0].name)
+	require.Equal(t, "prod", result[0].value)
 }
 
 // TestBuildUserLabels_Prefixed_TwoDistinctLabels: probe has region=eu, check has env=prod.
 // Both appear prefixed, probe label first.
 func TestBuildUserLabels_Prefixed_TwoDistinctLabels(t *testing.T) {
 	result := buildUserLabels(
-		labels("region", "eu"),
-		labels("env", "prod"),
+		makeLabels("region", "eu"),
+		makeLabels("env", "prod"),
 		sm.LabelMode_LABEL_MODE_PREFIXED,
 	)
 	require.Len(t, result, 2)
 	lp1 := findLabel(t, result, "label_region")
-	assert.Equal(t, "eu", lp1.value)
+	require.Equal(t, "eu", lp1.value)
 	lp2 := findLabel(t, result, "label_env")
-	assert.Equal(t, "prod", lp2.value)
+	require.Equal(t, "prod", lp2.value)
 }
 
 // TestBuildUserLabels_Prefixed_ReservedNotDropped: in PREFIXED mode, reserved names are NOT
@@ -73,12 +72,12 @@ func TestBuildUserLabels_Prefixed_TwoDistinctLabels(t *testing.T) {
 func TestBuildUserLabels_Prefixed_ReservedNotDropped(t *testing.T) {
 	result := buildUserLabels(
 		nil,
-		labels("probe", "myprobe"),
+		makeLabels("probe", "myprobe"),
 		sm.LabelMode_LABEL_MODE_PREFIXED,
 	)
 	require.Len(t, result, 1)
-	assert.Equal(t, "label_probe", result[0].name)
-	assert.Equal(t, "myprobe", result[0].value)
+	require.Equal(t, "label_probe", result[0].name)
+	require.Equal(t, "myprobe", result[0].value)
 }
 
 // TestBuildUserLabels_DualWrite_Basic: DUAL_WRITE emits all prefixed forms first, then all
@@ -87,46 +86,46 @@ func TestBuildUserLabels_Prefixed_ReservedNotDropped(t *testing.T) {
 func TestBuildUserLabels_DualWrite_Basic(t *testing.T) {
 	result := buildUserLabels(
 		nil,
-		labels("env", "prod"),
+		makeLabels("env", "prod"),
 		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
 	)
 	require.Len(t, result, 2)
-	assert.Equal(t, "label_env", result[0].name, "prefixed form must come first")
-	assert.Equal(t, "prod", result[0].value)
-	assert.Equal(t, "env", result[1].name, "un-prefixed form must come second")
-	assert.Equal(t, "prod", result[1].value)
+	require.Equal(t, "label_env", result[0].name, "prefixed form must come first")
+	require.Equal(t, "prod", result[0].value)
+	require.Equal(t, "env", result[1].name, "un-prefixed form must come second")
+	require.Equal(t, "prod", result[1].value)
 }
 
 // TestBuildUserLabels_DualWrite_TwoLabels: two labels produce [label_a, label_b, a, b] —
 // all prefixed first, then all un-prefixed.
 func TestBuildUserLabels_DualWrite_TwoLabels(t *testing.T) {
 	result := buildUserLabels(
-		labels("team", "sre"),
-		labels("env", "prod"),
+		makeLabels("team", "sre"),
+		makeLabels("env", "prod"),
 		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
 	)
 	require.Len(t, result, 4)
 	// First half: all prefixed
-	assert.Equal(t, "label_team", result[0].name)
-	assert.Equal(t, "label_env", result[1].name)
+	require.Equal(t, "label_team", result[0].name)
+	require.Equal(t, "label_env", result[1].name)
 	// Second half: all un-prefixed
-	assert.Equal(t, "team", result[2].name)
-	assert.Equal(t, "env", result[3].name)
+	require.Equal(t, "team", result[2].name)
+	require.Equal(t, "env", result[3].name)
 }
 
 // TestBuildUserLabels_DualWrite_CheckOverridesProbe: probe env=dev, check env=prod.
 // Both forms should carry the check's value.
 func TestBuildUserLabels_DualWrite_CheckOverridesProbe(t *testing.T) {
 	result := buildUserLabels(
-		labels("env", "dev"),
-		labels("env", "prod"),
+		makeLabels("env", "dev"),
+		makeLabels("env", "prod"),
 		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
 	)
 	require.Len(t, result, 2)
-	assert.Equal(t, "label_env", result[0].name)
-	assert.Equal(t, "prod", result[0].value, "prefixed form should have check value")
-	assert.Equal(t, "env", result[1].name)
-	assert.Equal(t, "prod", result[1].value, "un-prefixed form should have check value")
+	require.Equal(t, "label_env", result[0].name)
+	require.Equal(t, "prod", result[0].value, "prefixed form should have check value")
+	require.Equal(t, "env", result[1].name)
+	require.Equal(t, "prod", result[1].value, "un-prefixed form should have check value")
 }
 
 // TestBuildUserLabels_DualWrite_ReservedNamePassthrough: reserved names are NOT dropped —
@@ -134,37 +133,102 @@ func TestBuildUserLabels_DualWrite_CheckOverridesProbe(t *testing.T) {
 func TestBuildUserLabels_DualWrite_ReservedNamePassthrough(t *testing.T) {
 	result := buildUserLabels(
 		nil,
-		labels("probe", "myprobe", "env", "prod"),
+		makeLabels("probe", "myprobe", "env", "prod"),
 		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
 	)
 	// [label_probe, label_env, probe, env]
 	require.Len(t, result, 4)
-	assert.Equal(t, "label_probe", result[0].name)
-	assert.Equal(t, "label_env", result[1].name)
-	assert.Equal(t, "probe", result[2].name)
-	assert.Equal(t, "env", result[3].name)
+	require.Equal(t, "label_probe", result[0].name)
+	require.Equal(t, "label_env", result[1].name)
+	require.Equal(t, "probe", result[2].name)
+	require.Equal(t, "env", result[3].name)
 }
 
 // TestBuildUserLabels_Unprefixed_Basic: single label env=prod produces only env=prod.
 func TestBuildUserLabels_Unprefixed_Basic(t *testing.T) {
 	result := buildUserLabels(
 		nil,
-		labels("env", "prod"),
+		makeLabels("env", "prod"),
 		sm.LabelMode_LABEL_MODE_UNPREFIXED,
 	)
 	require.Len(t, result, 1)
-	assert.Equal(t, "env", result[0].name)
-	assert.Equal(t, "prod", result[0].value)
+	require.Equal(t, "env", result[0].name)
+	require.Equal(t, "prod", result[0].value)
 }
 
 // TestBuildUserLabels_Unprefixed_ReservedNamePassthrough: reserved names are NOT dropped.
 func TestBuildUserLabels_Unprefixed_ReservedNamePassthrough(t *testing.T) {
 	result := buildUserLabels(
 		nil,
-		labels("probe", "myprobe", "env", "prod"),
+		makeLabels("probe", "myprobe", "env", "prod"),
 		sm.LabelMode_LABEL_MODE_UNPREFIXED,
 	)
 	require.Len(t, result, 2)
 	findLabel(t, result, "probe")
 	findLabel(t, result, "env")
+}
+
+// ── userLabelsForExecution tests ─────────────────────────────────────────────
+
+// TestUserLabelsForExecution_Prefixed: PREFIXED mode returns nil — no user labels on execution metrics.
+func TestUserLabelsForExecution_Prefixed(t *testing.T) {
+	result := userLabelsForExecution(
+		makeLabels("env", "prod"),
+		makeLabels("team", "platform"),
+		sm.LabelMode_LABEL_MODE_PREFIXED,
+	)
+	require.Nil(t, result, "PREFIXED mode should return nil — execution metrics carry no user labels")
+}
+
+// TestUserLabelsForExecution_DualWrite: DUAL_WRITE returns only un-prefixed form.
+func TestUserLabelsForExecution_DualWrite(t *testing.T) {
+	result := userLabelsForExecution(
+		nil,
+		makeLabels("env", "prod", "team", "platform"),
+		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
+	)
+	require.Len(t, result, 2, "should emit one entry per user label (un-prefixed only)")
+	findLabel(t, result, "env")
+	findLabel(t, result, "team")
+	assertNoLabel(t, result, "label_env")
+	assertNoLabel(t, result, "label_team")
+}
+
+// TestUserLabelsForExecution_Unprefixed: UNPREFIXED returns un-prefixed form.
+func TestUserLabelsForExecution_Unprefixed(t *testing.T) {
+	result := userLabelsForExecution(
+		nil,
+		makeLabels("env", "prod"),
+		sm.LabelMode_LABEL_MODE_UNPREFIXED,
+	)
+	require.Len(t, result, 1)
+	require.Equal(t, "env", result[0].name)
+	require.Equal(t, "prod", result[0].value)
+}
+
+// TestUserLabelsForExecution_ReservedNamePassthrough: reserved names are NOT dropped —
+// if a tenant reaches this state post-migration it means we added a new reserved label,
+// and the user-defined value should win to avoid breaking existing behaviour.
+func TestUserLabelsForExecution_ReservedNamePassthrough(t *testing.T) {
+	for _, mode := range []sm.LabelMode{sm.LabelMode_LABEL_MODE_DUAL_WRITE, sm.LabelMode_LABEL_MODE_UNPREFIXED} {
+		result := userLabelsForExecution(
+			nil,
+			makeLabels("probe", "myprobe", "env", "prod"),
+			mode,
+		)
+		require.Len(t, result, 2)
+		findLabel(t, result, "probe")
+		findLabel(t, result, "env")
+	}
+}
+
+// TestUserLabelsForExecution_CheckOverridesProbe: check label wins over probe label for the same name.
+func TestUserLabelsForExecution_CheckOverridesProbe(t *testing.T) {
+	result := userLabelsForExecution(
+		makeLabels("env", "staging"),
+		makeLabels("env", "prod"),
+		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
+	)
+	require.Len(t, result, 1)
+	require.Equal(t, "prod", result[0].value, "check label should override probe label")
 }

--- a/internal/scraper/labels_test.go
+++ b/internal/scraper/labels_test.go
@@ -68,7 +68,7 @@ func TestBuildUserLabels_Prefixed_TwoDistinctLabels(t *testing.T) {
 }
 
 // TestBuildUserLabels_Prefixed_ReservedNotDropped: in PREFIXED mode, reserved names are NOT
-// dropped — enforcement is at the API layer, not here.
+// dropped.
 func TestBuildUserLabels_Prefixed_ReservedNotDropped(t *testing.T) {
 	result := buildUserLabels(
 		nil,
@@ -128,20 +128,21 @@ func TestBuildUserLabels_DualWrite_CheckOverridesProbe(t *testing.T) {
 	require.Equal(t, "prod", result[1].value, "un-prefixed form should have check value")
 }
 
-// TestBuildUserLabels_DualWrite_ReservedNamePassthrough: reserved names are NOT dropped —
-// user-defined value wins over the system-emitted value for post-migration additions.
-func TestBuildUserLabels_DualWrite_ReservedNamePassthrough(t *testing.T) {
+// TestBuildUserLabels_DualWrite_ReservedNameDropped: a reserved name keeps its prefixed
+// form (label_le, which cannot collide) but its un-prefixed form is dropped so it cannot
+// overwrite an intrinsic per-series metric label. Non-reserved names keep both forms.
+func TestBuildUserLabels_DualWrite_ReservedNameDropped(t *testing.T) {
 	result := buildUserLabels(
 		nil,
-		makeLabels("probe", "myprobe", "env", "prod"),
+		makeLabels("le", "user-value", "env", "prod"),
 		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
 	)
-	// [label_probe, label_env, probe, env]
-	require.Len(t, result, 4)
-	require.Equal(t, "label_probe", result[0].name)
+	// [label_le, label_env, env] — the un-prefixed "le" is dropped.
+	require.Len(t, result, 3)
+	require.Equal(t, "label_le", result[0].name)
 	require.Equal(t, "label_env", result[1].name)
-	require.Equal(t, "probe", result[2].name)
-	require.Equal(t, "env", result[3].name)
+	require.Equal(t, "env", result[2].name)
+	assertNoLabel(t, result, "le")
 }
 
 // TestBuildUserLabels_Unprefixed_Basic: single label env=prod produces only env=prod.
@@ -156,16 +157,17 @@ func TestBuildUserLabels_Unprefixed_Basic(t *testing.T) {
 	require.Equal(t, "prod", result[0].value)
 }
 
-// TestBuildUserLabels_Unprefixed_ReservedNamePassthrough: reserved names are NOT dropped.
-func TestBuildUserLabels_Unprefixed_ReservedNamePassthrough(t *testing.T) {
+// TestBuildUserLabels_Unprefixed_ReservedNameDropped: a reserved name is dropped entirely
+// in UNPREFIXED mode; non-reserved names pass through.
+func TestBuildUserLabels_Unprefixed_ReservedNameDropped(t *testing.T) {
 	result := buildUserLabels(
 		nil,
-		makeLabels("probe", "myprobe", "env", "prod"),
+		makeLabels("le", "user-value", "env", "prod"),
 		sm.LabelMode_LABEL_MODE_UNPREFIXED,
 	)
-	require.Len(t, result, 2)
-	findLabel(t, result, "probe")
-	findLabel(t, result, "env")
+	require.Len(t, result, 1)
+	require.Equal(t, "env", result[0].name)
+	assertNoLabel(t, result, "le")
 }
 
 // ── customMetricLabels tests ─────────────────────────────────────────────
@@ -206,19 +208,19 @@ func TestUserLabelsForExecution_Unprefixed(t *testing.T) {
 	require.Equal(t, "prod", result[0].value)
 }
 
-// TestUserLabelsForExecution_ReservedNamePassthrough: reserved names are NOT dropped —
-// if a tenant reaches this state post-migration it means we added a new reserved label,
-// and the user-defined value should win to avoid breaking existing behaviour.
-func TestUserLabelsForExecution_ReservedNamePassthrough(t *testing.T) {
+// TestUserLabelsForExecution_ReservedNameDropped: reserved names are dropped from
+// execution-metric labels in both DUAL_WRITE and UNPREFIXED, so a user label cannot
+// overwrite an intrinsic per-series metric label such as `le`.
+func TestUserLabelsForExecution_ReservedNameDropped(t *testing.T) {
 	for _, mode := range []sm.LabelMode{sm.LabelMode_LABEL_MODE_DUAL_WRITE, sm.LabelMode_LABEL_MODE_UNPREFIXED} {
 		result := customMetricLabels(
 			nil,
-			makeLabels("probe", "myprobe", "env", "prod"),
+			makeLabels("le", "user-value", "env", "prod"),
 			mode,
 		)
-		require.Len(t, result, 2)
-		findLabel(t, result, "probe")
-		findLabel(t, result, "env")
+		require.Len(t, result, 1)
+		require.Equal(t, "env", result[0].name)
+		assertNoLabel(t, result, "le")
 	}
 }
 

--- a/internal/scraper/labels_test.go
+++ b/internal/scraper/labels_test.go
@@ -1,0 +1,146 @@
+package scraper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+func labels(pairs ...string) []sm.Label {
+	if len(pairs)%2 != 0 {
+		panic("labels: pairs must be even")
+	}
+	out := make([]sm.Label, 0, len(pairs)/2)
+	for i := 0; i < len(pairs); i += 2 {
+		out = append(out, sm.Label{Name: pairs[i], Value: pairs[i+1]})
+	}
+	return out
+}
+
+func findLabel(t *testing.T, lps []labelPair, name string) labelPair {
+	t.Helper()
+	for _, lp := range lps {
+		if lp.name == name {
+			return lp
+		}
+	}
+	t.Fatalf("label %q not found in %v", name, lps)
+	return labelPair{}
+}
+
+func assertNoLabel(t *testing.T, lps []labelPair, name string) {
+	t.Helper()
+	for _, lp := range lps {
+		if lp.name == name {
+			t.Errorf("unexpected label %q found in %v", name, lps)
+		}
+	}
+}
+
+// TestBuildUserLabels_Prefixed_CheckOverridesProbe: probe sets env=dev, check sets env=prod.
+// Result should be only label_env=prod (check wins, prefixed).
+func TestBuildUserLabels_Prefixed_CheckOverridesProbe(t *testing.T) {
+	result := buildUserLabels(
+		labels("env", "dev"),
+		labels("env", "prod"),
+		sm.LabelMode_LABEL_MODE_PREFIXED,
+	)
+	require.Len(t, result, 1)
+	assert.Equal(t, "label_env", result[0].name)
+	assert.Equal(t, "prod", result[0].value)
+}
+
+// TestBuildUserLabels_Prefixed_TwoDistinctLabels: probe has region=eu, check has env=prod.
+// Both appear prefixed, probe label first.
+func TestBuildUserLabels_Prefixed_TwoDistinctLabels(t *testing.T) {
+	result := buildUserLabels(
+		labels("region", "eu"),
+		labels("env", "prod"),
+		sm.LabelMode_LABEL_MODE_PREFIXED,
+	)
+	require.Len(t, result, 2)
+	lp1 := findLabel(t, result, "label_region")
+	assert.Equal(t, "eu", lp1.value)
+	lp2 := findLabel(t, result, "label_env")
+	assert.Equal(t, "prod", lp2.value)
+}
+
+// TestBuildUserLabels_Prefixed_ReservedNotDropped: in PREFIXED mode, reserved names are NOT
+// dropped — enforcement is at the API layer, not here.
+func TestBuildUserLabels_Prefixed_ReservedNotDropped(t *testing.T) {
+	result := buildUserLabels(
+		nil,
+		labels("probe", "myprobe"),
+		sm.LabelMode_LABEL_MODE_PREFIXED,
+	)
+	require.Len(t, result, 1)
+	assert.Equal(t, "label_probe", result[0].name)
+	assert.Equal(t, "myprobe", result[0].value)
+}
+
+// TestBuildUserLabels_DualWrite_Basic: DUAL_WRITE emits all prefixed forms first, then all
+// un-prefixed forms: [label_env, env]. The prefixed form comes first so that in the event
+// of log stream label overflow, the form existing policies depend on is preserved.
+func TestBuildUserLabels_DualWrite_Basic(t *testing.T) {
+	result := buildUserLabels(
+		nil,
+		labels("env", "prod"),
+		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
+	)
+	require.Len(t, result, 2)
+	assert.Equal(t, "label_env", result[0].name, "prefixed form must come first")
+	assert.Equal(t, "prod", result[0].value)
+	assert.Equal(t, "env", result[1].name, "un-prefixed form must come second")
+	assert.Equal(t, "prod", result[1].value)
+}
+
+// TestBuildUserLabels_DualWrite_TwoLabels: two labels produce [label_a, label_b, a, b] —
+// all prefixed first, then all un-prefixed.
+func TestBuildUserLabels_DualWrite_TwoLabels(t *testing.T) {
+	result := buildUserLabels(
+		labels("team", "sre"),
+		labels("env", "prod"),
+		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
+	)
+	require.Len(t, result, 4)
+	// First half: all prefixed
+	assert.Equal(t, "label_team", result[0].name)
+	assert.Equal(t, "label_env", result[1].name)
+	// Second half: all un-prefixed
+	assert.Equal(t, "team", result[2].name)
+	assert.Equal(t, "env", result[3].name)
+}
+
+// TestBuildUserLabels_DualWrite_CheckOverridesProbe: probe env=dev, check env=prod.
+// Both forms should carry the check's value.
+func TestBuildUserLabels_DualWrite_CheckOverridesProbe(t *testing.T) {
+	result := buildUserLabels(
+		labels("env", "dev"),
+		labels("env", "prod"),
+		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
+	)
+	require.Len(t, result, 2)
+	assert.Equal(t, "label_env", result[0].name)
+	assert.Equal(t, "prod", result[0].value, "prefixed form should have check value")
+	assert.Equal(t, "env", result[1].name)
+	assert.Equal(t, "prod", result[1].value, "un-prefixed form should have check value")
+}
+
+// TestBuildUserLabels_DualWrite_ReservedNamePassthrough: reserved names are NOT dropped —
+// user-defined value wins over the system-emitted value for post-migration additions.
+func TestBuildUserLabels_DualWrite_ReservedNamePassthrough(t *testing.T) {
+	result := buildUserLabels(
+		nil,
+		labels("probe", "myprobe", "env", "prod"),
+		sm.LabelMode_LABEL_MODE_DUAL_WRITE,
+	)
+	// [label_probe, label_env, probe, env]
+	require.Len(t, result, 4)
+	assert.Equal(t, "label_probe", result[0].name)
+	assert.Equal(t, "label_env", result[1].name)
+	assert.Equal(t, "probe", result[2].name)
+	assert.Equal(t, "env", result[3].name)
+}

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -69,9 +69,6 @@ type TenantCals interface {
 	CostAttributionLabels(ctx context.Context, tenantID model.GlobalID) ([]string, error)
 }
 
-// TenantLabelMode provides the label migration mode for a tenant.
-// The implementation reads from the GetTenant response, which is cached by the
-// tenant manager, so calls within the cache TTL are fast local reads.
 type TenantLabelMode interface {
 	ForTenant(ctx context.Context, tenantID model.GlobalID) (sm.LabelMode, error)
 }
@@ -89,9 +86,9 @@ type Scraper struct {
 	check         model.Check
 	probe         sm.Probe
 	prober        prober.Prober
-	labelsLimiter  LabelsLimiter
-	labellingMode  TenantLabelMode
-	stop           chan struct{}
+	labelsLimiter LabelsLimiter
+	labellingMode TenantLabelMode
+	stop          chan struct{}
 	metrics       Metrics
 	summaries     map[uint64]prometheus.Summary
 	histograms    map[uint64]prometheus.Histogram
@@ -516,10 +513,16 @@ func tickWithOffset(
 }
 
 func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time.Duration, error) {
+	target := s.target
+
+	labelMode, err := s.labellingMode.ForTenant(ctx, s.check.GlobalTenantID())
+	if err != nil {
+		return nil, 0, fmt.Errorf("retrieving tenant label mode: %w", err)
+	}
+
 	var (
-		target = s.target
 		// These are the labels defined by the user.
-		userLabels = s.buildUserLabels()
+		userLabels = buildUserLabels(s.probe.Labels, s.check.Labels, labelMode)
 		// These labels are applied to the sm_check_info metric.
 		checkInfoLabels = s.buildCheckInfoLabels(userLabels)
 		// This is the execution ID for the check run.
@@ -608,6 +611,14 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 		// {name: "source", value: CheckInfoSource}, // identify metrics that belong to synthetic-monitoring-agent
 	}
 
+	// In DUAL_WRITE and UNPREFIXED modes, append un-prefixed user labels to every
+	// execution metric (probe_success, probe_duration_seconds, probe_http_*, etc.).
+	// This enables label-based filtering and cost attribution directly on high-frequency
+	// series without requiring a join to sm_check_info.
+	// Only the un-prefixed form is added — the dual-write of prefixed+un-prefixed
+	// continues to apply to sm_check_info and Loki streams only.
+	metricLabels = append(metricLabels, userLabelsForExecution(s.probe.Labels, s.check.Labels, labelMode)...)
+
 	ts := s.extractTimeseries(t, mfs, metricLabels)
 
 	successValue := "1"
@@ -616,13 +627,27 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 		successValue = "0"
 	}
 
-	if len(logLabels) >= maxLogLabels {
-		logLabels = logLabels[:maxLogLabels-1]
+	// Split logLabels into stream labels and structured metadata overflow.
+	// maxLogLabels - 1 reserves one slot for probe_success which is always appended.
+	var streamLogLabels []labelPair
+	var overflowMetadata []logproto.LabelAdapter
+	maxUserLogLabels := maxLogLabels - 1
+	if len(logLabels) > maxUserLogLabels {
+		streamLogLabels = logLabels[:maxUserLogLabels]
+		for _, lp := range logLabels[maxUserLogLabels:] {
+			overflowMetadata = append(overflowMetadata, logproto.LabelAdapter{Name: lp.name, Value: lp.value})
+		}
+	} else {
+		streamLogLabels = logLabels
 	}
-	logLabels = append(logLabels, labelPair{name: ProbeSuccessMetricName, value: successValue}) // identify log lines that are failures
+	streamLogLabels = append(streamLogLabels, labelPair{name: ProbeSuccessMetricName, value: successValue}) // identify log lines that are failures
+
+	// full set of structured metadata consists of any overflow labels
+	// and the execution_id
+	structuredMetadata := append(overflowMetadata, logproto.LabelAdapter{Name: "execution_id", Value: executionID})
 
 	// streams need to have all the labels applied to them because loki does not support joins
-	streams := s.extractLogs(t, logs.Bytes(), logLabels, executionID)
+	streams := s.extractLogs(t, logs.Bytes(), streamLogLabels, structuredMetadata)
 
 	return &probeData{ts: ts, streams: streams, tenantId: s.check.GlobalTenantID()}, duration, err
 }
@@ -835,7 +860,10 @@ func getDerivedMetrics(mfs []*dto.MetricFamily, summaries map[uint64]prometheus.
 	return nil
 }
 
-func (s Scraper) extractLogs(t time.Time, logs []byte, sharedLabels []labelPair, executionID string) Streams {
+// extractLogs parses logfmt-encoded log bytes and returns Loki streams using sharedLabels
+// as stream labels. Any labels in structuredMetadata are attached to each log entry as
+// Loki structured metadata (queryable but not indexed as stream labels).
+func (s Scraper) extractLogs(t time.Time, logs []byte, sharedLabels []labelPair, structuredMetadata []logproto.LabelAdapter) Streams {
 	var line strings.Builder
 
 	dec := logfmt.NewDecoder(bytes.NewReader(logs))
@@ -896,11 +924,9 @@ RECORD:
 			s.logger.Warn().Err(err).Msg("encoding logs")
 		}
 		entries = append(entries, logproto.Entry{
-			Timestamp: t,
-			Line:      line.String(),
-			StructuredMetadata: logproto.LabelsAdapter{
-				{Name: "execution_id", Value: executionID},
-			},
+			Timestamp:          t,
+			Line:               line.String(),
+			StructuredMetadata: structuredMetadata,
 		})
 	}
 
@@ -955,32 +981,89 @@ func (s Scraper) buildCheckInfoLabels(userLabels []labelPair) map[string]string 
 	return labels
 }
 
-func (s Scraper) buildUserLabels() []labelPair {
-	labels := []labelPair{}
-	idx := make(map[string]int)
+// buildUserLabels builds the user-defined label pairs from probe and check labels
+// according to the tenant's LabelMode.
+//
+// Reserved system label names are not filtered here. The API enforces that tenants
+// in DUAL_WRITE or UNPREFIXED mode cannot have user labels whose names collide with
+// the reserved set at the time of migration. Any collision that occurs post-migration
+// can only be caused by adding a new label to the reserved set, in which case the
+// user-defined value should win — preserving existing tenant behaviour is preferable
+// to silently breaking it.
+//
+// In DUAL_WRITE mode, all prefixed forms are emitted first, followed by all
+// un-prefixed forms: [label_foo, label_bar, foo, bar]. This ordering ensures that
+// in the event of log stream label overflow, the prefixed forms — which existing
+// policies depend on — are preserved as stream labels, while the un-prefixed forms
+// spill into StructuredMetadata.
+func buildUserLabels(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) []labelPair {
+	// Collect unique labels in order, with check values overriding probe values.
+	collected := []labelPair{}
+	seen := make(map[string]int) // name → index in collected
 
-	// add probe labels
-	for _, l := range s.probe.Labels {
-		idx[l.Name] = len(labels)
-
-		labels = append(labels,
-			labelPair{name: "label_" + l.Name, value: l.Value})
-	}
-
-	// add check labels
-	for _, l := range s.check.Labels {
-		if where, found := idx[l.Name]; found {
-			// already there, update value
-			labels[where].value = l.Value
-			continue
+	for _, src := range [][]sm.Label{probeLabels, checkLabels} {
+		for _, l := range src {
+			if i, found := seen[l.Name]; found {
+				collected[i].value = l.Value
+				continue
+			}
+			seen[l.Name] = len(collected)
+			collected = append(collected, labelPair{name: l.Name, value: l.Value})
 		}
-
-		idx[l.Name] = len(labels)
-
-		labels = append(labels,
-			labelPair{name: "label_" + l.Name, value: l.Value})
 	}
 
+	switch mode {
+	case sm.LabelMode_LABEL_MODE_DUAL_WRITE:
+		// All prefixed forms first, then all un-prefixed forms.
+		labels := make([]labelPair, 0, 2*len(collected))
+		for _, e := range collected {
+			labels = append(labels, labelPair{name: "label_" + e.name, value: e.value})
+		}
+		for _, e := range collected {
+			labels = append(labels, labelPair{name: e.name, value: e.value})
+		}
+		return labels
+	case sm.LabelMode_LABEL_MODE_UNPREFIXED:
+		labels := make([]labelPair, 0, len(collected))
+		for _, e := range collected {
+			labels = append(labels, labelPair{name: e.name, value: e.value})
+		}
+		return labels
+	default: // LABEL_MODE_PREFIXED
+		labels := make([]labelPair, 0, len(collected))
+		for _, e := range collected {
+			labels = append(labels, labelPair{name: "label_" + e.name, value: e.value})
+		}
+		return labels
+	}
+}
+
+// userLabelsForExecution returns the un-prefixed user-defined labels to be added to
+// check execution metrics (probe_success, probe_duration_seconds, probe_http_*, etc.)
+// in DUAL_WRITE and UNPREFIXED modes.
+//
+// In PREFIXED mode this returns nil — execution metrics carry no user labels.
+//
+// In DUAL_WRITE and UNPREFIXED modes, only the un-prefixed form is returned — the
+// dual-write of prefixed+un-prefixed applies only to sm_check_info and Loki streams.
+func userLabelsForExecution(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) []labelPair {
+	if mode == sm.LabelMode_LABEL_MODE_PREFIXED {
+		return nil
+	}
+
+	var labels []labelPair
+	seen := make(map[string]int) // base name → index in labels; check overrides probe
+
+	for _, src := range [][]sm.Label{probeLabels, checkLabels} {
+		for _, l := range src {
+			if idx, found := seen[l.Name]; found {
+				labels[idx].value = l.Value
+				continue
+			}
+			seen[l.Name] = len(labels)
+			labels = append(labels, labelPair{name: l.Name, value: l.Value})
+		}
+	}
 	return labels
 }
 

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -522,9 +522,9 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 
 	labelMode, err := s.labellingMode.ForTenant(ctx, s.check.GlobalTenantID())
 	if err != nil {
-		// ForTenant falls back to PREFIXED on transient errors so that a temporary tenant
+		// ForTenant falls back to UNPREFIXED on transient errors so that a temporary tenant
 		// cache miss does not abort the scrape.
-		s.logger.Warn().Err(err).Msg("could not retrieve tenant label mode, falling back to PREFIXED")
+		s.logger.Warn().Err(err).Msg("could not retrieve tenant label mode, falling back to UNPREFIXED")
 	}
 
 	// TODO(mem): this is constant for the scraper, move this

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -1021,18 +1021,18 @@ func (s Scraper) buildCheckInfoLabels(userLabels []labelPair, commonLabels []lab
 // buildUserLabels builds the user-defined label pairs from probe and check labels
 // according to the tenant's LabelMode.
 //
-// Reserved system label names are not filtered here. The API enforces that tenants
-// in DUAL_WRITE or UNPREFIXED mode cannot have user labels whose names collide with
-// the reserved set at the time of migration. Any collision that occurs post-migration
-// can only be caused by adding a new label to the reserved set, in which case the
-// user-defined value should win — preserving existing tenant behaviour is preferable
-// to silently breaking it.
+// In DUAL_WRITE and UNPREFIXED modes, un-prefixed user labels whose names are
+// reserved system labels (sm.IsSystemLabel) are dropped. This asserts the API's
+// guarantee that a migrated tenant carries no such label, and prevents a stray
+// reserved name from overwriting an intrinsic per-series metric label such as
+// `le` or `phase`. Prefixed forms (`label_*`) are never dropped, since no reserved
+// name begins with "label_", and PREFIXED mode is left untouched.
 //
 // In DUAL_WRITE mode, all prefixed forms are emitted first, followed by all
-// un-prefixed forms: [label_foo, label_bar, foo, bar]. This ordering ensures that
-// in the event of log stream label overflow, the prefixed forms — which existing
-// policies depend on — are preserved as stream labels, while the un-prefixed forms
-// spill into StructuredMetadata.
+// surviving un-prefixed forms: [label_foo, label_bar, foo, bar]. This ordering
+// ensures that in the event of log stream label overflow, the prefixed forms —
+// which existing policies depend on — are preserved as stream labels, while the
+// un-prefixed forms spill into StructuredMetadata.
 func buildUserLabels(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) []labelPair {
 	// Probe labels first, then any non-colliding check labels. On a name
 	// collision the check value overwrites in place, so check values win while
@@ -1047,11 +1047,23 @@ func buildUserLabels(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) []l
 			labels = append(labels, labelPair{name: "label_" + e.name, value: e.value})
 		}
 		for _, e := range userLabels {
+			// reserved labels should be dropped from the user's custom set
+			if sm.IsSystemLabel(e.name) {
+				continue
+			}
 			labels = append(labels, labelPair{name: e.name, value: e.value})
 		}
 		return labels
 	case sm.LabelMode_LABEL_MODE_UNPREFIXED:
-		return userLabels
+		filtered := make([]labelPair, 0, len(userLabels))
+		for _, e := range userLabels {
+			// reserved labels should be dropped from the user's custom set
+			if sm.IsSystemLabel(e.name) {
+				continue
+			}
+			filtered = append(filtered, e)
+		}
+		return filtered
 	default: // LABEL_MODE_PREFIXED - prefix custom label names with label_
 		for i := range userLabels {
 			userLabels[i].name = "label_" + userLabels[i].name

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -541,7 +541,15 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 		return nil, 0, fmt.Errorf("retrieving tenant log labels limit: %w", err)
 	}
 
-	if len(checkInfoLabels) > maxMetricLabels {
+	// In DUAL_WRITE mode, buildUserLabels emits both prefixed and un-prefixed
+	// forms, so checkInfoLabels can contain up to 2× the user label entries.
+	// Cap at 40 (the Mimir hard limit) to avoid false-firing while still
+	// guarding against genuinely invalid sizes.
+	checkInfoLimit := min(maxMetricLabels*2, 40)
+	if labelMode != sm.LabelMode_LABEL_MODE_DUAL_WRITE {
+		checkInfoLimit = maxMetricLabels
+	}
+	if len(checkInfoLabels) > checkInfoLimit {
 		// This should never happen.
 		return nil, 0, fmt.Errorf("invalid configuration, too many labels: %d", len(checkInfoLabels))
 	}

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -69,6 +69,13 @@ type TenantCals interface {
 	CostAttributionLabels(ctx context.Context, tenantID model.GlobalID) ([]string, error)
 }
 
+// TenantLabelMode provides the label migration mode for a tenant.
+// The implementation reads from the GetTenant response, which is cached by the
+// tenant manager, so calls within the cache TTL are fast local reads.
+type TenantLabelMode interface {
+	ForTenant(ctx context.Context, tenantID model.GlobalID) (sm.LabelMode, error)
+}
+
 type Telemeter interface {
 	AddExecution(e telemetry.Execution)
 }
@@ -82,8 +89,9 @@ type Scraper struct {
 	check         model.Check
 	probe         sm.Probe
 	prober        prober.Prober
-	labelsLimiter LabelsLimiter
-	stop          chan struct{}
+	labelsLimiter  LabelsLimiter
+	labellingMode  TenantLabelMode
+	stop           chan struct{}
 	metrics       Metrics
 	summaries     map[uint64]prometheus.Summary
 	histograms    map[uint64]prometheus.Histogram
@@ -101,6 +109,7 @@ type Factory func(
 	telemeter *telemetry.Telemeter,
 	secretStore secrets.SecretProvider,
 	cals TenantCals,
+	labellingMode TenantLabelMode,
 ) (*Scraper, error)
 
 type (
@@ -136,6 +145,7 @@ func New(
 	telemeter *telemetry.Telemeter,
 	secretStore secrets.SecretProvider,
 	cals TenantCals,
+	labellingMode TenantLabelMode,
 ) (*Scraper, error) {
 	return NewWithOpts(ctx, check, ScraperOpts{
 		Probe:                 probe,
@@ -146,6 +156,7 @@ func New(
 		LabelsLimiter:         labelsLimiter,
 		Telemeter:             telemeter,
 		CostAttributionLabels: cals,
+		LabellingMode:         labellingMode,
 	})
 }
 
@@ -158,6 +169,7 @@ type ScraperOpts struct {
 	Metrics               Metrics
 	ProbeFactory          prober.ProberFactory
 	LabelsLimiter         LabelsLimiter
+	LabellingMode         TenantLabelMode
 	Telemeter             Telemeter
 	CostAttributionLabels TenantCals
 }
@@ -192,6 +204,7 @@ func NewWithOpts(ctx context.Context, check model.Check, opts ScraperOpts) (*Scr
 		probe:         opts.Probe,
 		prober:        smProber,
 		labelsLimiter: opts.LabelsLimiter,
+		labellingMode: opts.LabellingMode,
 		stop:          make(chan struct{}),
 		metrics:       opts.Metrics,
 		summaries:     make(map[uint64]prometheus.Summary),

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -218,6 +218,7 @@ func NewWithOpts(ctx context.Context, check model.Check, opts ScraperOpts) (*Scr
 var (
 	errCheckFailed       = errors.New("probe failed")
 	errUnsupportedMetric = errors.New("unsupported metric type")
+	errTooManyLabels     = errors.New("invalid configuration, too many labels")
 )
 
 type checkStateMachine struct {
@@ -566,7 +567,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 	}
 	if len(checkInfoLabels) > checkInfoLimit {
 		// This should never happen.
-		return nil, 0, fmt.Errorf("invalid configuration, too many labels: %d", len(checkInfoLabels))
+		return nil, 0, fmt.Errorf("%w: %d", errTooManyLabels, len(checkInfoLabels))
 	}
 
 	logLabels := []labelPair{
@@ -1138,7 +1139,7 @@ func mergeUserLabels(probeLabels, checkLabels []sm.Label) []labelPair {
 // tail spills into structured metadata. User values still win on collision,
 // which protects a tenant whose existing label name later becomes reserved.
 func mergeLogLabels(systemLabels, userLabels []labelPair) []labelPair {
-	merged := make([]labelPair, len(systemLabels)+len(userLabels))
+	merged := make([]labelPair, len(systemLabels), len(systemLabels)+len(userLabels))
 	copy(merged, systemLabels)
 
 	idx := make(map[string]int, len(systemLabels))

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -613,10 +613,6 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 
 	// In DUAL_WRITE and UNPREFIXED modes, append un-prefixed user labels to every
 	// execution metric (probe_success, probe_duration_seconds, probe_http_*, etc.).
-	// This enables label-based filtering and cost attribution directly on high-frequency
-	// series without requiring a join to sm_check_info.
-	// Only the un-prefixed form is added — the dual-write of prefixed+un-prefixed
-	// continues to apply to sm_check_info and Loki streams only.
 	metricLabels = append(metricLabels, userLabelsForExecution(s.probe.Labels, s.check.Labels, labelMode)...)
 
 	ts := s.extractTimeseries(t, mfs, metricLabels)
@@ -642,8 +638,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 	}
 	streamLogLabels = append(streamLogLabels, labelPair{name: ProbeSuccessMetricName, value: successValue}) // identify log lines that are failures
 
-	// full set of structured metadata consists of any overflow labels
-	// and the execution_id
+	// full set of structured metadata consists of any overflow labels and the execution_id
 	overflowMetadata = append(overflowMetadata, logproto.LabelAdapter{Name: "execution_id", Value: executionID})
 	structuredMetadata := overflowMetadata
 
@@ -863,7 +858,7 @@ func getDerivedMetrics(mfs []*dto.MetricFamily, summaries map[uint64]prometheus.
 
 // extractLogs parses logfmt-encoded log bytes and returns Loki streams using sharedLabels
 // as stream labels. Any labels in structuredMetadata are attached to each log entry as
-// Loki structured metadata (queryable but not indexed as stream labels).
+// Loki structured metadata.
 func (s Scraper) extractLogs(t time.Time, logs []byte, sharedLabels []labelPair, structuredMetadata []logproto.LabelAdapter) Streams {
 	var line strings.Builder
 

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -526,11 +526,23 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 		s.logger.Warn().Err(err).Msg("could not retrieve tenant label mode, falling back to PREFIXED")
 	}
 
+	// TODO(mem): this is constant for the scraper, move this
+	// outside this function?
+	// sysMetricLabels are the common labels present on ALL metrics
+	// emitted by the system.
+	sysMetricLabels := []labelPair{
+		{name: probeLabelName, value: s.probe.Name},
+		{name: configVersionLabelName, value: s.check.ConfigVersion()},
+		{name: "instance", value: s.check.Target},
+		{name: "job", value: s.check.Job},
+		// {name: "source", value: CheckInfoSource}, // identify metrics that belong to synthetic-monitoring-agent
+	}
+
 	var (
 		// These are the labels defined by the user.
 		userLabels = buildUserLabels(s.probe.Labels, s.check.Labels, labelMode)
 		// These labels are applied to the sm_check_info metric.
-		checkInfoLabels = s.buildCheckInfoLabels(userLabels)
+		checkInfoLabels = s.buildCheckInfoLabels(userLabels, sysMetricLabels)
 		// This is the execution ID for the check run.
 		executionID = uuid.New().String()
 	)
@@ -615,22 +627,12 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 	// At this point we know the check has been executed, regardless of
 	// whether it succeeded or not.
 
-	// TODO(mem): this is constant for the scraper, move this
-	// outside this function?
-	metricLabels := []labelPair{
-		{name: probeLabelName, value: s.probe.Name},
-		{name: configVersionLabelName, value: s.check.ConfigVersion()},
-		{name: "instance", value: s.check.Target},
-		{name: "job", value: s.check.Job},
-		// {name: "source", value: CheckInfoSource}, // identify metrics that belong to synthetic-monitoring-agent
-	}
-
-	// In DUAL_WRITE and UNPREFIXED modes, append un-prefixed user labels to every
-	// execution metric (probe_success, probe_duration_seconds, probe_http_*, etc.).
+	// In DUAL_WRITE and UNPREFIXED modes, un-prefixed user labels are appended to
+	// execution metrics (probe_success, probe_duration_seconds, probe_http_*, etc.).
 	// user-defined label values are retained over system-defined values.
-	metricLabels = appendUniqueLabels(userLabelsForExecution(s.probe.Labels, s.check.Labels, labelMode), metricLabels)
+	executionMetricLabels := appendUniqueLabels(customMetricLabels(s.probe.Labels, s.check.Labels, labelMode), sysMetricLabels)
 
-	ts := s.extractTimeseries(t, mfs, metricLabels)
+	ts := s.extractTimeseries(t, mfs, executionMetricLabels)
 
 	successValue := "1"
 	if !success {
@@ -953,43 +955,66 @@ RECORD:
 	}
 }
 
-func (s Scraper) extractTimeseries(t time.Time, metrics []*dto.MetricFamily, sharedLabels []labelPair) TimeSeries {
-	return extractTimeseries(t, metrics, sharedLabels, s.summaries, s.histograms, s.logger)
+func (s Scraper) extractTimeseries(t time.Time, metrics []*dto.MetricFamily, executionLabels []labelPair) TimeSeries {
+	return extractTimeseries(t, metrics, executionLabels, s.summaries, s.histograms, s.logger)
 }
 
-func extractTimeseries(t time.Time, metrics []*dto.MetricFamily, sharedLabels []labelPair, summaries map[uint64]prometheus.Summary, histograms map[uint64]prometheus.Histogram, logger zerolog.Logger) TimeSeries {
-	metricLabels := make([]prompb.Label, 0, len(sharedLabels))
-	for _, label := range sharedLabels {
-		metricLabels = append(metricLabels, prompb.Label{Name: label.name, Value: truncateLabelValue(label.value)})
+// extractTimeseries converts gathered Prometheus metrics into remote-write time series.
+//
+//	executionLabels: system labels + un-prefixed user labels; applied to all check execution
+//		metrics (probe_success, etc.).
+func extractTimeseries(t time.Time, metrics []*dto.MetricFamily, executionLabels []labelPair, summaries map[uint64]prometheus.Summary, histograms map[uint64]prometheus.Histogram, logger zerolog.Logger) TimeSeries {
+	toPrompb := func(pairs []labelPair) []prompb.Label {
+		out := make([]prompb.Label, 0, len(pairs))
+		for _, label := range pairs {
+			out = append(out, prompb.Label{Name: label.name, Value: truncateLabelValue(label.value)})
+		}
+		return out
 	}
+
+	executionPrompb := toPrompb(executionLabels)
 
 	var ts []prompb.TimeSeries
 	for _, mf := range metrics {
 		mName := mf.GetName()
 		mType := mf.GetType()
 
+		shared := executionPrompb
+		if mName == CheckInfoMetricName {
+			// sm_check_info is already constructed with the user labels
+			// added to it under the correct LabeLMode paradigm.
+			shared = nil
+		}
+
 		for _, m := range mf.GetMetric() {
-			ts = appendDtoToTimeseries(ts, t, mName, metricLabels, mType, m)
+			ts = appendDtoToTimeseries(ts, t, mName, shared, mType, m)
 		}
 	}
 
 	return ts
 }
 
-func (s Scraper) buildCheckInfoLabels(userLabels []labelPair) map[string]string {
-	labels := map[string]string{
-		"check_name":    s.checkName,
-		regionLabelName: s.probe.Region,
-		"frequency":     strconv.FormatInt(s.check.Frequency, 10),
-		"geohash":       geohash.Encode(float64(s.probe.Latitude), float64(s.probe.Longitude)),
+func (s Scraper) buildCheckInfoLabels(userLabels []labelPair, commonLabels []labelPair) map[string]string {
+	baseLabels := []labelPair{
+		{name: "check_name", value: s.checkName},
+		{name: regionLabelName, value: s.probe.Region},
+		{name: "frequency", value: strconv.FormatInt(s.check.Frequency, 10)},
+		{name: "geohash", value: geohash.Encode(float64(s.probe.Latitude), float64(s.probe.Longitude))},
 	}
+	baseLabels = append(baseLabels, commonLabels...)
+
 	if s.check.AlertSensitivity != "" && s.check.AlertSensitivity != "none" {
-		labels["alert_sensitivity"] = s.check.AlertSensitivity
+		baseLabels = append(baseLabels, labelPair{name: "alert_sensitivity", value: s.check.AlertSensitivity})
 	}
-	for _, label := range userLabels {
-		labels[label.name] = label.value
+
+	checkInfoLabels := appendUniqueLabels(userLabels, baseLabels)
+
+	labelMap := make(map[string]string, len(checkInfoLabels))
+	for _, l := range checkInfoLabels {
+		labelMap[l.name] = l.value
 	}
-	return labels
+
+	return labelMap
 }
 
 // buildUserLabels builds the user-defined label pairs from probe and check labels
@@ -1034,12 +1059,12 @@ func buildUserLabels(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) []l
 	}
 }
 
-// userLabelsForExecution returns the un-prefixed user-defined labels to be added to
+// customMetricLabels returns the un-prefixed user-defined labels to be added to
 // check execution metrics (probe_success, probe_duration_seconds, probe_http_*, etc.)
 // in DUAL_WRITE and UNPREFIXED modes.
 //
 // In PREFIXED mode this returns nil — execution metrics carry no custom labels.
-func userLabelsForExecution(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) []labelPair {
+func customMetricLabels(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) []labelPair {
 	if mode == sm.LabelMode_LABEL_MODE_PREFIXED {
 		return nil
 	}
@@ -1049,8 +1074,27 @@ func userLabelsForExecution(probeLabels, checkLabels []sm.Label, mode sm.LabelMo
 func makeTimeseries(t time.Time, value float64, labels ...prompb.Label) prompb.TimeSeries {
 	var ts prompb.TimeSeries
 
-	ts.Labels = make([]prompb.Label, len(labels))
-	copy(ts.Labels, labels)
+	// duplicate labels on timeseries are rejected by Mimir.
+	// this is also a common point to enforce conflict resolution
+	// for LabelMode - user-defined labels should appear first in the list
+	// of labels associated with each timeseries so that de-duplication favours retaining them
+	// over system-defined values.
+	ts.Labels = make([]prompb.Label, 0, len(labels))
+
+	for _, l := range labels {
+		dup := false
+
+		for i := range ts.Labels {
+			if ts.Labels[i].Name == l.Name {
+				dup = true
+				break
+			}
+		}
+
+		if !dup {
+			ts.Labels = append(ts.Labels, l)
+		}
+	}
 
 	ts.Samples = []prompb.Sample{
 		{Timestamp: t.UnixNano() / 1e6, Value: value},

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -517,7 +517,10 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 
 	labelMode, err := s.labellingMode.ForTenant(ctx, s.check.GlobalTenantID())
 	if err != nil {
-		return nil, 0, fmt.Errorf("retrieving tenant label mode: %w", err)
+		// Fall back to PREFIXED on transient errors so that a temporary tenant
+		// cache miss does not abort the scrape.
+		s.logger.Warn().Err(err).Msg("could not retrieve tenant label mode, falling back to PREFIXED")
+		labelMode = sm.LabelMode_LABEL_MODE_PREFIXED
 	}
 
 	var (

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -644,7 +644,8 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 
 	// full set of structured metadata consists of any overflow labels
 	// and the execution_id
-	structuredMetadata := append(overflowMetadata, logproto.LabelAdapter{Name: "execution_id", Value: executionID})
+	overflowMetadata = append(overflowMetadata, logproto.LabelAdapter{Name: "execution_id", Value: executionID})
+	structuredMetadata := overflowMetadata
 
 	// streams need to have all the labels applied to them because loki does not support joins
 	streams := s.extractLogs(t, logs.Bytes(), streamLogLabels, structuredMetadata)

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -49,6 +49,10 @@ const (
 	configVersionLabelName = "config_version"
 )
 
+// mimirMaxLabelsIngest protects us and Mimir from hitting an error due to
+// ingest limit; is short of the true ingest limit to retain room for growth.
+const mimirMaxLabelsIngest = 40
+
 var (
 	staleNaN    uint64  = 0x7ff0000000000002
 	staleMarker float64 = math.Float64frombits(staleNaN)
@@ -517,10 +521,9 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 
 	labelMode, err := s.labellingMode.ForTenant(ctx, s.check.GlobalTenantID())
 	if err != nil {
-		// Fall back to PREFIXED on transient errors so that a temporary tenant
+		// ForTenant falls back to PREFIXED on transient errors so that a temporary tenant
 		// cache miss does not abort the scrape.
 		s.logger.Warn().Err(err).Msg("could not retrieve tenant label mode, falling back to PREFIXED")
-		labelMode = sm.LabelMode_LABEL_MODE_PREFIXED
 	}
 
 	var (
@@ -543,9 +546,9 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 
 	// In DUAL_WRITE mode, buildUserLabels emits both prefixed and un-prefixed
 	// forms, so checkInfoLabels can contain up to 2× the user label entries.
-	// Cap at 40 (the Mimir hard limit) to avoid false-firing while still
-	// guarding against genuinely invalid sizes.
-	checkInfoLimit := min(maxMetricLabels*2, 40)
+	// Cap at mimirMaxLabelsIngest to avoid false-firing while still guarding
+	// against genuinely invalid sizes.
+	checkInfoLimit := min(maxMetricLabels*2, mimirMaxLabelsIngest)
 	if labelMode != sm.LabelMode_LABEL_MODE_DUAL_WRITE {
 		checkInfoLimit = maxMetricLabels
 	}
@@ -624,7 +627,8 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 
 	// In DUAL_WRITE and UNPREFIXED modes, append un-prefixed user labels to every
 	// execution metric (probe_success, probe_duration_seconds, probe_http_*, etc.).
-	metricLabels = append(metricLabels, userLabelsForExecution(s.probe.Labels, s.check.Labels, labelMode)...)
+	// user-defined label values are retained over system-defined values.
+	metricLabels = appendUniqueLabels(userLabelsForExecution(s.probe.Labels, s.check.Labels, labelMode), metricLabels)
 
 	ts := s.extractTimeseries(t, mfs, metricLabels)
 
@@ -1004,44 +1008,29 @@ func (s Scraper) buildCheckInfoLabels(userLabels []labelPair) map[string]string 
 // policies depend on — are preserved as stream labels, while the un-prefixed forms
 // spill into StructuredMetadata.
 func buildUserLabels(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) []labelPair {
-	// Collect unique labels in order, with check values overriding probe values.
-	collected := []labelPair{}
-	seen := make(map[string]int) // name → index in collected
-
-	for _, src := range [][]sm.Label{probeLabels, checkLabels} {
-		for _, l := range src {
-			if i, found := seen[l.Name]; found {
-				collected[i].value = l.Value
-				continue
-			}
-			seen[l.Name] = len(collected)
-			collected = append(collected, labelPair{name: l.Name, value: l.Value})
-		}
-	}
+	// Probe labels first, then any non-colliding check labels. On a name
+	// collision the check value overwrites in place, so check values win while
+	// probe ordering is preserved.
+	userLabels := mergeUserLabels(probeLabels, checkLabels)
 
 	switch mode {
 	case sm.LabelMode_LABEL_MODE_DUAL_WRITE:
 		// All prefixed forms first, then all un-prefixed forms.
-		labels := make([]labelPair, 0, 2*len(collected))
-		for _, e := range collected {
+		labels := make([]labelPair, 0, 2*len(userLabels))
+		for _, e := range userLabels {
 			labels = append(labels, labelPair{name: "label_" + e.name, value: e.value})
 		}
-		for _, e := range collected {
+		for _, e := range userLabels {
 			labels = append(labels, labelPair{name: e.name, value: e.value})
 		}
 		return labels
 	case sm.LabelMode_LABEL_MODE_UNPREFIXED:
-		labels := make([]labelPair, 0, len(collected))
-		for _, e := range collected {
-			labels = append(labels, labelPair{name: e.name, value: e.value})
+		return userLabels
+	default: // LABEL_MODE_PREFIXED - prefix custom label names with label_
+		for i := range userLabels {
+			userLabels[i].name = "label_" + userLabels[i].name
 		}
-		return labels
-	default: // LABEL_MODE_PREFIXED
-		labels := make([]labelPair, 0, len(collected))
-		for _, e := range collected {
-			labels = append(labels, labelPair{name: "label_" + e.name, value: e.value})
-		}
-		return labels
+		return userLabels
 	}
 }
 
@@ -1049,29 +1038,12 @@ func buildUserLabels(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) []l
 // check execution metrics (probe_success, probe_duration_seconds, probe_http_*, etc.)
 // in DUAL_WRITE and UNPREFIXED modes.
 //
-// In PREFIXED mode this returns nil — execution metrics carry no user labels.
-//
-// In DUAL_WRITE and UNPREFIXED modes, only the un-prefixed form is returned — the
-// dual-write of prefixed+un-prefixed applies only to sm_check_info and Loki streams.
+// In PREFIXED mode this returns nil — execution metrics carry no custom labels.
 func userLabelsForExecution(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) []labelPair {
 	if mode == sm.LabelMode_LABEL_MODE_PREFIXED {
 		return nil
 	}
-
-	var labels []labelPair
-	seen := make(map[string]int) // base name → index in labels; check overrides probe
-
-	for _, src := range [][]sm.Label{probeLabels, checkLabels} {
-		for _, l := range src {
-			if idx, found := seen[l.Name]; found {
-				labels[idx].value = l.Value
-				continue
-			}
-			seen[l.Name] = len(labels)
-			labels = append(labels, labelPair{name: l.Name, value: l.Value})
-		}
-	}
-	return labels
+	return buildUserLabels(probeLabels, checkLabels, sm.LabelMode_LABEL_MODE_UNPREFIXED)
 }
 
 func makeTimeseries(t time.Time, value float64, labels ...prompb.Label) prompb.TimeSeries {
@@ -1085,6 +1057,58 @@ func makeTimeseries(t time.Time, value float64, labels ...prompb.Label) prompb.T
 	}
 
 	return ts
+}
+
+// mergeUserLabels combines probe- and check-level labels into a single ordered
+// slice. Probe labels come first (in order), followed by any check labels whose
+// names do not appear among the probe labels. When a check label's name collides
+// with a probe label, the check value overwrites the probe value in place,
+// preserving the label's original position.
+func mergeUserLabels(probeLabels, checkLabels []sm.Label) []labelPair {
+	labels := make([]labelPair, 0, len(probeLabels)+len(checkLabels))
+	idx := make(map[string]int, len(probeLabels))
+
+	for _, l := range probeLabels {
+		idx[l.Name] = len(labels)
+		labels = append(labels, labelPair{name: l.Name, value: l.Value})
+	}
+
+	for _, l := range checkLabels {
+		if where, found := idx[l.Name]; found {
+			labels[where].value = l.Value
+			continue
+		}
+		idx[l.Name] = len(labels)
+		labels = append(labels, labelPair{name: l.Name, value: l.Value})
+	}
+
+	return labels
+}
+
+// appendUniqueLabels returns a slice of key-value labels which
+// are unique by key. Duplicates are discarded, meaning values
+// from prior slices are favoured over latter ones.
+func appendUniqueLabels(slice1, slice2 []labelPair) []labelPair {
+	if slice1 == nil && slice2 == nil {
+		return nil
+	}
+
+	result := make([]labelPair, 0, len(slice1)+len(slice2))
+	seen := make(map[string]bool)
+
+	addUnique := func(slice []labelPair) {
+		for _, val := range slice {
+			if !seen[val.name] {
+				seen[val.name] = true
+				result = append(result, val)
+			}
+		}
+	}
+
+	addUnique(slice1)
+	addUnique(slice2)
+
+	return slices.Clip(result)
 }
 
 func appendDtoToTimeseries(ts []prompb.TimeSeries, t time.Time, mName string, sharedLabels []prompb.Label, mType dto.MetricType, metric *dto.Metric) []prompb.TimeSeries {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -557,7 +557,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 	}
 
 	// In DUAL_WRITE mode, buildUserLabels emits both prefixed and un-prefixed
-	// forms, so checkInfoLabels can contain up to 2× the user label entries.
+	// forms, so the user portion can be up to 2× the user label entries.
 	// Cap at mimirMaxLabelsIngest to avoid false-firing while still guarding
 	// against genuinely invalid sizes.
 	checkInfoLimit := min(maxMetricLabels*2, mimirMaxLabelsIngest)
@@ -577,7 +577,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 		{name: "check_name", value: s.checkName},
 		{name: "source", value: CheckInfoSource}, // identify log lines that belong to synthetic-monitoring-agent
 	}
-	logLabels = append(logLabels, userLabels...)
+	logLabels = mergeLogLabels(logLabels, userLabels)
 
 	// set up logger to capture check logs
 	logs := bytes.Buffer{}
@@ -1127,6 +1127,35 @@ func mergeUserLabels(probeLabels, checkLabels []sm.Label) []labelPair {
 	}
 
 	return labels
+}
+
+// mergeLogLabels merges user-defined labels into the system log labels. On a
+// name collision the user value wins in place, preserving the ordering of the
+// system labels; user labels whose names do not collide are appended after them.
+//
+// Ordering matters: the system labels keep their leading positions so they are
+// retained as stream labels when the label set exceeds the stream cap and the
+// tail spills into structured metadata. User values still win on collision,
+// which protects a tenant whose existing label name later becomes reserved.
+func mergeLogLabels(systemLabels, userLabels []labelPair) []labelPair {
+	merged := make([]labelPair, len(systemLabels)+len(userLabels))
+	copy(merged, systemLabels)
+
+	idx := make(map[string]int, len(systemLabels))
+	for i, l := range merged {
+		idx[l.name] = i
+	}
+
+	for _, l := range userLabels {
+		if where, found := idx[l.name]; found {
+			merged[where].value = l.value
+			continue
+		}
+		idx[l.name] = len(merged)
+		merged = append(merged, l)
+	}
+
+	return merged
 }
 
 // appendUniqueLabels returns a slice of key-value labels which

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -2064,6 +2065,227 @@ func TestScraperCollectData(t *testing.T) {
 			}
 		})
 	}
+}
+
+func findPromPbLabel(t *testing.T, labels []prompb.Label, name string) string {
+	idx := slices.IndexFunc(labels, func(v prompb.Label) bool { return v.GetName() == name })
+	require.GreaterOrEqualf(t, idx, int(0), "label %q must be present", name)
+
+	return labels[idx].GetValue()
+}
+
+// histogramProber emits a single histogram (test_duration_seconds) with several
+// buckets, so the gathered metric families contain multiple *_bucket series that
+// differ only by their intrinsic `le` label. This is the shape that makes a
+// reserved-name collision destructive: unlike sm_check_info's single-valued
+// identity labels, `le` is per-series.
+type histogramProber struct{}
+
+func (histogramProber) Name() string { return "histogram prober" }
+
+func (histogramProber) Probe(_ context.Context, _ string, registry *prometheus.Registry, _ logger.Logger, _ string) (bool, float64) {
+	h := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "test_duration_seconds",
+		Buckets: []float64{0.1, 0.5, 1},
+	})
+	registry.MustRegister(h)
+
+	// Observations spread across buckets so every bucket series is distinct.
+	h.Observe(0.05)
+	h.Observe(0.3)
+	h.Observe(0.8)
+
+	return true, 1
+}
+
+// TestScraperCollectDataReservedLabelCollision pins the agent's behaviour when
+// a tenant carries a user label whose name collides with a *per-series
+// intrinsic* reserved label (`le`) while in UNPREFIXED mode.
+//
+// Per checks_extra.go, the API is supposed to make this unreachable: reserved
+// names are rejected at check create/update and at the LabelMode transition.
+// This test is the agent-side backstop for the case where such a label reaches
+// the scraper anyway. It asserts the safe contract: the histogram's real
+// bucket boundaries survive as distinct series ({0.1, 0.5, 1, +Inf}) and are
+// NOT collapsed onto the user's value.
+//
+// TODO(mem): Remove this note. This test FAILS against the current
+// implementation. customMetricLabels seeds the user `le` into
+// executionMetricLabels, appendDtoToTimeseries appends the real bucket `le`
+// last, and makeTimeseries de-dupes keeping the first occurrence, so every
+// bucket collapses to le=user-value. It will pass once per-series
+// reserved-name filtering is added to customMetricLabels. The same collapse
+// also corrupts the agent's own probe_all_duration_seconds histogram, so this
+// is not limited to custom prober metrics.
+func TestScraperCollectDataReservedLabelCollision(t *testing.T) {
+	s := Scraper{
+		checkName:     "check name",
+		target:        "test target",
+		logger:        testhelper.Logger(t),
+		prober:        histogramProber{},
+		labelsLimiter: testLabelsLimiter{maxMetricLabels: 22, maxLogLabels: 15},
+		labellingMode: testLabellingMode{mode: sm.LabelMode_LABEL_MODE_UNPREFIXED},
+		summaries:     make(map[uint64]prometheus.Summary),
+		histograms:    make(map[uint64]prometheus.Histogram),
+		check: model.Check{
+			Check: sm.Check{
+				Id:               1,
+				TenantId:         2,
+				Frequency:        2000,
+				Timeout:          2000,
+				Enabled:          true,
+				Target:           "target name",
+				Job:              "job name",
+				BasicMetricsOnly: false,
+				Created:          42,
+				Modified:         42,
+				// User label collides with the reserved, per-series `le`.
+				Labels:   []sm.Label{{Name: "le", Value: "user-value"}},
+				Settings: sm.CheckSettings{Http: &sm.HttpSettings{}},
+			},
+		},
+		probe: sm.Probe{
+			Id:       100,
+			TenantId: 200,
+			Name:     "probe name",
+			Region:   "REGION",
+		},
+	}
+
+	data, _, err := s.collectData(context.Background(), time.Unix(3141, 0))
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	// Collect the `le` value from every test_duration_seconds_bucket
+	// series. Scoped to this histogram so the count is deterministic; note
+	// that the agent's own probe_all_duration_seconds_bucket series
+	// collapse identically.
+	bucketLEs := make(map[string]int)
+	bucketSeries := 0
+
+	for _, ts := range data.Metrics() {
+		name := findPromPbLabel(t, ts.GetLabels(), prom.MetricNameLabel)
+		if name != "test_duration_seconds_bucket" {
+			continue
+		}
+
+		le := findPromPbLabel(t, ts.GetLabels(), labels.BucketLabel)
+
+		bucketSeries++
+		bucketLEs[le]++
+	}
+
+	// A 3-boundary histogram yields 4 bucket series: 0.1, 0.5, 1, +Inf.
+	require.Equal(t, 4, bucketSeries, "expected one series per bucket boundary")
+
+	// The intended contract: real bucket boundaries survive, distinct and
+	// un-clobbered by the user's `le=user-value`.
+	require.Equal(t,
+		map[string]int{"0.1": 1, "0.5": 1, "1": 1, "+Inf": 1},
+		bucketLEs,
+		"histogram bucket `le` labels were overwritten/collapsed by the user label")
+}
+
+// phaseProber emits probe_http_duration_seconds as a gauge with a `phase`
+// label, mirroring the real HTTP prober's per-phase timing breakdown. `phase`
+// is a reserved, per-series label (checks_extra.go) but, unlike `le` above, it
+// is a name a tenant might plausibly define themselves, which makes this the
+// more realistic collision vehicle.
+type phaseProber struct{}
+
+func (phaseProber) Name() string { return "phase prober" }
+
+func (phaseProber) Probe(_ context.Context, _ string, registry *prometheus.Registry, _ logger.Logger, _ string) (bool, float64) {
+	g := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "probe_http_duration_seconds",
+	}, []string{"phase"})
+	registry.MustRegister(g)
+
+	// One series per HTTP phase, each with a distinct value.
+	for i, phase := range []string{"resolve", "connect", "tls", "processing", "transfer"} {
+		g.WithLabelValues(phase).Set(float64(i+1) * 0.01)
+	}
+
+	return true, 1
+}
+
+// TestScraperCollectDataReservedPhaseCollision is the realistic sibling of
+// TestScraperCollectDataReservedLabelCollision: it collides a user label with
+// the reserved per-series label `phase` on the multi-series
+// probe_http_duration_seconds gauge instead of `le` on a histogram.
+//
+// It feeds a check label phase=user-value in UNPREFIXED mode and asserts the
+// five per-phase series retain their distinct phase values.
+//
+// TODO(mem): remove this note. Like the `le` test above it FAILS against the
+// current implementation: customMetricLabels seeds the user `phase` into
+// executionMetricLabels ahead of each metric's own `phase` label
+// (appendDtoToTimeseries appends the metric's labels after sharedLabels), and
+// makeTimeseries' keep-first dedup drops the real phase, so all five series
+// collapse to phase=user-value. It will pass once per-series reserved-name
+// filtering is added to customMetricLabels.
+func TestScraperCollectDataReservedPhaseCollision(t *testing.T) {
+	s := Scraper{
+		checkName:     "check name",
+		target:        "test target",
+		logger:        testhelper.Logger(t),
+		prober:        phaseProber{},
+		labelsLimiter: testLabelsLimiter{maxMetricLabels: 22, maxLogLabels: 15},
+		labellingMode: testLabellingMode{mode: sm.LabelMode_LABEL_MODE_UNPREFIXED},
+		summaries:     make(map[uint64]prometheus.Summary),
+		histograms:    make(map[uint64]prometheus.Histogram),
+		check: model.Check{
+			Check: sm.Check{
+				Id:               1,
+				TenantId:         2,
+				Frequency:        2000,
+				Timeout:          2000,
+				Enabled:          true,
+				Target:           "target name",
+				Job:              "job name",
+				BasicMetricsOnly: false,
+				Created:          42,
+				Modified:         42,
+				// User label collides with the reserved, per-series `phase`.
+				Labels:   []sm.Label{{Name: "phase", Value: "user-value"}},
+				Settings: sm.CheckSettings{Http: &sm.HttpSettings{}},
+			},
+		},
+		probe: sm.Probe{
+			Id:       100,
+			TenantId: 200,
+			Name:     "probe name",
+			Region:   "REGION",
+		},
+	}
+
+	data, _, err := s.collectData(context.Background(), time.Unix(3141, 0))
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	// Collect the `phase` value from every probe_http_duration_seconds series.
+	phases := make(map[string]int)
+	phaseSeries := 0
+	for _, ts := range data.Metrics() {
+		name := findPromPbLabel(t, ts.GetLabels(), prom.MetricNameLabel)
+		if name != "probe_http_duration_seconds" {
+			continue
+		}
+
+		phase := findPromPbLabel(t, ts.GetLabels(), "phase")
+
+		phaseSeries++
+		phases[phase]++
+	}
+
+	// Five phases emitted, so five distinct series.
+	require.Equal(t, 5, phaseSeries, "expected one series per HTTP phase")
+
+	// The intended contract: each phase survives as its own series, un-clobbered
+	// by the user's phase=user-value.
+	require.Equal(t, map[string]int{
+		"resolve": 1, "connect": 1, "tls": 1, "processing": 1, "transfer": 1,
+	}, phases, "per-phase series were overwritten/collapsed by the user label")
 }
 
 // these are generated using

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1837,18 +1837,19 @@ func TestScraperCollectData(t *testing.T) {
 			),
 		},
 
-		// This tests the default label mode falls back to PREFIXED, but note
+		// This tests simulates the default label mode falling back to UNPREFIXED, but note
 		// the scraper would actually abort if there was no tenant in cache due to
 		// the label limits being unavailable.
-		"label mode fetch error degrades to prefixed": {
+		"label mode fetch error degrades to unprefixed": {
+			labelMode:            sm.LabelMode_LABEL_MODE_UNPREFIXED,
 			labelModeErr:         errors.New("simulated tenant label-mode fetch failure"),
 			maxMetricLabels:      defMaxMetricLabels,
 			maxLogLabels:         defMaxLogLabels,
 			checkLabels:          generateLabels(1, 3, "c"),
-			expectedMetricLabels: mergeMaps(baseExpectedMetricLabels),
-			expectedInfoLabels:   mergeMaps(baseExpectedMetricLabels, baseExpectedInfoLabels, generateLabelSet(1, 3, "c")),
-			expectedLogLabels:    mergeMaps(baseExpectedLogLabels, generateLabelSet(1, 3, "c")),
-			expectedLogEntries:   mergeMaps(baseExpectedLogLabels, generateLabelSet(1, 3, "c")),
+			expectedMetricLabels: mergeMaps(baseExpectedMetricLabels, generateUnprefixedLabelSet(1, 3, "c")),
+			expectedInfoLabels:   mergeMaps(baseExpectedMetricLabels, baseExpectedInfoLabels, generateUnprefixedLabelSet(1, 3, "c")),
+			expectedLogLabels:    mergeMaps(baseExpectedLogLabels, generateUnprefixedLabelSet(1, 3, "c")),
+			expectedLogEntries:   mergeMaps(baseExpectedLogLabels, generateUnprefixedLabelSet(1, 3, "c")),
 		},
 	}
 

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1663,6 +1663,38 @@ func TestScraperCollectData(t *testing.T) {
 		}
 	}
 
+	// assertStructuredMetadata verifies that each log entry's StructuredMetadata
+	// contains a valid execution_id UUID plus any overflow labels (those present in
+	// expectedLogEntries but absent from expectedLogLabels — they fit in the log
+	// entry body but were truncated from the stream label set).
+	assertStructuredMetadata := func(t *testing.T, entry logproto.Entry, tc testcase) {
+		t.Helper()
+		executionIDFound := false
+		overflowFound := 0
+		for _, meta := range entry.StructuredMetadata {
+			if meta.Name == "execution_id" {
+				executionIDFound = true
+				_, err := uuid.Parse(meta.Value)
+				require.NoError(t, err, "execution_id should be a valid UUID")
+			} else {
+				expectedVal, inEntries := tc.expectedLogEntries[meta.Name]
+				_, inLabels := tc.expectedLogLabels[meta.Name]
+				require.Truef(t, inEntries && !inLabels,
+					"unexpected structured metadata entry: %s=%s", meta.Name, meta.Value)
+				require.Equal(t, expectedVal, meta.Value, "overflow label value mismatch: %s", meta.Name)
+				overflowFound++
+			}
+		}
+		require.True(t, executionIDFound, "execution_id not found in structured metadata")
+		expectedOverflow := 0
+		for name := range tc.expectedLogEntries {
+			if _, inLabels := tc.expectedLogLabels[name]; !inLabels {
+				expectedOverflow++
+			}
+		}
+		require.Equal(t, expectedOverflow, overflowFound, "overflow label count in structured metadata")
+	}
+
 	validateStreams := func(t *testing.T, s Scraper, stream logproto.Stream, tc testcase) {
 		sLabels, err := metricParser.ParseMetric(stream.Labels)
 		require.NoError(t, err)
@@ -1704,34 +1736,7 @@ func TestScraperCollectData(t *testing.T) {
 			}
 			require.NoError(t, dec.Err())
 
-			// Verify StructuredMetadata contains execution_id and any overflow log labels.
-			// Overflow labels are those present in expectedLogEntries but not in expectedLogLabels
-			// (they fit in the log entry body but were truncated from the stream label set).
-			executionIDFound := false
-			overflowFound := 0
-			for _, meta := range entry.StructuredMetadata {
-				if meta.Name == "execution_id" {
-					executionIDFound = true
-					_, err := uuid.Parse(meta.Value)
-					require.NoError(t, err, "execution_id should be a valid UUID")
-				} else {
-					expectedVal, inEntries := tc.expectedLogEntries[meta.Name]
-					_, inLabels := tc.expectedLogLabels[meta.Name]
-					require.Truef(t, inEntries && !inLabels,
-						"unexpected structured metadata entry: %s=%s", meta.Name, meta.Value)
-					require.Equal(t, expectedVal, meta.Value, "overflow label value mismatch: %s", meta.Name)
-					overflowFound++
-				}
-			}
-			require.True(t, executionIDFound, "execution_id not found in structured metadata")
-
-			expectedOverflow := 0
-			for name := range tc.expectedLogEntries {
-				if _, inLabels := tc.expectedLogLabels[name]; !inLabels {
-					expectedOverflow++
-				}
-			}
-			require.Equal(t, expectedOverflow, overflowFound, "overflow label count in structured metadata")
+			assertStructuredMetadata(t, entry, tc)
 		}
 	}
 

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1513,7 +1513,19 @@ func TestScraperCollectData(t *testing.T) {
 		return labels
 	}
 
+	// generateUnprefixedLabelSet produces {"l0":"c0","l1":"c1",...} — used to describe
+	// expected user labels on execution metrics in DUAL_WRITE and UNPREFIXED modes.
+	generateUnprefixedLabelSet := func(offset, count int, valuePrefix string) map[string]string {
+		labels := make(map[string]string)
+		for i := range count {
+			n := strconv.Itoa(offset + i)
+			labels["l"+n] = valuePrefix + n
+		}
+		return labels
+	}
+
 	type testcase struct {
+		labelMode            sm.LabelMode // zero value = PREFIXED
 		maxMetricLabels      int
 		maxLogLabels         int
 		checkLabels          []sm.Label
@@ -1596,6 +1608,146 @@ func TestScraperCollectData(t *testing.T) {
 			expectedLogLabels:    mergeMaps(baseExpectedLogLabels, generateLabelSet(0, 10, "c"), generateLabelSet(10, 4, "p")),
 			expectedLogEntries:   mergeMaps(baseExpectedLogLabels, generateLabelSet(0, 10, "c"), generateLabelSet(10, 4, "p")),
 		},
+
+		// ── DUAL_WRITE and UNPREFIXED mode tests ──────────────────────────────────
+		//
+		// Key differences:
+		//   expectedMetricLabels includes un-prefixed user labels (execution metrics
+		//     gain user labels via customMetricLabels in DUAL_WRITE/UNPREFIXED).
+		//   expectedInfoLabels includes both forms in DUAL_WRITE (prefixed first in the
+		//     slice produced by buildUserLabels, then un-prefixed) and un-prefixed only
+		//     in UNPREFIXED.
+		//   expectedLogLabels follows DUAL_WRITE ordering: all prefixed forms before all
+		//     un-prefixed forms in the stream labels; overflow goes to StructuredMetadata.
+
+		"dual write basic": {
+			// 3 check labels + 1 probe label; no stream-label overflow.
+			// Verifies: execution metrics carry un-prefixed user labels;
+			//           sm_check_info carries both forms;
+			//           log stream carries both forms in correct ordering.
+			labelMode:       sm.LabelMode_LABEL_MODE_DUAL_WRITE,
+			maxMetricLabels: defMaxMetricLabels,
+			maxLogLabels:    defMaxLogLabels,
+			checkLabels:     generateLabels(0, 3, "c"),
+			probeLabels:     generateLabels(10, 1, "p"),
+			// Execution metrics: base + un-prefixed user labels.
+			expectedMetricLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				generateUnprefixedLabelSet(10, 1, "p"),
+				generateUnprefixedLabelSet(0, 3, "c"),
+			),
+			// sm_check_info: system sharedLabels (probe, config_version, instance, job)
+			// + check-info system labels + both forms of user labels from ConstLabels.
+			expectedInfoLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				baseExpectedInfoLabels,
+				generateLabelSet(10, 1, "p"),
+				generateUnprefixedLabelSet(10, 1, "p"),
+				generateLabelSet(0, 3, "c"),
+				generateUnprefixedLabelSet(0, 3, "c"),
+			),
+			// Log stream: DUAL_WRITE ordering — all prefixed first, then un-prefixed.
+			// 4 user labels × 2 = 8 entries + 6 system labels = 14; probe_success
+			// is appended last, totalling 15 = defMaxLogLabels. No overflow.
+			expectedLogLabels: mergeMaps(
+				baseExpectedLogLabels,
+				generateLabelSet(10, 1, "p"),
+				generateLabelSet(0, 3, "c"),
+				generateUnprefixedLabelSet(10, 1, "p"),
+				generateUnprefixedLabelSet(0, 3, "c"),
+			),
+			expectedLogEntries: mergeMaps(
+				baseExpectedLogLabels,
+				generateLabelSet(10, 1, "p"),
+				generateLabelSet(0, 3, "c"),
+				generateUnprefixedLabelSet(10, 1, "p"),
+				generateUnprefixedLabelSet(0, 3, "c"),
+			),
+		},
+
+		"unprefixed basic": {
+			// 3 check labels + 1 probe label in UNPREFIXED mode.
+			// Verifies: execution metrics carry un-prefixed user labels;
+			//           sm_check_info and log stream carry only un-prefixed forms.
+			labelMode:       sm.LabelMode_LABEL_MODE_UNPREFIXED,
+			maxMetricLabels: defMaxMetricLabels,
+			maxLogLabels:    defMaxLogLabels,
+			checkLabels:     generateLabels(0, 3, "c"),
+			probeLabels:     generateLabels(10, 1, "p"),
+			expectedMetricLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				generateUnprefixedLabelSet(10, 1, "p"),
+				generateUnprefixedLabelSet(0, 3, "c"),
+			),
+			expectedInfoLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				baseExpectedInfoLabels,
+				generateUnprefixedLabelSet(10, 1, "p"),
+				generateUnprefixedLabelSet(0, 3, "c"),
+			),
+			expectedLogLabels: mergeMaps(
+				baseExpectedLogLabels,
+				generateUnprefixedLabelSet(10, 1, "p"),
+				generateUnprefixedLabelSet(0, 3, "c"),
+			),
+			expectedLogEntries: mergeMaps(
+				baseExpectedLogLabels,
+				generateUnprefixedLabelSet(10, 1, "p"),
+				generateUnprefixedLabelSet(0, 3, "c"),
+			),
+		},
+
+		"dual write log overflow": {
+			// 10 check labels + 3 probe labels in DUAL_WRITE mode causes log stream
+			// overflow. DUAL_WRITE ordering means all prefixed forms come first in the
+			// stream labels, so they are preserved when the label count exceeds the cap;
+			// the un-prefixed forms spill into StructuredMetadata instead.
+			//
+			// Label budget: 6 system + 26 user (13×2) = 32 total; cap at
+			// defMaxLogLabels-1=14 stream slots before probe_success.
+			// Stream labels: system labels (6) + first 8 prefixed user labels.
+			// Overflow into StructuredMetadata: remaining prefixed (5) + all 13
+			// un-prefixed user labels.
+			labelMode:       sm.LabelMode_LABEL_MODE_DUAL_WRITE,
+			maxMetricLabels: defMaxMetricLabels,
+			maxLogLabels:    defMaxLogLabels,
+			checkLabels:     generateLabels(0, 10, "c"),
+			probeLabels:     generateLabels(10, 3, "p"),
+			// Execution metrics: base + all un-prefixed user labels.
+			expectedMetricLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				generateUnprefixedLabelSet(10, 3, "p"),
+				generateUnprefixedLabelSet(0, 10, "c"),
+			),
+			// sm_check_info: system sharedLabels + both forms of user labels from ConstLabels.
+			expectedInfoLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				baseExpectedInfoLabels,
+				generateLabelSet(10, 3, "p"),
+				generateUnprefixedLabelSet(10, 3, "p"),
+				generateLabelSet(0, 10, "c"),
+				generateUnprefixedLabelSet(0, 10, "c"),
+			),
+			// Stream labels: system(6) + 8 prefixed user labels (prefixed-first
+			// ordering means label_l10,label_l11,label_l12 + label_l0..label_l4
+			// fill the 8 available slots before the cap).
+			expectedLogLabels: mergeMaps(
+				baseExpectedLogLabels,
+				generateLabelSet(10, 3, "p"), // label_l10, label_l11, label_l12
+				generateLabelSet(0, 5, "c"),  // label_l0 .. label_l4
+			),
+			// Log entry body includes all user labels in both forms (log entry is not
+			// truncated, only stream labels are capped). The entries in
+			// expectedLogEntries \ expectedLogLabels become StructuredMetadata overflow
+			// and are validated by assertStructuredMetadata.
+			expectedLogEntries: mergeMaps(
+				baseExpectedLogLabels,
+				generateLabelSet(10, 3, "p"),
+				generateLabelSet(0, 10, "c"),
+				generateUnprefixedLabelSet(10, 3, "p"),
+				generateUnprefixedLabelSet(0, 10, "c"),
+			),
+		},
 	}
 
 	getMetricName := func(t *testing.T, ts prompb.TimeSeries) string {
@@ -1616,6 +1768,16 @@ func TestScraperCollectData(t *testing.T) {
 		require.NotNil(t, ts)
 
 		metricName := getMetricName(t, ts)
+
+		// Ensure no label name appears more than once. Duplicate label keys are
+		// rejected by Mimir and indicate a bug in label assembly (e.g. user labels
+		// reaching a metric via both ConstLabels and sharedLabels).
+		seenLabelNames := make(map[string]bool, len(ts.GetLabels()))
+		for _, l := range ts.GetLabels() {
+			require.Falsef(t, seenLabelNames[l.GetName()],
+				"duplicate label %q in metric %s", l.GetName(), metricName)
+			seenLabelNames[l.GetName()] = true
+		}
 
 		actualLabels := make(map[string]string)
 		actualLabelsCount := 0
@@ -1751,7 +1913,7 @@ func TestScraperCollectData(t *testing.T) {
 					maxMetricLabels: tc.maxMetricLabels,
 					maxLogLabels:    tc.maxLogLabels,
 				},
-				labellingMode: testLabellingMode{},
+				labellingMode: testLabellingMode{mode: tc.labelMode},
 				summaries:     make(map[uint64]prometheus.Summary),
 				histograms:    make(map[uint64]prometheus.Histogram),
 				check: model.Check{

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1537,7 +1537,7 @@ func TestScraperCollectData(t *testing.T) {
 	}
 
 	const (
-		defMaxMetricLabels = 20
+		defMaxMetricLabels = 22
 		defMaxLogLabels    = 15
 	)
 
@@ -1599,8 +1599,8 @@ func TestScraperCollectData(t *testing.T) {
 			expectedLogEntries:   mergeMaps(baseExpectedLogLabels, generateLabelSet(0, 10, "c"), generateLabelSet(10, 3, "p")),
 		},
 		"max labels override": {
-			maxMetricLabels:      21,
-			maxLogLabels:         21,
+			maxMetricLabels:      23,
+			maxLogLabels:         23,
 			checkLabels:          generateLabels(0, 10, "c"),
 			probeLabels:          generateLabels(10, 4, "p"),
 			expectedMetricLabels: mergeMaps(baseExpectedMetricLabels),

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1092,9 +1092,10 @@ func TestValidateLabels(t *testing.T) {
 					maxMetricLabels: 100,
 					maxLogLabels:    100,
 				},
-				summaries:  make(map[uint64]prometheus.Summary),
-				histograms: make(map[uint64]prometheus.Histogram),
-				check:      check,
+				labellingMode: testLabellingMode{},
+				summaries:     make(map[uint64]prometheus.Summary),
+				histograms:    make(map[uint64]prometheus.Histogram),
+				check:         check,
 				probe: sm.Probe{
 					Id:        100,
 					TenantId:  200,
@@ -1435,6 +1436,14 @@ func (l testLabelsLimiter) LogLabels(ctx context.Context, tenantID model.GlobalI
 	return l.maxLogLabels, nil
 }
 
+type testLabellingMode struct {
+	mode sm.LabelMode
+}
+
+func (l testLabellingMode) ForTenant(ctx context.Context, tenantID model.GlobalID) (sm.LabelMode, error) {
+	return l.mode, nil
+}
+
 type testCalTenants struct {
 	costAttributionLabels []string
 }
@@ -1713,8 +1722,9 @@ func TestScraperCollectData(t *testing.T) {
 					maxMetricLabels: tc.maxMetricLabels,
 					maxLogLabels:    tc.maxLogLabels,
 				},
-				summaries:  make(map[uint64]prometheus.Summary),
-				histograms: make(map[uint64]prometheus.Histogram),
+				labellingMode: testLabellingMode{},
+				summaries:     make(map[uint64]prometheus.Summary),
+				histograms:    make(map[uint64]prometheus.Histogram),
 				check: model.Check{
 					Check: sm.Check{
 						Id:               1,
@@ -2019,7 +2029,8 @@ func TestScraperRun(t *testing.T) {
 			maxMetricLabels: 20,
 			maxLogLabels:    15,
 		},
-		Telemeter: testTelemeter,
+		LabellingMode: testLabellingMode{},
+		Telemeter:     testTelemeter,
 		CostAttributionLabels: testCalTenants{
 			costAttributionLabels: []string{"testing", "you"},
 		},
@@ -2351,9 +2362,10 @@ func TestHTTPCheckLogTimestampsAreNonDecreasing(t *testing.T) {
 			maxMetricLabels: 20,
 			maxLogLabels:    15,
 		},
-		summaries:  make(map[uint64]prometheus.Summary),
-		histograms: make(map[uint64]prometheus.Histogram),
-		check:      check,
+		labellingMode: testLabellingMode{},
+		summaries:     make(map[uint64]prometheus.Summary),
+		histograms:    make(map[uint64]prometheus.Histogram),
+		check:         check,
 		probe: sm.Probe{
 			Name:   "test-probe",
 			Region: "test-region",

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1175,6 +1175,65 @@ func TestMakeTimeseries(t *testing.T) {
 	}
 }
 
+// TestMakeTimeseriesDeduplicates verifies that makeTimeseries drops duplicate
+// label names, keeping the first occurrence (Mimir rejects duplicate keys)
+func TestMakeTimeseriesDeduplicates(t *testing.T) {
+	ts := makeTimeseries(time.Unix(1, 0), 1,
+		prompb.Label{Name: prom.MetricNameLabel, Value: "m"},
+		prompb.Label{Name: "probe", Value: "user-probe"},
+		prompb.Label{Name: "job", Value: "system"},
+		prompb.Label{Name: "probe", Value: "system"}, // duplicate name — must be dropped
+		prompb.Label{Name: "env", Value: "prod"},
+	)
+
+	require.Equal(t, []prompb.Label{
+		{Name: prom.MetricNameLabel, Value: "m"},
+		{Name: "probe", Value: "user-probe"}, // first occurrence wins
+		{Name: "job", Value: "system"},
+		{Name: "env", Value: "prod"},
+	}, ts.Labels)
+}
+
+// TestScraperCollectDataTooManyMetricLabels verifies that the check-info label
+// guard rejects a scrape whose non-system label count exceeds the tenant's
+// metric-label budget, before any data is emitted.
+func TestScraperCollectDataTooManyMetricLabels(t *testing.T) {
+	s := Scraper{
+		checkName:     "check name",
+		target:        "test target",
+		logger:        testhelper.Logger(t),
+		prober:        testProber{},
+		labelsLimiter: testLabelsLimiter{maxMetricLabels: 1, maxLogLabels: 15},
+		labellingMode: testLabellingMode{},
+		summaries:     make(map[uint64]prometheus.Summary),
+		histograms:    make(map[uint64]prometheus.Histogram),
+		check: model.Check{
+			Check: sm.Check{
+				Id:               1,
+				TenantId:         2,
+				Frequency:        2000,
+				Timeout:          2000,
+				Enabled:          true,
+				Target:           "target name",
+				Job:              "job name",
+				BasicMetricsOnly: true,
+				Created:          42,
+				Modified:         42,
+				Labels: []sm.Label{
+					{Name: "a", Value: "1"},
+					{Name: "b", Value: "2"},
+					{Name: "c", Value: "3"},
+				},
+				Settings: sm.CheckSettings{Http: &sm.HttpSettings{}},
+			},
+		},
+		probe: sm.Probe{Id: 100, TenantId: 200, Name: "probe name", Region: "REGION"},
+	}
+
+	_, _, err := s.collectData(context.Background(), time.Unix(3141, 0))
+	require.ErrorIs(t, err, errTooManyLabels)
+}
+
 func TestAppendDtoToTimeseries(t *testing.T) {
 	makeUint64Ptr := func(n uint64) *uint64 {
 		return &n
@@ -1438,10 +1497,11 @@ func (l testLabelsLimiter) LogLabels(ctx context.Context, tenantID model.GlobalI
 
 type testLabellingMode struct {
 	mode sm.LabelMode
+	err  error
 }
 
 func (l testLabellingMode) ForTenant(ctx context.Context, tenantID model.GlobalID) (sm.LabelMode, error) {
-	return l.mode, nil
+	return l.mode, l.err
 }
 
 type testCalTenants struct {
@@ -1526,6 +1586,7 @@ func TestScraperCollectData(t *testing.T) {
 
 	type testcase struct {
 		labelMode            sm.LabelMode // zero value = PREFIXED
+		labelModeErr         error        // simulates a tenant label-mode lookup failure
 		maxMetricLabels      int
 		maxLogLabels         int
 		checkLabels          []sm.Label
@@ -1748,6 +1809,47 @@ func TestScraperCollectData(t *testing.T) {
 				generateUnprefixedLabelSet(0, 10, "c"),
 			),
 		},
+
+		"unprefixed system label collision": {
+			labelMode:       sm.LabelMode_LABEL_MODE_UNPREFIXED,
+			maxMetricLabels: defMaxMetricLabels,
+			maxLogLabels:    defMaxLogLabels,
+			checkLabels: []sm.Label{
+				{Name: "job", Value: "user-job"},
+				{Name: "env", Value: "prod"},
+			},
+			expectedMetricLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				map[string]string{"job": "user-job", "env": "prod"},
+			),
+			expectedInfoLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				baseExpectedInfoLabels,
+				map[string]string{"job": "user-job", "env": "prod"},
+			),
+			expectedLogLabels: mergeMaps(
+				baseExpectedLogLabels,
+				map[string]string{"job": "user-job", "env": "prod"},
+			),
+			expectedLogEntries: mergeMaps(
+				baseExpectedLogLabels,
+				map[string]string{"job": "user-job", "env": "prod"},
+			),
+		},
+
+		// This tests the default label mode falls back to PREFIXED, but note
+		// the scraper would actually abort if there was no tenant in cache due to
+		// the label limits being unavailable.
+		"label mode fetch error degrades to prefixed": {
+			labelModeErr:         errors.New("simulated tenant label-mode fetch failure"),
+			maxMetricLabels:      defMaxMetricLabels,
+			maxLogLabels:         defMaxLogLabels,
+			checkLabels:          generateLabels(1, 3, "c"),
+			expectedMetricLabels: mergeMaps(baseExpectedMetricLabels),
+			expectedInfoLabels:   mergeMaps(baseExpectedMetricLabels, baseExpectedInfoLabels, generateLabelSet(1, 3, "c")),
+			expectedLogLabels:    mergeMaps(baseExpectedLogLabels, generateLabelSet(1, 3, "c")),
+			expectedLogEntries:   mergeMaps(baseExpectedLogLabels, generateLabelSet(1, 3, "c")),
+		},
 	}
 
 	getMetricName := func(t *testing.T, ts prompb.TimeSeries) string {
@@ -1913,7 +2015,7 @@ func TestScraperCollectData(t *testing.T) {
 					maxMetricLabels: tc.maxMetricLabels,
 					maxLogLabels:    tc.maxLogLabels,
 				},
-				labellingMode: testLabellingMode{mode: tc.labelMode},
+				labellingMode: testLabellingMode{mode: tc.labelMode, err: tc.labelModeErr},
 				summaries:     make(map[uint64]prometheus.Summary),
 				histograms:    make(map[uint64]prometheus.Histogram),
 				check: model.Check{

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1452,6 +1452,7 @@ func (t testCalTenants) CostAttributionLabels(_ context.Context, tenantID model.
 	return t.costAttributionLabels, nil
 }
 
+//nolint:gocyclo
 func TestScraperCollectData(t *testing.T) {
 	const (
 		checkName     = "check name"
@@ -1703,11 +1704,34 @@ func TestScraperCollectData(t *testing.T) {
 			}
 			require.NoError(t, dec.Err())
 
-			// Verify that the execution_id is present in the structured metadata.
-			require.Len(t, entry.StructuredMetadata, 1)
-			require.Equal(t, "execution_id", entry.StructuredMetadata[0].Name)
-			_, err := uuid.Parse(entry.StructuredMetadata[0].Value)
-			require.NoError(t, err, "execution_id should be a valid UUID")
+			// Verify StructuredMetadata contains execution_id and any overflow log labels.
+			// Overflow labels are those present in expectedLogEntries but not in expectedLogLabels
+			// (they fit in the log entry body but were truncated from the stream label set).
+			executionIDFound := false
+			overflowFound := 0
+			for _, meta := range entry.StructuredMetadata {
+				if meta.Name == "execution_id" {
+					executionIDFound = true
+					_, err := uuid.Parse(meta.Value)
+					require.NoError(t, err, "execution_id should be a valid UUID")
+				} else {
+					expectedVal, inEntries := tc.expectedLogEntries[meta.Name]
+					_, inLabels := tc.expectedLogLabels[meta.Name]
+					require.Truef(t, inEntries && !inLabels,
+						"unexpected structured metadata entry: %s=%s", meta.Name, meta.Value)
+					require.Equal(t, expectedVal, meta.Value, "overflow label value mismatch: %s", meta.Name)
+					overflowFound++
+				}
+			}
+			require.True(t, executionIDFound, "execution_id not found in structured metadata")
+
+			expectedOverflow := 0
+			for name := range tc.expectedLogEntries {
+				if _, inLabels := tc.expectedLogLabels[name]; !inLabels {
+					expectedOverflow++
+				}
+			}
+			require.Equal(t, expectedOverflow, overflowFound, "overflow label count in structured metadata")
 		}
 	}
 
@@ -2341,7 +2365,7 @@ func TestExtractLogsK6TimeOverridesDefaultTimestamp(t *testing.T) {
 				logger: testhelper.Logger(t),
 			}
 
-			streams := s.extractLogs(time.Now(), []byte(tc.logs), tc.sharedLabels, "test-execution-id")
+			streams := s.extractLogs(time.Now(), []byte(tc.logs), tc.sharedLabels, nil)
 			tc.expected(t, streams)
 		})
 	}

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1811,7 +1811,12 @@ func TestScraperCollectData(t *testing.T) {
 			),
 		},
 
-		"unprefixed system label collision": {
+		// In UNPREFIXED mode a user label named "job" collides with the reserved
+		// system "job" label. buildUserLabels drops it (sm.IsSystemLabel), so the
+		// system value is retained on every surface — execution metrics,
+		// sm_check_info, and the log stream — rather than being overwritten. The
+		// non-reserved "env" label is emitted normally.
+		"unprefixed reserved label dropped": {
 			labelMode:       sm.LabelMode_LABEL_MODE_UNPREFIXED,
 			maxMetricLabels: defMaxMetricLabels,
 			maxLogLabels:    defMaxLogLabels,
@@ -1819,22 +1824,23 @@ func TestScraperCollectData(t *testing.T) {
 				{Name: "job", Value: "user-job"},
 				{Name: "env", Value: "prod"},
 			},
+			// "job" keeps its system value (from base); only "env" is added.
 			expectedMetricLabels: mergeMaps(
 				baseExpectedMetricLabels,
-				map[string]string{"job": "user-job", "env": "prod"},
+				map[string]string{"env": "prod"},
 			),
 			expectedInfoLabels: mergeMaps(
 				baseExpectedMetricLabels,
 				baseExpectedInfoLabels,
-				map[string]string{"job": "user-job", "env": "prod"},
+				map[string]string{"env": "prod"},
 			),
 			expectedLogLabels: mergeMaps(
 				baseExpectedLogLabels,
-				map[string]string{"job": "user-job", "env": "prod"},
+				map[string]string{"env": "prod"},
 			),
 			expectedLogEntries: mergeMaps(
 				baseExpectedLogLabels,
-				map[string]string{"job": "user-job", "env": "prod"},
+				map[string]string{"env": "prod"},
 			),
 		},
 

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -139,11 +139,11 @@ const (
 // A tenant therefore cannot enter a non-PREFIXED mode while holding a label
 // whose name collides with the current reserved set.
 //
-// The agent does NOT filter these names itself. A collision is only reachable
-// if a name is added to this set after a tenant already uses it; in that case
-// the agent lets the user-defined value win, deliberately preserving existing
-// tenant behaviour rather than dropping the label. This protects tenants
-// against future expansion of the reserved set. See buildUserLabels in
+// The agent also asserts this reservation as a backstop: in DUAL_WRITE and
+// UNPREFIXED modes it drops un-prefixed user labels whose names are reserved,
+// rather than letting them win, so a stray reserved name cannot overwrite an
+// intrinsic per-series metric label (`le`, `phase`, ...). Prefixed forms
+// (`label_*`) and PREFIXED-mode labels are unaffected. See buildUserLabels in
 // internal/scraper for the collision-resolution contract.
 //
 // This map must not be modified at runtime. Use IsSystemLabel to query it.

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -133,10 +133,18 @@ const (
 )
 
 // systemLabels is the read-only set of label names reserved by the
-// synthetic-monitoring-agent. User-defined labels with these names are
-// silently ignored by the agent when the tenant's LabelMode is
-// LABEL_MODE_DUAL_WRITE or LABEL_MODE_UNPREFIXED, and are rejected by the API
-// for tenants in dual-write mode or created after the feature epoch.
+// synthetic-monitoring-agent. The API enforces this reservation: user-defined
+// labels with these names are rejected at check create/update and when a
+// tenant's LabelMode changes to LABEL_MODE_DUAL_WRITE or LABEL_MODE_UNPREFIXED.
+// A tenant therefore cannot enter a non-PREFIXED mode while holding a label
+// whose name collides with the current reserved set.
+//
+// The agent does NOT filter these names itself. A collision is only reachable
+// if a name is added to this set after a tenant already uses it; in that case
+// the agent lets the user-defined value win, deliberately preserving existing
+// tenant behaviour rather than dropping the label. This protects tenants
+// against future expansion of the reserved set. See buildUserLabels in
+// internal/scraper for the collision-resolution contract.
 //
 // This map must not be modified at runtime. Use IsSystemLabel to query it.
 //


### PR DESCRIPTION
## Summary

Relates to https://github.com/grafana/synthetic-monitoring/issues/541

Implements the agent-side scraper behaviour for tenant-controlled label prefix removal. Depends on #1878 (`feat(proto)`), which must merge first.

## What this adds

**`TenantLabelMode` provider — separate from `LabelsLimiter`**

Follows the same pattern as `TenantCals` for cost attribution labels. A new `internal/labelmode` package exposes a `LabelMode` struct backed by a `TenantProvider` to return the label mode of a tenant by ID.

**`buildUserLabels()` — mode-aware label emission**

Accepts an explicit `LabelMode`. Behaviour by mode:

- `PREFIXED` (0, default): `env=prod` → `label_env="prod"` (unchanged)
- `DUAL_WRITE` (1): all prefixed forms first, then all un-prefixed — `[label_foo, label_bar, foo, bar]`. 
  - If the label limit for Loki is exceeded, remaining labels spill into the `StructuredMetadata`.
  - The ordering ensures the `label_`-prefixed labels are retained to avoid breaking dependencies on indexed labels.
- `UNPREFIXED` (2): `env=prod` → `env="prod"` only

Reserved system label names are **not filtered**. The API enforces that tenants clear all reserved-name collisions before entering `DUAL_WRITE`, so any post-migration collision can only be caused by a new label we add to the reserved set. In that case the user-defined value should win — preserving existing tenant behaviour is preferable to silently overwriting/breaking it.

**`userLabelsForExecution()` — user labels on check execution metrics**

In `DUAL_WRITE` and `UNPREFIXED` modes, un-prefixed user labels are appended to the shared label set applied to all check execution metrics (`probe_success`, `probe_duration_seconds`, `probe_http_*`, etc.). Only the un-prefixed form is added to execution metrics in `DUAL_WRITE` — the dual-write of both prefixed and un-prefixed forms applies only to `sm_check_info` and Loki streams.

Enables label-based cost attribution and direct PromQL filtering without a join to `sm_check_info`, e.g. `rate(probe_success{env="prod"}[5m])`.

**Log label overflow to `StructuredMetadata`**

When the combined system and user label count would exceed Loki's 15-stream-label cap, excess user labels spill into `logproto.Entry.StructuredMetadata` rather than being silently truncated. Structured metadata is queryable in LogQL but not indexed as stream labels.

**Unit tests**

- `TestBuildUserLabels_*` — all three modes, check-overrides-probe, DUAL_WRITE ordering (`[label_foo, label_bar, foo, bar]`), reserved name passthrough (user value preserved)
- `TestUserLabelsForExecution_*` — PREFIXED returns nil, DUAL_WRITE/UNPREFIXED return un-prefixed only, reserved names pass through, check overrides probe

## State machine note

The state machine (`PREFIXED → DUAL_WRITE` irreversible, `DUAL_WRITE ↔ UNPREFIXED` reversible) is enforced by the API, not the agent. The agent reads `LabelMode` from the tenant cache and applies it — no transition logic lives here.

## Stale series note

When a tenant enters `DUAL_WRITE`, existing execution metric series (without user labels) become stale and new series (with user labels) are created. This is expected — tenants entering `DUAL_WRITE` are in a label migration context and should anticipate schema changes to their series.