### PR TITLE
feat: Gate protocol secrets with the protocol-secrets feature

### DIFF
--- a/cmd/synthetic-monitoring-agent/main.go
+++ b/cmd/synthetic-monitoring-agent/main.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -182,9 +181,9 @@ func run(args []string, stdout io.Writer) error {
 	// Using API_TOKEN should be deprecated after March 1st, 2023.
 	config.ApiToken = Secret(stringFromEnv("API_TOKEN", stringFromEnv("SM_AGENT_API_TOKEN", string(config.ApiToken))))
 
-	// Enable protocol secrets support via environment variable.
-	// This is a feature flag to allow testing before enabling by default.
-	config.EnableProtocolSecrets = boolFromEnv("SM_AGENT_ENABLE_PROTOCOL_SECRETS", config.EnableProtocolSecrets)
+	// Enable protocol secrets support via the "protocol-secrets" feature flag.
+	// This allows testing before enabling by default.
+	config.EnableProtocolSecrets = features.IsSet(feature.ProtocolSecrets)
 
 	if config.ApiToken == "" {
 		return fmt.Errorf("invalid API token")
@@ -480,21 +479,6 @@ func stringFromEnv(name string, override string) string {
 	}
 
 	return os.Getenv(name)
-}
-
-func boolFromEnv(name string, defaultValue bool) bool {
-	value := os.Getenv(name)
-	if value == "" {
-		return defaultValue
-	}
-
-	parsed, err := strconv.ParseBool(value)
-	if err != nil {
-		// If parsing fails, return the default value
-		return defaultValue
-	}
-
-	return parsed
 }
 
 func notifyAboutDeprecatedFeatureFlags(features feature.Collection, zl zerolog.Logger) {

--- a/docs/architecture/cmd.md
+++ b/docs/architecture/cmd.md
@@ -140,6 +140,7 @@ If you add a new top-level component, follow the same pattern: define an
 - **gRPC keep-alive.** Tuned via `HealthCheckInterval` / `HealthCheckTimeout` defined in the protobuf package. Required to detect network failures absent client writes — without it, the agent hangs when the server disappears mid-call.
 - **Cache fallbacks.** `setupCache` and `setupLocalCache` log and fall back rather than failing — the agent will boot with a noop cache if everything else fails. This is intentional: caching is a load-shedding optimisation, not a correctness requirement.
 - **The `k6` and `traceroute` feature flags are deprecated.** They are permanently enabled. `notifyAboutDeprecatedFeatureFlags` logs a hint if someone still passes them on the command line.
+- **The `protocol-secrets` feature flag.** When set (`-features protocol-secrets`), `config.EnableProtocolSecrets` is turned on, which makes the agent advertise `ProbeInfo.SupportsProtocolSecrets=true` at registration and enables `${secrets.<name>}` resolution for checks that opt in. It is opt-in for now, intended to become the default once released.
 
 ## Testing strategy
 

--- a/internal/feature/feature.go
+++ b/internal/feature/feature.go
@@ -13,6 +13,7 @@ const (
 	Traceroute            = "traceroute"
 	K6                    = "k6"
 	ExperimentalDnsProber = "experimental-dns-prober"
+	ProtocolSecrets       = "protocol-secrets"
 )
 
 // ErrInvalidCollection is returned when you try to set a flag in an

--- a/internal/feature/feature_test.go
+++ b/internal/feature/feature_test.go
@@ -67,6 +67,22 @@ func TestCollection(t *testing.T) {
 	}
 }
 
+func TestNamedFeatureConstants(t *testing.T) {
+	// Guard the exported feature-name constants against typos: parsing the
+	// literal name must make IsSet(<constant>) true.
+	for name, want := range map[string]string{
+		"traceroute":       Traceroute,
+		"k6":               K6,
+		"protocol-secrets": ProtocolSecrets,
+	} {
+		require.Equal(t, name, want)
+
+		c := NewCollection()
+		require.NoError(t, c.Set(name))
+		require.True(t, c.IsSet(want))
+	}
+}
+
 func TestCollectionFromFlag(t *testing.T) {
 	testcases := map[string]struct {
 		input            []string


### PR DESCRIPTION
Protocol-secrets support was enabled through a bespoke environment variable, SM_AGENT_ENABLE_PROTOCOL_SECRETS, read via a one-off boolFromEnv helper. The agent already has a first-class feature-flag mechanism (the -features flag backed by feature.Collection), so use it: add a "protocol-secrets" feature and drive config.EnableProtocolSecrets from features.IsSet(feature.ProtocolSecrets).

The downstream wiring is unchanged: config.EnableProtocolSecrets still feeds SupportsProtocolSecrets into the checks updater and adhoc handler, which advertise it in ProbeInfo at registration.

Remove the now-unused environment variable and the boolFromEnv helper. The feature is pre-release (only ever set on dev probes), so there is no backward-compatible fallback. Enable it with `-features protocol-secrets`.