### PR TITLE
feat(k6runner): export grace time metric

### DIFF
--- a/internal/k6runner/http.go
+++ b/internal/k6runner/http.go
@@ -335,6 +335,7 @@ func (r HttpRunner) Versions(ctx context.Context) <-chan []string {
 type HTTPMetrics struct {
 	Requests       *prometheus.CounterVec
 	RequestsPerRun *prometheus.HistogramVec
+	GraceTime      prometheus.Gauge
 }
 
 const (
@@ -342,7 +343,7 @@ const (
 	metricLabelRetriable = "retriable"
 )
 
-func NewHTTPMetrics(registerer prometheus.Registerer) *HTTPMetrics {
+func NewHTTPMetrics(registerer prometheus.Registerer, graceTime time.Duration) *HTTPMetrics {
 	m := &HTTPMetrics{}
 	m.Requests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -372,6 +373,15 @@ func NewHTTPMetrics(registerer prometheus.Registerer) *HTTPMetrics {
 		[]string{metricLabelSuccess},
 	)
 	registerer.MustRegister(m.RequestsPerRun)
+
+	m.GraceTime = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "sm_agent",
+		Subsystem: "k6runner",
+		Name:      "grace_time_seconds",
+		Help:      "Grace time added to a k6 script timeout when determining the request timeout.",
+	})
+	m.GraceTime.Set(graceTime.Seconds())
+	registerer.MustRegister(m.GraceTime)
 
 	return m
 }

--- a/internal/k6runner/http_test.go
+++ b/internal/k6runner/http_test.go
@@ -104,6 +104,25 @@ func TestHttpRunnerRun(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestNewHTTPMetricsExportsGraceTime(t *testing.T) {
+	t.Parallel()
+
+	registry := prometheus.NewRegistry()
+	NewHTTPMetrics(registry, 42*time.Second)
+
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	for _, metricFamily := range metricFamilies {
+		if metricFamily.GetName() == "sm_agent_k6runner_grace_time_seconds" {
+			require.Equal(t, 42.0, metricFamily.GetMetric()[0].GetGauge().GetValue())
+			return
+		}
+	}
+
+	t.Fatal("sm_agent_k6runner_grace_time_seconds metric was not exported")
+}
+
 func TestHttpRunnerRunError(t *testing.T) {
 	t.Parallel()
 
@@ -320,7 +339,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			srv := httptest.NewServer(mux)
 			t.Cleanup(srv.Close)
 
-			runner := HttpRunner{url: srv.URL, graceTime: time.Second, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry())}
+			runner := HttpRunner{url: srv.URL, graceTime: time.Second, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry(), time.Second)}
 			script, err := NewProcessor(Script{
 				Script: []byte("tee-hee"),
 				Settings: Settings{
@@ -460,7 +479,7 @@ func TestHTTPProcessorRetries(t *testing.T) {
 				srv := httptest.NewServer(mux)
 				t.Cleanup(srv.Close)
 
-				runner := HttpRunner{url: srv.URL, graceTime: tc.graceTime, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry())}
+				runner := HttpRunner{url: srv.URL, graceTime: tc.graceTime, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry(), tc.graceTime)}
 				processor, err := NewProcessor(Script{Script: nil, Settings: Settings{tc.scriptTimeout.Milliseconds()}}, runner)
 				require.NoError(t, err)
 
@@ -506,7 +525,7 @@ func TestHTTPProcessorRetries(t *testing.T) {
 
 		addr := <-listenerCh
 
-		runner := HttpRunner{url: "http://" + addr, graceTime: time.Second, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry())}
+		runner := HttpRunner{url: "http://" + addr, graceTime: time.Second, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry(), time.Second)}
 		processor, err := NewProcessor(Script{Script: nil, Settings: Settings{Timeout: 1000}}, runner)
 		require.NoError(t, err)
 

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -130,7 +130,7 @@ func New(opts RunnerOpts) (Runner, error) {
 			logger:              &logger,
 			graceTime:           defaultGraceTime,
 			backoff:             defaultBackoff,
-			metrics:             NewHTTPMetrics(registerer),
+			metrics:             NewHTTPMetrics(registerer, defaultGraceTime),
 			versionPollInterval: 30 * time.Second,
 		}
 	} else {


### PR DESCRIPTION
Closes #987

## What changed
- export the configured k6 runner grace time as `sm_agent_k6runner_grace_time_seconds`
- pass the runtime grace duration into the metrics constructor so the dashboard value cannot drift from request timeout behavior
- add a regression test that gathers the metric and verifies its value

## Validation
- `go test -race ./internal/k6runner`
- `go vet ./internal/k6runner`
- focused RED/GREEN test for `TestNewHTTPMetricsExportsGraceTime`
- `git diff --check`

I also ran `go test ./...`; the touched package and most repository packages passed, while the aggregate command hit existing environment prerequisites outside this change: CGO is required by `internal/scraper`, k6 fixture binaries were killed, and `dist/darwin-arm64` was not built for the multihttp test.