### PR TITLE
feat: emit region as sm_region for tenants in label migration

### DIFF
--- a/docs/architecture/scraper.md
+++ b/docs/architecture/scraper.md
@@ -121,7 +121,7 @@ you need to change republishing behaviour.
 
 For each probe run:
 
-1. Build **user labels** (from check configuration) and **check-info labels** (probe, region, instance, job, check_name, plus user labels with a `label_` prefix) used by the `sm_check_info` metric.
+1. Build **user labels** (from check configuration) and **check-info labels** (probe, region — emitted as `sm_region` for tenants in label mode DUAL_WRITE/UNPREFIXED — instance, job, check_name, plus user labels in their mode-appropriate form) used by the `sm_check_info` metric.
 2. Pull the per-tenant `MetricLabels` and `LogLabels` limits from `LabelsLimiter`. Fail closed if the limiter errors.
 3. Capture all check logs into an in-memory `bytes.Buffer` via a `kitlog` logfmt logger. The logger is decorated with every log label.
 4. Choose a `timeout`:
@@ -145,7 +145,7 @@ Special metric carrying check metadata for join queries. Defined by:
 
 - name = `sm_check_info`
 - value = `1`
-- labels = the `checkInfoLabels` built in `buildCheckInfoLabels` (probe, region, instance, job, check_name, frequency, geohash, alert sensitivity, plus user labels with a `label_` prefix).
+- labels = the `checkInfoLabels` built in `buildCheckInfoLabels` (probe, region — `sm_region` for tenants in label mode DUAL_WRITE/UNPREFIXED — instance, job, check_name, frequency, geohash, alert sensitivity, plus user labels in their mode-appropriate form).
 
 If you add a new piece of check metadata that operators need to join
 on, this is the metric to extend.

--- a/internal/scraper/labels_test.go
+++ b/internal/scraper/labels_test.go
@@ -284,3 +284,30 @@ func TestMergeLogLabels_NoUserLabels(t *testing.T) {
 
 	require.Equal(t, system, got)
 }
+
+// TestRegionLabelNameForMode pins the mode-conditional rename of the agent's
+// region label: legacy PREFIXED tenants keep "region"; tenants that have
+// started the migration receive "sm_region" (the reserved name).
+func TestRegionLabelNameForMode(t *testing.T) {
+	require.Equal(t, "region", regionLabelNameForMode(sm.LabelMode_LABEL_MODE_PREFIXED))
+	require.Equal(t, "sm_region", regionLabelNameForMode(sm.LabelMode_LABEL_MODE_DUAL_WRITE))
+	require.Equal(t, "sm_region", regionLabelNameForMode(sm.LabelMode_LABEL_MODE_UNPREFIXED))
+}
+
+// TestBuildUserLabels_SMRegionDropped pins that a user label named sm_region —
+// the reserved name the agent's own region label migrates to — is dropped in
+// enforced modes and cannot shadow the agent's value.
+func TestBuildUserLabels_SMRegionDropped(t *testing.T) {
+	labels := []sm.Label{{Name: "sm_region", Value: "spoofed"}}
+
+	// DUAL_WRITE drops the un-prefixed reserved form but keeps the prefixed
+	// form, which cannot collide with the agent's sm_region.
+	require.Equal(t,
+		[]labelPair{{name: "label_sm_region", value: "spoofed"}},
+		buildUserLabels(nil, labels, sm.LabelMode_LABEL_MODE_DUAL_WRITE))
+	require.Empty(t, buildUserLabels(nil, labels, sm.LabelMode_LABEL_MODE_UNPREFIXED))
+	// In PREFIXED mode it is emitted with the prefix, which cannot collide.
+	require.Equal(t,
+		[]labelPair{{name: "label_sm_region", value: "spoofed"}},
+		buildUserLabels(nil, labels, sm.LabelMode_LABEL_MODE_PREFIXED))
+}

--- a/internal/scraper/labels_test.go
+++ b/internal/scraper/labels_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
@@ -285,13 +286,30 @@ func TestMergeLogLabels_NoUserLabels(t *testing.T) {
 	require.Equal(t, system, got)
 }
 
-// TestRegionLabelNameForMode pins the mode-conditional rename of the agent's
-// region label: legacy PREFIXED tenants keep "region"; tenants that have
-// started the migration receive "sm_region" (the reserved name).
-func TestRegionLabelNameForMode(t *testing.T) {
-	require.Equal(t, "region", regionLabelNameForMode(sm.LabelMode_LABEL_MODE_PREFIXED))
-	require.Equal(t, "sm_region", regionLabelNameForMode(sm.LabelMode_LABEL_MODE_DUAL_WRITE))
-	require.Equal(t, "sm_region", regionLabelNameForMode(sm.LabelMode_LABEL_MODE_UNPREFIXED))
+// TestRegionLabelForMode pins the mode-conditional rename of the agent's
+// region label — legacy PREFIXED tenants keep "region"; tenants that have
+// started the migration receive "sm_region" (the reserved name) — and the
+// invariant the API's alert expressions depend on: for migrated modes,
+// sm_region is ALWAYS non-empty. A probe without a region gets the "unset"
+// sentinel, because an empty label value is the same as an absent label in
+// PromQL, and an absent sm_region classifies the series as pre-migration.
+func TestRegionLabelForMode(t *testing.T) {
+	require.Equal(t, labelPair{name: "region", value: "EMEA"},
+		regionLabelForMode(sm.LabelMode_LABEL_MODE_PREFIXED, "EMEA"))
+	require.Equal(t, labelPair{name: "sm_region", value: "EMEA"},
+		regionLabelForMode(sm.LabelMode_LABEL_MODE_DUAL_WRITE, "EMEA"))
+	require.Equal(t, labelPair{name: "sm_region", value: "EMEA"},
+		regionLabelForMode(sm.LabelMode_LABEL_MODE_UNPREFIXED, "EMEA"))
+
+	// Probe without a region: PREFIXED keeps the historical empty value
+	// (equivalent to an absent label), preserving legacy series identity.
+	require.Equal(t, labelPair{name: "region", value: ""},
+		regionLabelForMode(sm.LabelMode_LABEL_MODE_PREFIXED, ""))
+	// Migrated modes must never emit an empty sm_region.
+	require.Equal(t, labelPair{name: "sm_region", value: "unset"},
+		regionLabelForMode(sm.LabelMode_LABEL_MODE_DUAL_WRITE, ""))
+	require.Equal(t, labelPair{name: "sm_region", value: "unset"},
+		regionLabelForMode(sm.LabelMode_LABEL_MODE_UNPREFIXED, ""))
 }
 
 // TestBuildUserLabels_SMRegionDropped pins that a user label named sm_region —
@@ -310,4 +328,25 @@ func TestBuildUserLabels_SMRegionDropped(t *testing.T) {
 	require.Equal(t,
 		[]labelPair{{name: "label_sm_region", value: "spoofed"}},
 		buildUserLabels(nil, labels, sm.LabelMode_LABEL_MODE_PREFIXED))
+}
+
+// TestBuildCheckInfoLabels_RegionlessProbe pins the sentinel end to end on
+// sm_check_info: a migrated tenant's check running on a probe without a
+// region still carries a non-empty sm_region (the generation marker the
+// API's alert expressions select on), while a PREFIXED tenant's series keeps
+// the historical empty region value.
+func TestBuildCheckInfoLabels_RegionlessProbe(t *testing.T) {
+	s := Scraper{
+		checkName: "ping",
+		check:     model.Check{Check: sm.Check{Frequency: 60000}},
+		probe:     sm.Probe{Name: "regionless"},
+	}
+
+	migrated := s.buildCheckInfoLabels(nil, nil, sm.LabelMode_LABEL_MODE_DUAL_WRITE)
+	require.Equal(t, "unset", migrated["sm_region"])
+	require.NotContains(t, migrated, "region")
+
+	legacy := s.buildCheckInfoLabels(nil, nil, sm.LabelMode_LABEL_MODE_PREFIXED)
+	require.Equal(t, "", legacy["region"])
+	require.NotContains(t, legacy, "sm_region")
 }

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -46,6 +46,7 @@ const (
 const (
 	probeLabelName         = "probe"
 	regionLabelName        = "region"
+	smRegionLabelName      = "sm_region"
 	configVersionLabelName = "config_version"
 )
 
@@ -547,7 +548,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 		// These are the labels defined by the user.
 		userLabels = buildUserLabels(s.probe.Labels, s.check.Labels, labelMode)
 		// These labels are applied to the sm_check_info metric.
-		checkInfoLabels = s.buildCheckInfoLabels(userLabels, sysMetricLabels)
+		checkInfoLabels = s.buildCheckInfoLabels(userLabels, sysMetricLabels, labelMode)
 		// This is the execution ID for the check run.
 		executionID = uuid.New().String()
 	)
@@ -578,7 +579,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 
 	logLabels := []labelPair{
 		{name: probeLabelName, value: s.probe.Name},
-		{name: regionLabelName, value: s.probe.Region},
+		{name: regionLabelNameForMode(labelMode), value: s.probe.Region},
 		{name: "instance", value: s.check.Target},
 		{name: "job", value: s.check.Job},
 		{name: "check_name", value: s.checkName},
@@ -1021,10 +1022,10 @@ func extractTimeseries(t time.Time, metrics []*dto.MetricFamily, executionLabels
 	return ts
 }
 
-func (s Scraper) buildCheckInfoLabels(userLabels []labelPair, commonLabels []labelPair) map[string]string {
+func (s Scraper) buildCheckInfoLabels(userLabels []labelPair, commonLabels []labelPair, mode sm.LabelMode) map[string]string {
 	baseLabels := []labelPair{
 		{name: "check_name", value: s.checkName},
-		{name: regionLabelName, value: s.probe.Region},
+		{name: regionLabelNameForMode(mode), value: s.probe.Region},
 		{name: "frequency", value: strconv.FormatInt(s.check.Frequency, 10)},
 		{name: "geohash", value: geohash.Encode(float64(s.probe.Latitude), float64(s.probe.Longitude))},
 	}
@@ -1115,6 +1116,19 @@ func customMetricLabels(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) 
 	}
 
 	return buildUserLabels(probeLabels, checkLabels, sm.LabelMode_LABEL_MODE_UNPREFIXED)
+}
+
+// regionLabelNameForMode returns the label name under which the agent emits
+// the probe's region. Tenants that have started the label migration (any mode
+// other than PREFIXED) receive it as sm_region, which is part of the reserved
+// set, freeing "region" for use as one of their own labels. Legacy PREFIXED
+// tenants keep the historical "region" name.
+func regionLabelNameForMode(mode sm.LabelMode) string {
+	if mode == sm.LabelMode_LABEL_MODE_PREFIXED {
+		return regionLabelName
+	}
+
+	return smRegionLabelName
 }
 
 func makeTimeseries(t time.Time, value float64, labels ...prompb.Label) prompb.TimeSeries {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -47,6 +47,7 @@ const (
 	probeLabelName         = "probe"
 	regionLabelName        = "region"
 	smRegionLabelName      = "sm_region"
+	unsetRegionValue       = "unset"
 	configVersionLabelName = "config_version"
 	instanceLabelName      = "instance"
 	checkNameLabelName     = "check_name"
@@ -581,7 +582,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 
 	logLabels := []labelPair{
 		{name: probeLabelName, value: s.probe.Name},
-		{name: regionLabelNameForMode(labelMode), value: s.probe.Region},
+		regionLabelForMode(labelMode, s.probe.Region),
 		{name: instanceLabelName, value: s.check.Target},
 		{name: "job", value: s.check.Job},
 		{name: checkNameLabelName, value: s.checkName},
@@ -1027,7 +1028,7 @@ func extractTimeseries(t time.Time, metrics []*dto.MetricFamily, executionLabels
 func (s Scraper) buildCheckInfoLabels(userLabels []labelPair, commonLabels []labelPair, mode sm.LabelMode) map[string]string {
 	baseLabels := []labelPair{
 		{name: checkNameLabelName, value: s.checkName},
-		{name: regionLabelNameForMode(mode), value: s.probe.Region},
+		regionLabelForMode(mode, s.probe.Region),
 		{name: "frequency", value: strconv.FormatInt(s.check.Frequency, 10)},
 		{name: "geohash", value: geohash.Encode(float64(s.probe.Latitude), float64(s.probe.Longitude))},
 	}
@@ -1120,17 +1121,28 @@ func customMetricLabels(probeLabels, checkLabels []sm.Label, mode sm.LabelMode) 
 	return buildUserLabels(probeLabels, checkLabels, sm.LabelMode_LABEL_MODE_UNPREFIXED)
 }
 
-// regionLabelNameForMode returns the label name under which the agent emits
-// the probe's region. Tenants that have started the label migration (any mode
+// regionLabelForMode returns the label under which the agent emits the
+// probe's region. Tenants that have started the label migration (any mode
 // other than PREFIXED) receive it as sm_region, which is part of the reserved
 // set, freeing "region" for use as one of their own labels. Legacy PREFIXED
 // tenants keep the historical "region" name.
-func regionLabelNameForMode(mode sm.LabelMode) string {
+//
+// sm_region always carries a non-empty value — "unset" when the probe has no
+// region — because its presence is how the API's alert expressions recognize
+// a migrated series: an empty label value is equivalent to an absent label in
+// PromQL, which would classify the series as legacy and route its alerts with
+// the wrong exclusion list. The historical region label keeps its value as-is
+// (absent when the probe has no region), preserving legacy series identity.
+func regionLabelForMode(mode sm.LabelMode, probeRegion string) labelPair {
 	if mode == sm.LabelMode_LABEL_MODE_PREFIXED {
-		return regionLabelName
+		return labelPair{name: regionLabelName, value: probeRegion}
 	}
 
-	return smRegionLabelName
+	if probeRegion == "" {
+		probeRegion = unsetRegionValue
+	}
+
+	return labelPair{name: smRegionLabelName, value: probeRegion}
 }
 
 func makeTimeseries(t time.Time, value float64, labels ...prompb.Label) prompb.TimeSeries {

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -48,6 +48,8 @@ const (
 	regionLabelName        = "region"
 	smRegionLabelName      = "sm_region"
 	configVersionLabelName = "config_version"
+	instanceLabelName      = "instance"
+	checkNameLabelName     = "check_name"
 )
 
 // mimirMaxLabelsIngest protects us and Mimir from hitting an error due to
@@ -539,7 +541,7 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 	sysMetricLabels := []labelPair{
 		{name: probeLabelName, value: s.probe.Name},
 		{name: configVersionLabelName, value: s.check.ConfigVersion()},
-		{name: "instance", value: s.check.Target},
+		{name: instanceLabelName, value: s.check.Target},
 		{name: "job", value: s.check.Job},
 		// {name: "source", value: CheckInfoSource}, // identify metrics that belong to synthetic-monitoring-agent
 	}
@@ -580,9 +582,9 @@ func (s Scraper) collectData(ctx context.Context, t time.Time) (*probeData, time
 	logLabels := []labelPair{
 		{name: probeLabelName, value: s.probe.Name},
 		{name: regionLabelNameForMode(labelMode), value: s.probe.Region},
-		{name: "instance", value: s.check.Target},
+		{name: instanceLabelName, value: s.check.Target},
 		{name: "job", value: s.check.Job},
-		{name: "check_name", value: s.checkName},
+		{name: checkNameLabelName, value: s.checkName},
 		{name: "source", value: CheckInfoSource}, // identify log lines that belong to synthetic-monitoring-agent
 	}
 	logLabels = mergeLogLabels(logLabels, userLabels)
@@ -1024,7 +1026,7 @@ func extractTimeseries(t time.Time, metrics []*dto.MetricFamily, executionLabels
 
 func (s Scraper) buildCheckInfoLabels(userLabels []labelPair, commonLabels []labelPair, mode sm.LabelMode) map[string]string {
 	baseLabels := []labelPair{
-		{name: "check_name", value: s.checkName},
+		{name: checkNameLabelName, value: s.checkName},
 		{name: regionLabelNameForMode(mode), value: s.probe.Region},
 		{name: "frequency", value: strconv.FormatInt(s.check.Frequency, 10)},
 		{name: "geohash", value: geohash.Encode(float64(s.probe.Latitude), float64(s.probe.Longitude))},

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1593,6 +1593,24 @@ func TestScraperCollectData(t *testing.T) {
 			"region":               region,
 			"source":               CheckInfoSource,
 		}
+
+		// Tenants that have started the label migration (DUAL_WRITE/UNPREFIXED)
+		// receive the agent's region label as sm_region instead of region.
+		baseExpectedInfoLabelsSMRegion = map[string]string{
+			"check_name": checkName,
+			"frequency":  strconv.Itoa(frequency),
+			"geohash":    geohash.Encode(probeLatitude, probeLongitde),
+			"sm_region":  region,
+		}
+		baseExpectedLogLabelsSMRegion = map[string]string{
+			"check_name":           checkName,
+			"instance":             checkTarget,
+			"job":                  job,
+			"probe":                probeName,
+			ProbeSuccessMetricName: "1",
+			"sm_region":            region,
+			"source":               CheckInfoSource,
+		}
 	)
 
 	generateLabels := func(offset, count int, valuePrefix string) []sm.Label {
@@ -1750,7 +1768,7 @@ func TestScraperCollectData(t *testing.T) {
 			// + check-info system labels + both forms of user labels from ConstLabels.
 			expectedInfoLabels: mergeMaps(
 				baseExpectedMetricLabels,
-				baseExpectedInfoLabels,
+				baseExpectedInfoLabelsSMRegion,
 				generateLabelSet(10, 1, "p"),
 				generateUnprefixedLabelSet(10, 1, "p"),
 				generateLabelSet(0, 3, "c"),
@@ -1760,14 +1778,14 @@ func TestScraperCollectData(t *testing.T) {
 			// 4 user labels × 2 = 8 entries + 6 system labels = 14; probe_success
 			// is appended last, totalling 15 = defMaxLogLabels. No overflow.
 			expectedLogLabels: mergeMaps(
-				baseExpectedLogLabels,
+				baseExpectedLogLabelsSMRegion,
 				generateLabelSet(10, 1, "p"),
 				generateLabelSet(0, 3, "c"),
 				generateUnprefixedLabelSet(10, 1, "p"),
 				generateUnprefixedLabelSet(0, 3, "c"),
 			),
 			expectedLogEntries: mergeMaps(
-				baseExpectedLogLabels,
+				baseExpectedLogLabelsSMRegion,
 				generateLabelSet(10, 1, "p"),
 				generateLabelSet(0, 3, "c"),
 				generateUnprefixedLabelSet(10, 1, "p"),
@@ -1791,17 +1809,17 @@ func TestScraperCollectData(t *testing.T) {
 			),
 			expectedInfoLabels: mergeMaps(
 				baseExpectedMetricLabels,
-				baseExpectedInfoLabels,
+				baseExpectedInfoLabelsSMRegion,
 				generateUnprefixedLabelSet(10, 1, "p"),
 				generateUnprefixedLabelSet(0, 3, "c"),
 			),
 			expectedLogLabels: mergeMaps(
-				baseExpectedLogLabels,
+				baseExpectedLogLabelsSMRegion,
 				generateUnprefixedLabelSet(10, 1, "p"),
 				generateUnprefixedLabelSet(0, 3, "c"),
 			),
 			expectedLogEntries: mergeMaps(
-				baseExpectedLogLabels,
+				baseExpectedLogLabelsSMRegion,
 				generateUnprefixedLabelSet(10, 1, "p"),
 				generateUnprefixedLabelSet(0, 3, "c"),
 			),
@@ -1832,7 +1850,7 @@ func TestScraperCollectData(t *testing.T) {
 			// sm_check_info: system sharedLabels + both forms of user labels from ConstLabels.
 			expectedInfoLabels: mergeMaps(
 				baseExpectedMetricLabels,
-				baseExpectedInfoLabels,
+				baseExpectedInfoLabelsSMRegion,
 				generateLabelSet(10, 3, "p"),
 				generateUnprefixedLabelSet(10, 3, "p"),
 				generateLabelSet(0, 10, "c"),
@@ -1842,7 +1860,7 @@ func TestScraperCollectData(t *testing.T) {
 			// ordering means label_l10,label_l11,label_l12 + label_l0..label_l4
 			// fill the 8 available slots before the cap).
 			expectedLogLabels: mergeMaps(
-				baseExpectedLogLabels,
+				baseExpectedLogLabelsSMRegion,
 				generateLabelSet(10, 3, "p"), // label_l10, label_l11, label_l12
 				generateLabelSet(0, 5, "c"),  // label_l0 .. label_l4
 			),
@@ -1851,7 +1869,7 @@ func TestScraperCollectData(t *testing.T) {
 			// expectedLogEntries \ expectedLogLabels become StructuredMetadata overflow
 			// and are validated by assertStructuredMetadata.
 			expectedLogEntries: mergeMaps(
-				baseExpectedLogLabels,
+				baseExpectedLogLabelsSMRegion,
 				generateLabelSet(10, 3, "p"),
 				generateLabelSet(0, 10, "c"),
 				generateUnprefixedLabelSet(10, 3, "p"),
@@ -1879,16 +1897,75 @@ func TestScraperCollectData(t *testing.T) {
 			),
 			expectedInfoLabels: mergeMaps(
 				baseExpectedMetricLabels,
-				baseExpectedInfoLabels,
+				baseExpectedInfoLabelsSMRegion,
 				map[string]string{"env": "prod"},
 			),
 			expectedLogLabels: mergeMaps(
-				baseExpectedLogLabels,
+				baseExpectedLogLabelsSMRegion,
 				map[string]string{"env": "prod"},
 			),
 			expectedLogEntries: mergeMaps(
-				baseExpectedLogLabels,
+				baseExpectedLogLabelsSMRegion,
 				map[string]string{"env": "prod"},
+			),
+		},
+
+		// Renaming the agent's own region label to sm_region frees "region" for
+		// tenant use: a user label named region must reach every surface intact,
+		// alongside the agent's sm_region.
+		"unprefixed user region label freed": {
+			labelMode:       sm.LabelMode_LABEL_MODE_UNPREFIXED,
+			maxMetricLabels: defMaxMetricLabels,
+			maxLogLabels:    defMaxLogLabels,
+			checkLabels: []sm.Label{
+				{Name: "region", Value: "user-region"},
+			},
+			expectedMetricLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				map[string]string{"region": "user-region"},
+			),
+			expectedInfoLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				baseExpectedInfoLabelsSMRegion,
+				map[string]string{"region": "user-region"},
+			),
+			expectedLogLabels: mergeMaps(
+				baseExpectedLogLabelsSMRegion,
+				map[string]string{"region": "user-region"},
+			),
+			expectedLogEntries: mergeMaps(
+				baseExpectedLogLabelsSMRegion,
+				map[string]string{"region": "user-region"},
+			),
+		},
+
+		// Same as above but in DUAL_WRITE: the riskiest mode, where the user's
+		// region (as both region and label_region) coexists with the agent's
+		// sm_region — three distinct keys, no duplicates, on every surface.
+		"dual write user region label freed": {
+			labelMode:       sm.LabelMode_LABEL_MODE_DUAL_WRITE,
+			maxMetricLabels: defMaxMetricLabels,
+			maxLogLabels:    defMaxLogLabels,
+			checkLabels: []sm.Label{
+				{Name: "region", Value: "user-region"},
+			},
+			// Execution metrics carry only the un-prefixed user form.
+			expectedMetricLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				map[string]string{"region": "user-region"},
+			),
+			expectedInfoLabels: mergeMaps(
+				baseExpectedMetricLabels,
+				baseExpectedInfoLabelsSMRegion,
+				map[string]string{"label_region": "user-region", "region": "user-region"},
+			),
+			expectedLogLabels: mergeMaps(
+				baseExpectedLogLabelsSMRegion,
+				map[string]string{"label_region": "user-region", "region": "user-region"},
+			),
+			expectedLogEntries: mergeMaps(
+				baseExpectedLogLabelsSMRegion,
+				map[string]string{"label_region": "user-region", "region": "user-region"},
 			),
 		},
 
@@ -1902,9 +1979,9 @@ func TestScraperCollectData(t *testing.T) {
 			maxLogLabels:         defMaxLogLabels,
 			checkLabels:          generateLabels(1, 3, "c"),
 			expectedMetricLabels: mergeMaps(baseExpectedMetricLabels, generateUnprefixedLabelSet(1, 3, "c")),
-			expectedInfoLabels:   mergeMaps(baseExpectedMetricLabels, baseExpectedInfoLabels, generateUnprefixedLabelSet(1, 3, "c")),
-			expectedLogLabels:    mergeMaps(baseExpectedLogLabels, generateUnprefixedLabelSet(1, 3, "c")),
-			expectedLogEntries:   mergeMaps(baseExpectedLogLabels, generateUnprefixedLabelSet(1, 3, "c")),
+			expectedInfoLabels:   mergeMaps(baseExpectedMetricLabels, baseExpectedInfoLabelsSMRegion, generateUnprefixedLabelSet(1, 3, "c")),
+			expectedLogLabels:    mergeMaps(baseExpectedLogLabelsSMRegion, generateUnprefixedLabelSet(1, 3, "c")),
+			expectedLogEntries:   mergeMaps(baseExpectedLogLabelsSMRegion, generateUnprefixedLabelSet(1, 3, "c")),
 		},
 	}
 


### PR DESCRIPTION
Relates to https://github.com/grafana/synthetic-monitoring/issues/549

Gives the `region` label back to users who perform the `label_`-prefix migration - `region` can be highly context/user-specific, so distinguish the SM-defined region with a `sm_` prefix (`sm_region`).
* Ensure `sm_region` is always present on `sm_check_info` - defaults to `unset` if empty.

Note that this has ramifications on per-check alerting expressions, which current exclude the `region` label and must start excluding `sm_region` instead. A corresponding change in the API must update the alerting rule expressions for tenants who switch away from the initial `PREFIXED` state.

For tenants that have started the label migration (label mode DUAL_WRITE or UNPREFIXED), the agent now emits its region label as `sm_region`. 