### PR TITLE
feat: Export k6 grace time metric

### DIFF
--- a/internal/adhoc/adhoc.go
+++ b/internal/adhoc/adhoc.go
@@ -85,7 +85,8 @@ type apiInfo struct {
 }
 
 type metrics struct {
-	opsCounter *prometheus.CounterVec
+	opsCounter  *prometheus.CounterVec
+	k6GraceTime prometheus.Gauge
 }
 
 // Backoffer defines an interface to provide backoff durations.
@@ -138,7 +139,21 @@ func NewHandler(opts HandlerOpts) (*Handler, error) {
 		[]string{"type"},
 	)
 
+	k6GraceTime := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "sm",
+			Subsystem: "adhoc",
+			Name:      "k6_grace_time_seconds",
+			Help:      "Grace time added to ad-hoc k6 check timeouts",
+		},
+	)
+	k6GraceTime.Set(k6AdhocGraceTime.Seconds())
+
 	if err := opts.PromRegisterer.Register(opsCounter); err != nil {
+		return nil, err
+	}
+
+	if err := opts.PromRegisterer.Register(k6GraceTime); err != nil {
 		return nil, err
 	}
 
@@ -156,7 +171,8 @@ func NewHandler(opts HandlerOpts) (*Handler, error) {
 			conn: opts.Conn,
 		},
 		metrics: metrics{
-			opsCounter: opsCounter,
+			opsCounter:  opsCounter,
+			k6GraceTime: k6GraceTime,
 		},
 	}
 

--- a/internal/adhoc/adhoc_test.go
+++ b/internal/adhoc/adhoc_test.go
@@ -56,6 +56,7 @@ func TestNewHandler(t *testing.T) {
 	require.NotNil(t, h.metrics.opsCounter)
 	require.NotNil(t, h.metrics.k6GraceTime)
 	require.Equal(t, k6AdhocGraceTime.Seconds(), testutil.ToFloat64(h.metrics.k6GraceTime))
+
 	metricCount, err := testutil.GatherAndCount(registry, "sm_adhoc_k6_grace_time_seconds")
 	require.NoError(t, err)
 	require.Equal(t, 1, metricCount)

--- a/internal/adhoc/adhoc_test.go
+++ b/internal/adhoc/adhoc_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -31,12 +32,13 @@ func TestNewHandler(t *testing.T) {
 	features := feature.NewCollection()
 	require.NoError(t, features.Set("adhoc"))
 
+	registry := prometheus.NewPedanticRegistry()
 	opts := HandlerOpts{
 		Conn:           nil,
 		Logger:         zerolog.New(io.Discard),
 		Publisher:      channelPublisher(make(chan pusher.Payload)),
 		TenantCh:       make(chan sm.Tenant),
-		PromRegisterer: prometheus.NewPedanticRegistry(),
+		PromRegisterer: registry,
 		Features:       features,
 	}
 
@@ -52,6 +54,11 @@ func TestNewHandler(t *testing.T) {
 	require.NotNil(t, h.grpcAdhocChecksClientFactory)
 	require.Nil(t, h.probe, "probe should not be set at this point")
 	require.NotNil(t, h.metrics.opsCounter)
+	require.NotNil(t, h.metrics.k6GraceTime)
+	require.Equal(t, k6AdhocGraceTime.Seconds(), testutil.ToFloat64(h.metrics.k6GraceTime))
+	metricCount, err := testutil.GatherAndCount(registry, "sm_adhoc_k6_grace_time_seconds")
+	require.NoError(t, err)
+	require.Equal(t, 1, metricCount)
 	require.False(t, h.supportsProtocolSecrets, "default value should be false")
 }
 

--- a/internal/k6runner/http.go
+++ b/internal/k6runner/http.go
@@ -349,6 +349,7 @@ func (r HttpRunner) Versions(ctx context.Context) <-chan []string {
 type HTTPMetrics struct {
 	Requests       *prometheus.CounterVec
 	RequestsPerRun *prometheus.HistogramVec
+	GraceTime      prometheus.Gauge
 }
 
 const (
@@ -356,7 +357,7 @@ const (
 	metricLabelRetriable = "retriable"
 )
 
-func NewHTTPMetrics(registerer prometheus.Registerer) *HTTPMetrics {
+func NewHTTPMetrics(registerer prometheus.Registerer, graceTime time.Duration) *HTTPMetrics {
 	m := &HTTPMetrics{}
 	m.Requests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -386,6 +387,17 @@ func NewHTTPMetrics(registerer prometheus.Registerer) *HTTPMetrics {
 		[]string{metricLabelSuccess},
 	)
 	registerer.MustRegister(m.RequestsPerRun)
+
+	m.GraceTime = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "sm_agent",
+			Subsystem: "k6runner",
+			Name:      "grace_time_seconds",
+			Help:      "Grace time added to remote k6 runner request timeouts",
+		},
+	)
+	m.GraceTime.Set(graceTime.Seconds())
+	registerer.MustRegister(m.GraceTime)
 
 	return m
 }

--- a/internal/k6runner/http_test.go
+++ b/internal/k6runner/http_test.go
@@ -18,10 +18,22 @@ import (
 	"github.com/go-logfmt/logfmt"
 	"github.com/grafana/synthetic-monitoring-agent/internal/testhelper"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/expfmt"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewHTTPMetrics(t *testing.T) {
+	registry := prometheus.NewPedanticRegistry()
+	metrics := NewHTTPMetrics(registry, defaultGraceTime)
+
+	require.Equal(t, defaultGraceTime.Seconds(), testutil.ToFloat64(metrics.GraceTime))
+
+	metricCount, err := testutil.GatherAndCount(registry, "sm_agent_k6runner_grace_time_seconds")
+	require.NoError(t, err)
+	require.Equal(t, 1, metricCount)
+}
 
 func TestHttpRunnerRun(t *testing.T) {
 	t.Parallel()
@@ -325,7 +337,7 @@ func TestScriptHTTPRun(t *testing.T) {
 			srv := httptest.NewServer(mux)
 			t.Cleanup(srv.Close)
 
-			runner := HttpRunner{url: srv.URL, graceTime: time.Second, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry())}
+			runner := HttpRunner{url: srv.URL, graceTime: time.Second, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry(), time.Second)}
 			script, err := NewProcessor(Script{
 				Script: []byte("tee-hee"),
 				Settings: Settings{
@@ -466,7 +478,7 @@ func TestHTTPProcessorRetries(t *testing.T) {
 				srv := httptest.NewServer(mux)
 				t.Cleanup(srv.Close)
 
-				runner := HttpRunner{url: srv.URL, graceTime: tc.graceTime, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry())}
+				runner := HttpRunner{url: srv.URL, graceTime: tc.graceTime, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry(), tc.graceTime)}
 				processor, err := NewProcessor(Script{Script: nil, Settings: Settings{tc.scriptTimeout.Milliseconds()}}, runner)
 				require.NoError(t, err)
 
@@ -513,7 +525,7 @@ func TestHTTPProcessorRetries(t *testing.T) {
 
 		addr := <-listenerCh
 
-		runner := HttpRunner{url: "http://" + addr, graceTime: time.Second, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry())}
+		runner := HttpRunner{url: "http://" + addr, graceTime: time.Second, backoff: time.Second, metrics: NewHTTPMetrics(prometheus.NewRegistry(), time.Second)}
 		processor, err := NewProcessor(Script{Script: nil, Settings: Settings{Timeout: 1000}}, runner)
 		require.NoError(t, err)
 

--- a/internal/k6runner/k6runner.go
+++ b/internal/k6runner/k6runner.go
@@ -133,7 +133,7 @@ func New(opts RunnerOpts) (Runner, error) {
 			logger:              &logger,
 			graceTime:           defaultGraceTime,
 			backoff:             defaultBackoff,
-			metrics:             NewHTTPMetrics(registerer),
+			metrics:             NewHTTPMetrics(registerer, defaultGraceTime),
 			versionPollInterval: 30 * time.Second,
 		}
 	} else {


### PR DESCRIPTION
Export the k6 grace-time values from the agent's Prometheus registry:

- `sm_adhoc_k6_grace_time_seconds` for the ad-hoc outer timeout
- `sm_agent_k6runner_grace_time_seconds` for the remote k6 runner used by scheduled browser, scripted, and multi-HTTP checks

This lets dashboards show the effective timeout threshold without duplicating source constants.

Tests cover metric registration and values.

Closes #987.
