### PR TITLE
fix: Substitute variables in multihttp assertion values and expressions

### DIFF
--- a/internal/prober/multihttp/script.go
+++ b/internal/prober/multihttp/script.go
@@ -70,6 +70,18 @@ func performVariableExpansion(in string) string {
 	return s.String()
 }
 
+// expandAssertionField renders a user-supplied assertion field as a JavaScript
+// expression. Fields without any ${variable} reference keep their plain string
+// literal form, so the scripts generated for checks that don't use variables
+// are unchanged.
+func expandAssertionField(in string) string {
+	if !userVariables.MatchString(in) {
+		return `"` + template.JSEscapeString(in) + `"`
+	}
+
+	return performVariableExpansion(in)
+}
+
 // Query params must be appended to a URL that has already been created.
 // urlVarName is the variable name to reference when appending params.
 func buildQueryParams(urlVarName string, req *sm.MultiHttpEntryRequest) []string {
@@ -226,6 +238,10 @@ func (c assertionCondition) Name(w *strings.Builder, subject, value string) {
 }
 
 func (c assertionCondition) Render(w *strings.Builder, subject, value string) {
+	// The value may reference variables, in which case it is emitted as an
+	// expression that resolves them at run time rather than a string literal.
+	expr := expandAssertionField(value)
+
 	switch sm.MultiHttpEntryAssertionConditionVariant(c) {
 	case sm.MultiHttpEntryAssertionConditionVariant_NOT_CONTAINS:
 		w.WriteRune('!')
@@ -233,27 +249,26 @@ func (c assertionCondition) Render(w *strings.Builder, subject, value string) {
 
 	case sm.MultiHttpEntryAssertionConditionVariant_CONTAINS, sm.MultiHttpEntryAssertionConditionVariant_DEFAULT_CONDITION:
 		w.WriteString(subject)
-		w.WriteString(`.includes("`)
-		w.WriteString(template.JSEscapeString(value))
-		w.WriteString(`")`)
+		w.WriteString(`.includes(`)
+		w.WriteString(expr)
+		w.WriteString(`)`)
 
 	case sm.MultiHttpEntryAssertionConditionVariant_EQUALS:
 		w.WriteString(subject)
-		w.WriteString(` === "`)
-		w.WriteString(template.JSEscapeString(value))
-		w.WriteString(`"`)
+		w.WriteString(` === `)
+		w.WriteString(expr)
 
 	case sm.MultiHttpEntryAssertionConditionVariant_STARTS_WITH:
 		w.WriteString(subject)
-		w.WriteString(`.startsWith("`)
-		w.WriteString(template.JSEscapeString(value))
-		w.WriteString(`")`)
+		w.WriteString(`.startsWith(`)
+		w.WriteString(expr)
+		w.WriteString(`)`)
 
 	case sm.MultiHttpEntryAssertionConditionVariant_ENDS_WITH:
 		w.WriteString(subject)
-		w.WriteString(`.endsWith("`)
-		w.WriteString(template.JSEscapeString(value))
-		w.WriteString(`")`)
+		w.WriteString(`.endsWith(`)
+		w.WriteString(expr)
+		w.WriteString(`)`)
 	}
 }
 
@@ -293,9 +308,9 @@ func buildChecks(urlVarName, method string, assertion *sm.MultiHttpEntryAssertio
 				b.WriteString(`);`)
 			} else {
 				// Expression provided, search for a matching header.
-				b.WriteString(`return assertHeader(response.headers, "`)
-				b.WriteString(template.JSEscapeString(assertion.Expression))
-				b.WriteString(`", `)
+				b.WriteString(`return assertHeader(response.headers, `)
+				b.WriteString(expandAssertionField(assertion.Expression))
+				b.WriteString(`, `)
 				b.WriteString(`v => `)
 				cond.Render(&b, "value", assertion.Value)
 				cond.Render(&assertionDescriptor, "value", assertion.Value)
@@ -314,29 +329,29 @@ func buildChecks(urlVarName, method string, assertion *sm.MultiHttpEntryAssertio
 	case sm.MultiHttpEntryAssertionType_JSON_PATH_VALUE:
 		cond := assertionCondition(assertion.Condition)
 		cond.Name(&b, assertion.Expression, assertion.Value)
-		b.WriteString(`": response => jsonpath.query(response.json(), "`)
-		b.WriteString(template.JSEscapeString(assertion.Expression))
-		b.WriteString(`").some(values => `)
+		b.WriteString(`": response => jsonpath.query(response.json(), `)
+		b.WriteString(expandAssertionField(assertion.Expression))
+		b.WriteString(`).some(values => `)
 		cond.Render(&b, `values`, assertion.Value)
 		cond.Render(&assertionDescriptor, `values`, assertion.Value)
 		b.WriteString(`)`)
 
 	case sm.MultiHttpEntryAssertionType_JSON_PATH_ASSERTION:
 		b.WriteString(template.JSEscapeString(assertion.Expression))
-		b.WriteString(` exists": response => jsonpath.query(response.json(), "`)
-		b.WriteString(template.JSEscapeString(assertion.Expression))
+		b.WriteString(` exists": response => jsonpath.query(response.json(), `)
+		b.WriteString(expandAssertionField(assertion.Expression))
 		assertionDescriptor.WriteString(`JsonPath expression `)
 		assertionDescriptor.WriteString(assertion.Expression)
-		b.WriteString(`").length > 0`)
+		b.WriteString(`).length > 0`)
 
 	case sm.MultiHttpEntryAssertionType_REGEX_ASSERTION:
 		switch assertion.Subject {
 		case sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_BODY, sm.MultiHttpEntryAssertionSubjectVariant_DEFAULT_SUBJECT:
 			b.WriteString(`body matches /`)
 			b.WriteString(template.JSEscapeString(assertion.Expression))
-			b.WriteString(`/": response => { const expr = new RegExp("`)
-			b.WriteString(template.JSEscapeString(assertion.Expression))
-			b.WriteString(`"); `)
+			b.WriteString(`/": response => { const expr = new RegExp(`)
+			b.WriteString(expandAssertionField(assertion.Expression))
+			b.WriteString(`); `)
 			b.WriteString(`return expr.test(response.body); }`)
 			assertionDescriptor.WriteString("Body matches")
 			assertionDescriptor.WriteString(assertion.Expression)
@@ -344,9 +359,9 @@ func buildChecks(urlVarName, method string, assertion *sm.MultiHttpEntryAssertio
 		case sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_HEADERS:
 			b.WriteString(`headers matches /`)
 			b.WriteString(template.JSEscapeString(assertion.Expression))
-			b.WriteString(`/": response => { const expr = new RegExp("`)
-			b.WriteString(template.JSEscapeString(assertion.Expression))
-			b.WriteString(`"); `)
+			b.WriteString(`/": response => { const expr = new RegExp(`)
+			b.WriteString(expandAssertionField(assertion.Expression))
+			b.WriteString(`); `)
 			b.WriteString(`const values = Object.entries(response.headers).map(header => header[0].toLowerCase() + ': ' + header[1]); `)
 			b.WriteString(`return !!values.find(value => expr.test(value)); }`)
 			assertionDescriptor.WriteString("Headers match")
@@ -355,9 +370,9 @@ func buildChecks(urlVarName, method string, assertion *sm.MultiHttpEntryAssertio
 		case sm.MultiHttpEntryAssertionSubjectVariant_HTTP_STATUS_CODE:
 			b.WriteString(`status matches /`)
 			b.WriteString(template.JSEscapeString(assertion.Expression))
-			b.WriteString(`/": response => { const expr = new RegExp("`)
-			b.WriteString(template.JSEscapeString(assertion.Expression))
-			b.WriteString(`"); `)
+			b.WriteString(`/": response => { const expr = new RegExp(`)
+			b.WriteString(expandAssertionField(assertion.Expression))
+			b.WriteString(`); `)
 			b.WriteString(`return expr.test(response.status.toString()); }`)
 			assertionDescriptor.WriteString("Status matches")
 			assertionDescriptor.WriteString(assertion.Expression)

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -469,6 +469,56 @@ func TestAssertionConditionRender(t *testing.T) {
 			value:     "val'ue",
 			expected:  `subject.endsWith("val\'ue")`,
 		},
+		// The value can reference variables extracted from earlier requests,
+		// which must be resolved at run time rather than compared literally.
+		"TestAssertionConditionRenderContainsVariable": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+			subject:   "subject",
+			value:     "${my_var}",
+			expected:  `subject.includes(vars['my_var'])`,
+		},
+		"TestAssertionConditionRenderNotContainsVariable": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_NOT_CONTAINS,
+			subject:   "subject",
+			value:     "${my_var}",
+			expected:  `!subject.includes(vars['my_var'])`,
+		},
+		"TestAssertionConditionRenderEqualsVariable": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+			subject:   "subject",
+			value:     "${my_var}",
+			expected:  `subject === vars['my_var']`,
+		},
+		"TestAssertionConditionRenderStartsWithVariable": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_STARTS_WITH,
+			subject:   "subject",
+			value:     "${my_var}",
+			expected:  `subject.startsWith(vars['my_var'])`,
+		},
+		"TestAssertionConditionRenderEndsWithVariable": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_ENDS_WITH,
+			subject:   "subject",
+			value:     "${my_var}",
+			expected:  `subject.endsWith(vars['my_var'])`,
+		},
+		"TestAssertionConditionRenderVariableSurroundedByText": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+			subject:   "subject",
+			value:     "pre-${my_var}-post",
+			expected:  `subject === 'pre-'+vars['my_var']+'-post'`,
+		},
+		"TestAssertionConditionRenderMultipleVariables": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+			subject:   "subject",
+			value:     "${v1}/${v2}",
+			expected:  `subject === vars['v1']+'/'+vars['v2']`,
+		},
+		"TestAssertionConditionRenderEmptyValue": {
+			condition: sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+			subject:   "subject",
+			value:     "",
+			expected:  `subject === ""`,
+		},
 	}
 
 	for name, testcase := range testcases {
@@ -631,6 +681,104 @@ func TestBuildChecks(t *testing.T) {
 	};
 `,
 		},
+		// Assertions can reference variables extracted from earlier requests.
+		// The check name keeps the literal ${var} so that the resulting metric
+		// tag stays stable across iterations; only the comparison is resolved
+		// at run time.
+		"TestBuildChecksJsonPathValueAssertionWithVariableValue": {
+			urlVarName: "url",
+			method:     "GET",
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_VALUE,
+				Condition:  sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+				Expression: "$.theirValue",
+				Value:      "${my_var}",
+			},
+			expected: `currentCheck = check(response, { "$.theirValue equals \"${my_var}\"": response => jsonpath.query(response.json(), "$.theirValue").some(values => values === vars['my_var']) }, {"url": url.toString(), "method": "GET"});
+	if(!currentCheck) {
+		console.error("Assertion failed:", "values \u003D\u003D\u003D vars[\'my_var\']");
+		fail()
+	};
+`,
+		},
+		"TestBuildChecksJsonPathValueAssertionWithVariableExpression": {
+			urlVarName: "url",
+			method:     "GET",
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_VALUE,
+				Condition:  sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+				Expression: "$.items[${idx}].name",
+				Value:      "value",
+			},
+			expected: `currentCheck = check(response, { "$.items[${idx}].name contains \"value\"": response => jsonpath.query(response.json(), '$.items['+vars['idx']+'].name').some(values => values.includes("value")) }, {"url": url.toString(), "method": "GET"});
+	if(!currentCheck) {
+		console.error("Assertion failed:", "values.includes(\"value\")");
+		fail()
+	};
+`,
+		},
+		"TestBuildChecksTextAssertionWithVariableInValue": {
+			urlVarName: "url",
+			method:     "GET",
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:      sm.MultiHttpEntryAssertionType_TEXT,
+				Condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+				Subject:   sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_BODY,
+				Value:     "token-${session_id}",
+			},
+			expected: `currentCheck = check(response, { "body contains \"token-${session_id}\"": response => response.body.includes('token-'+vars['session_id']) }, {"url": url.toString(), "method": "GET"});
+	if(!currentCheck) {
+		console.error("Assertion failed:", "response.body.includes(\'token-\'+vars[\'session_id\'])");
+		fail()
+	};
+`,
+		},
+		"TestBuildChecksTextAssertionWithVariableHeaderName": {
+			urlVarName: "url",
+			method:     "GET",
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:       sm.MultiHttpEntryAssertionType_TEXT,
+				Condition:  sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+				Subject:    sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_HEADERS,
+				Expression: "${header_name}",
+				Value:      "${header_value}",
+			},
+			expected: `currentCheck = check(response, { "header equals \"${header_value}\"": response => { return assertHeader(response.headers, vars['header_name'], v => value === vars['header_value']); } }, {"url": url.toString(), "method": "GET"});
+	if(!currentCheck) {
+		console.error("Assertion failed:", "value \u003D\u003D\u003D vars[\'header_value\']");
+		fail()
+	};
+`,
+		},
+		"TestBuildChecksJsonPathAssertionWithVariableExpression": {
+			urlVarName: "url",
+			method:     "GET",
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_ASSERTION,
+				Expression: "$.${field}",
+			},
+			expected: `currentCheck = check(response, { "$.${field} exists": response => jsonpath.query(response.json(), '$.'+vars['field']).length > 0 }, {"url": url.toString(), "method": "GET"});
+	if(!currentCheck) {
+		console.error("Assertion failed:", "JsonPath expression $.${field}");
+		fail()
+	};
+`,
+		},
+		"TestBuildChecksRegexAssertionWithVariableExpression": {
+			urlVarName: "url",
+			method:     "GET",
+			assertion: &sm.MultiHttpEntryAssertion{
+				Type:       sm.MultiHttpEntryAssertionType_REGEX_ASSERTION,
+				Subject:    sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_BODY,
+				Expression: "^${prefix}-[0-9]+$",
+			},
+			expected: `currentCheck = check(response, { "body matches /^${prefix}-[0-9]+$/": response => { const expr = new RegExp('^'+vars['prefix']+'-[0-9]+$'); return expr.test(response.body); } }, {"url": url.toString(), "method": "GET"});
+	if(!currentCheck) {
+		console.error("Assertion failed:", "Body matches^${prefix}-[0-9]+$");
+		fail()
+	};
+`,
+		},
 	}
 
 	for name, testcase := range testcases {
@@ -774,6 +922,11 @@ func TestSettingsToScript(t *testing.T) {
 						Name:       "date",
 						Expression: "$.slideshow.date",
 					},
+					{
+						Type:       sm.MultiHttpEntryVariableType_REGEX,
+						Name:       "authorKey",
+						Expression: `"(author)"`,
+					},
 				},
 			},
 			{
@@ -785,6 +938,41 @@ func TestSettingsToScript(t *testing.T) {
 					{
 						Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_ASSERTION,
 						Expression: `$.slideshow.title`,
+					},
+				},
+			},
+			// Assertions referencing variables captured by the entries above.
+			// Without variable expansion these compare against the literal
+			// "${author}" / query the literal "$.slideshow.${authorKey}" and
+			// the whole probe fails.
+			{
+				Request: &sm.MultiHttpEntryRequest{
+					Method: sm.HttpMethod_GET,
+					Url:    testServer.URL + "/json",
+				},
+				Assertions: []*sm.MultiHttpEntryAssertion{
+					{
+						Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_VALUE,
+						Expression: "$.slideshow.author",
+						Condition:  sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+						Value:      "${author}",
+					},
+					{
+						Type:       sm.MultiHttpEntryAssertionType_JSON_PATH_VALUE,
+						Expression: "$.slideshow.${authorKey}",
+						Condition:  sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+						Value:      "${author}",
+					},
+					{
+						Type:      sm.MultiHttpEntryAssertionType_TEXT,
+						Subject:   sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_BODY,
+						Condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
+						Value:     "${author}",
+					},
+					{
+						Type:       sm.MultiHttpEntryAssertionType_REGEX_ASSERTION,
+						Subject:    sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_BODY,
+						Expression: `"${authorKey}": "${author}"`,
 					},
 				},
 			},


### PR DESCRIPTION
Fixes #1892

The [MultiHTTP docs](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/checks/multihttp/#variables) state that `${variable}` can be used "anywhere where a string is expected, for example as the value of a header or the value of an assertion". Substitution was wired up for URLs, query parameters, headers and (since #717) request bodies, but never for assertions.

An assertion configured with `value: "${my_var}"` generated `values === "${my_var}"` — a comparison against the literal, unsubstituted text — so it could never match unless the response happened to contain those exact characters.

## Changes

Assertion `value` and `expression` fields now go through `expandAssertionField`, which reuses the existing `performVariableExpansion` when a reference is present:

```go
func expandAssertionField(in string) string {
	if !userVariables.MatchString(in) {
		return `"` + template.JSEscapeString(in) + `"`
	}

	return performVariableExpansion(in)
}
```

A field with no variable reference produces the identical string literal it did before, so **the generated script is byte-for-byte unchanged for any check that doesn't use variables**. Only checks that actually reference a variable produce different output.

`performVariableExpansion` returns a self-quoting expression (`'text'`, `vars['x']`, or `'pre-'+vars['x']`), so the call sites no longer write the surrounding quotes themselves — keeping them would produce `.includes("'text'")`.

This covers the value for all five conditions (`contains`, `not contains`, `equals`, `starts with`, `ends with`), and the expression for the JSON path query, the header name, and the regex pattern.

Check *names* are deliberately untouched and keep the literal `${var}` text. They become metric tags, so resolving them per-iteration would make tag cardinality unbounded.

## Testing

`script_test.go` is **additions only — no existing expectation was modified**. Every pre-existing assertion on generated output still passes with its original text, which is the direct evidence for the no-change claim above.

- New unit cases in `TestAssertionConditionRender` and `TestBuildChecks` for variables in values and expressions, including partial interpolation (`pre-${v}-post`), multiple variables, and empty values.
- `TestSettingsToScript` runs the generated script through real k6 binaries; it now captures variables and asserts against them via JSON path value, text, and regex assertions.
- Verified with a negative control: forcing `expandAssertionField` to skip expansion fails the new end-to-end test on both k6 v1.1.10 and v2.0.6, with `values === "${author}"` comparing against the literal placeholder.

## Note

Behaviour change worth flagging: an assertion that intentionally matched the literal text `${...}` will now resolve it as a variable. This is the same trade-off accepted for request bodies in #717.

A separate, pre-existing bug in `buildChecks` surfaced while writing these tests and is fixed independently in #1943. The two branches touch adjacent lines, so whichever merges second will need a small conflict resolution.