### PR TITLE
fix: Reference the correct binding in header assertion callbacks

### DIFF
--- a/internal/prober/multihttp/script.go
+++ b/internal/prober/multihttp/script.go
@@ -296,7 +296,7 @@ func buildChecks(urlVarName, method string, assertion *sm.MultiHttpEntryAssertio
 				b.WriteString(`return assertHeader(response.headers, "`)
 				b.WriteString(template.JSEscapeString(assertion.Expression))
 				b.WriteString(`", `)
-				b.WriteString(`v => `)
+				b.WriteString(`value => `)
 				cond.Render(&b, "value", assertion.Value)
 				cond.Render(&assertionDescriptor, "value", assertion.Value)
 				b.WriteString(`);`)

--- a/internal/prober/multihttp/script_test.go
+++ b/internal/prober/multihttp/script_test.go
@@ -531,7 +531,7 @@ func TestBuildChecks(t *testing.T) {
 				Expression: "Content-Type",
 				Value:      "value",
 			},
-			expected: `currentCheck = check(response, { "header contains \"value\"": response => { return assertHeader(response.headers, "Content-Type", v => value.includes("value")); } }, {"url": url.toString(), "method": "GET"});
+			expected: `currentCheck = check(response, { "header contains \"value\"": response => { return assertHeader(response.headers, "Content-Type", value => value.includes("value")); } }, {"url": url.toString(), "method": "GET"});
 	if(!currentCheck) {
 		console.error("Assertion failed:", "value.includes(\"value\")");
 		fail()
@@ -709,6 +709,15 @@ func TestSettingsToScript(t *testing.T) {
 						Subject:   sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_HEADERS,
 						Condition: sm.MultiHttpEntryAssertionConditionVariant_CONTAINS,
 						Value:     "foo: bar",
+					},
+					// An expression selects a single header by name, which
+					// takes the assertHeader path.
+					{
+						Type:       sm.MultiHttpEntryAssertionType_TEXT,
+						Subject:    sm.MultiHttpEntryAssertionSubjectVariant_RESPONSE_HEADERS,
+						Condition:  sm.MultiHttpEntryAssertionConditionVariant_EQUALS,
+						Expression: "foo",
+						Value:      "bar",
 					},
 				},
 			},


### PR DESCRIPTION
A TEXT assertion on response headers that names a single header via an expression generated a callback whose parameter was `v`, while its body referenced `value`:

```js
assertHeader(response.headers, "Content-Type", v => value.includes("application/json"))
//                                             ^        ^^^^^ not defined in this scope
```

`value` is not bound in that scope, so the `ReferenceError` propagates out of `assertHeader` and aborts the check. Assertions of this shape never evaluate their condition — they fail hard with `ReferenceError: value is not defined` rather than returning a wrong verdict.

The fix names the parameter `value`, matching the callback in the sibling branch that scans all headers at once (`values.find(value => ...)`), which is why that variant was unaffected.

## Why it went unnoticed

`TestSettingsToScript` runs generated scripts against real k6 binaries, but it only covered header assertions *without* an expression — the "scan all headers" path, which is correct. The `assertHeader` path had no end-to-end coverage at all. This PR adds a header selected by name to that test.

Verified with a negative control: reverting the one-word change fails the new test on both k6 v1.1.10 and v2.0.6, with the exception surfacing through `assertHeader` in the stack trace.

## Relationship to #1942

Found while adding tests for #1942 (variable substitution in assertions), but it is an independent bug with an independent fix, so it is split out here to be reviewed and merged on its own.

The two branches touch adjacent lines in `buildChecks`, so whichever merges second will need a small conflict resolution. Once both are in, the end-to-end test can be extended to cover a header whose *name* comes from a variable, which exercises both fixes together — that case needs both and so belongs in neither PR.