### PR TITLE
feat: restart scrapers when a tenant's label mode changes

### DIFF
--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -692,10 +692,19 @@ func (c *Updater) handleCheckUpdate(ctx context.Context, check model.Check) erro
 }
 
 // restartCheck replaces check's running scraper with a freshly built one.
-// A check with no running scraper degrades to a plain add: the API can
-// legitimately send an update for a check this agent never saw (e.g. it
-// was created and updated while the agent was disconnected).
+// The replacement is built before the old scraper is touched, so a
+// construction failure leaves the old scraper registered and running
+// (there is no retry path for a dead check until its next config change
+// or a reconnect). A check with no running scraper degrades to a plain
+// add: the API can legitimately send an update for a check this agent
+// never saw (e.g. it was created and updated while the agent was
+// disconnected).
 func (c *Updater) restartCheck(ctx context.Context, check model.Check) error {
+	replacement, err := c.buildScraper(ctx, check)
+	if err != nil {
+		return err
+	}
+
 	old, found := c.scrapers.remove(check.GlobalID())
 	if !found {
 		c.logger.Warn().Int64("check_id", check.Id).Int("region_id", check.RegionId).Msg("update request for an unknown check")
@@ -705,7 +714,19 @@ func (c *Updater) restartCheck(ctx context.Context, check model.Check) error {
 		c.metrics.runningScrapers.WithLabelValues(old.CheckType().String()).Dec()
 	}
 
-	return c.addAndStartScraper(ctx, check)
+	// A nil replacement is a check a disabled feature flag filters out:
+	// accepted, but nothing to register or run.
+	if replacement == nil {
+		return nil
+	}
+
+	c.scrapers.add(check, replacement)
+
+	go replacement.Run(ctx)
+
+	c.metrics.runningScrapers.WithLabelValues(check.Type().String()).Inc()
+
+	return nil
 }
 
 func (c *Updater) handleCheckDelete(ctx context.Context, check model.Check) error {
@@ -870,9 +891,12 @@ func (c *Updater) handleChangeBatch(ctx context.Context, changes *sm.Changes, fi
 	}
 }
 
-// addAndStartScraper creates a new scraper, adds it to the list of
-// scrapers managed by this updater and starts running it.
-func (c *Updater) addAndStartScraper(ctx context.Context, check model.Check) error {
+// buildScraper constructs a scraper for check without registering or
+// starting it, so callers replacing a running scraper can keep the old one
+// until the new one is known to exist. It returns a nil scraper and a nil
+// error for checks that a disabled feature flag filters out: those are
+// accepted from the API's point of view but never run.
+func (c *Updater) buildScraper(ctx context.Context, check model.Check) (*scraper.Scraper, error) {
 	// This is a good place to filter out checks by feature flags.
 	//
 	// If we need to accept checks based on whether a feature flag
@@ -881,7 +905,7 @@ func (c *Updater) addAndStartScraper(ctx context.Context, check model.Check) err
 	switch check.Type() {
 	case sm.CheckTypeScripted:
 		if !c.features.IsSet(feature.K6) {
-			return nil
+			return nil, nil
 		}
 
 	case sm.CheckTypeMultiHttp:
@@ -889,7 +913,7 @@ func (c *Updater) addAndStartScraper(ctx context.Context, check model.Check) err
 		// to abstrct this by adding a function to the settings that
 		// returns whether the check requires k6 or not.
 		if !c.features.IsSet(feature.K6) {
-			return nil
+			return nil, nil
 		}
 
 	default:
@@ -906,7 +930,7 @@ func (c *Updater) addAndStartScraper(ctx context.Context, check model.Check) err
 		"regionId": ridStr,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	scrapeErrorCounter, err := c.metrics.scrapeErrorCounter.CurryWith(prometheus.Labels{
@@ -915,7 +939,7 @@ func (c *Updater) addAndStartScraper(ctx context.Context, check model.Check) err
 		"regionId": ridStr,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	metrics := scraper.NewMetrics(
@@ -932,14 +956,29 @@ func (c *Updater) addAndStartScraper(ctx context.Context, check model.Check) err
 		c.tenantLimits, c.telemeter, c.tenantSecrets, c.tenantCals, c.tenantLabellingMode,
 	)
 	if err != nil {
-		return fmt.Errorf("cannot create new scraper: %w", err)
+		return nil, fmt.Errorf("cannot create new scraper: %w", err)
+	}
+
+	return scraper, nil
+}
+
+// addAndStartScraper creates a new scraper, adds it to the list of
+// scrapers managed by this updater and starts running it.
+func (c *Updater) addAndStartScraper(ctx context.Context, check model.Check) error {
+	scraper, err := c.buildScraper(ctx, check)
+	if err != nil {
+		return err
+	}
+
+	if scraper == nil {
+		return nil
 	}
 
 	c.scrapers.add(check, scraper)
 
 	go scraper.Run(ctx)
 
-	c.metrics.runningScrapers.WithLabelValues(checkType).Inc()
+	c.metrics.runningScrapers.WithLabelValues(check.Type().String()).Inc()
 
 	return nil
 }

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -695,17 +695,34 @@ func (c *Updater) handleCheckUpdate(ctx context.Context, check model.Check) erro
 // The replacement is built before the old scraper is touched, so a
 // construction failure leaves the old scraper registered and running
 // (there is no retry path for a dead check until its next config change
-// or a reconnect). A check with no running scraper degrades to a plain
-// add: the API can legitimately send an update for a check this agent
-// never saw (e.g. it was created and updated while the agent was
-// disconnected).
+// or a reconnect), and the swap itself is a single registry operation, so
+// the check is never observably absent during a successful restart. A
+// check with no running scraper degrades to a plain add: the API can
+// legitimately send an update for a check this agent never saw (e.g. it
+// was created and updated while the agent was disconnected).
 func (c *Updater) restartCheck(ctx context.Context, check model.Check) error {
 	replacement, err := c.buildScraper(ctx, check)
 	if err != nil {
 		return err
 	}
 
-	old, found := c.scrapers.remove(check.GlobalID())
+	// A nil replacement is a check a disabled feature flag filters out:
+	// accepted, but nothing to register or run.
+	if replacement == nil {
+		old, found := c.scrapers.remove(check.GlobalID())
+		if !found {
+			c.logger.Warn().Int64("check_id", check.Id).Int("region_id", check.RegionId).Msg("update request for an unknown check")
+			return nil
+		}
+
+		old.Stop()
+
+		c.metrics.runningScrapers.WithLabelValues(old.CheckType().String()).Dec()
+
+		return nil
+	}
+
+	old, found := c.scrapers.replace(check, replacement)
 	if !found {
 		c.logger.Warn().Int64("check_id", check.Id).Int("region_id", check.RegionId).Msg("update request for an unknown check")
 	} else {
@@ -713,14 +730,6 @@ func (c *Updater) restartCheck(ctx context.Context, check model.Check) error {
 
 		c.metrics.runningScrapers.WithLabelValues(old.CheckType().String()).Dec()
 	}
-
-	// A nil replacement is a check a disabled feature flag filters out:
-	// accepted, but nothing to register or run.
-	if replacement == nil {
-		return nil
-	}
-
-	c.scrapers.add(check, replacement)
 
 	go replacement.Run(ctx)
 

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -81,8 +81,7 @@ type Updater struct {
 	probeTenantOnce         sync.Once
 	IsConnected             func(bool)
 	probe                   *sm.Probe
-	scrapersMutex           sync.Mutex
-	scrapers                map[model.GlobalID]*scraper.Scraper
+	scrapers                *scraperRegistry
 	metrics                 metrics
 	k6Runner                k6runner.Runner
 	scraperFactory          scraper.Factory
@@ -251,7 +250,7 @@ func NewUpdater(opts UpdaterOptions) (*Updater, error) {
 		tenantCh:                opts.TenantCh,
 		probeCh:                 opts.ProbeCh,
 		IsConnected:             opts.IsConnected,
-		scrapers:                make(map[model.GlobalID]*scraper.Scraper),
+		scrapers:                newScraperRegistry(),
 		k6Runner:                opts.K6Runner,
 		scraperFactory:          scraperFactory,
 		tenantLimits:            opts.TenantLimits,
@@ -471,14 +470,7 @@ func (c *Updater) loop(ctx context.Context) (bool, error) {
 	}
 
 	knownChecks := sm.ProbeState{
-		Checks: make([]sm.EntityRef, 0, len(c.scrapers)),
-	}
-
-	for cID, scraper := range c.scrapers {
-		knownChecks.Checks = append(knownChecks.Checks, sm.EntityRef{
-			Id:           int64(cID),
-			LastModified: scraper.LastModified(),
-		})
+		Checks: c.scrapers.entityRefs(),
 	}
 
 	cc, err := client.GetChanges(sigCtx, &knownChecks)
@@ -678,10 +670,7 @@ func (c *Updater) handleCheckAdd(ctx context.Context, check model.Check) error {
 		return fmt.Errorf("invalid check: %w", err)
 	}
 
-	c.scrapersMutex.Lock()
-	defer c.scrapersMutex.Unlock()
-
-	if running, found := c.scrapers[check.GlobalID()]; found {
+	if running, found := c.scrapers.get(check.GlobalID()); found {
 		// we can get here if the API sent us a check add twice:
 		// once during the initial connection and another right
 		// after that. The window for that is small, but it
@@ -689,7 +678,7 @@ func (c *Updater) handleCheckAdd(ctx context.Context, check model.Check) error {
 		return fmt.Errorf("check with id %d already exists (version %s)", check.GlobalID(), running.ConfigVersion())
 	}
 
-	return c.addAndStartScraperWithLock(ctx, check)
+	return c.addAndStartScraper(ctx, check)
 }
 
 func (c *Updater) handleCheckUpdate(ctx context.Context, check model.Check) error {
@@ -699,56 +688,38 @@ func (c *Updater) handleCheckUpdate(ctx context.Context, check model.Check) erro
 		return fmt.Errorf("invalid check: %w", err)
 	}
 
-	c.scrapersMutex.Lock()
-	defer c.scrapersMutex.Unlock()
-
-	return c.handleCheckUpdateWithLock(ctx, check)
+	return c.restartCheck(ctx, check)
 }
 
-// handleCheckUpdateWithLock is the bottom half of handleCheckUpdate. It
-// MUST be called with the scrapersMutex lock held.
-func (c *Updater) handleCheckUpdateWithLock(ctx context.Context, check model.Check) error {
-	cid := check.GlobalID()
-
-	scraper, found := c.scrapers[cid]
+// restartCheck replaces check's running scraper with a freshly built one.
+// A check with no running scraper degrades to a plain add: the API can
+// legitimately send an update for a check this agent never saw (e.g. it
+// was created and updated while the agent was disconnected).
+func (c *Updater) restartCheck(ctx context.Context, check model.Check) error {
+	old, found := c.scrapers.remove(check.GlobalID())
 	if !found {
 		c.logger.Warn().Int64("check_id", check.Id).Int("region_id", check.RegionId).Msg("update request for an unknown check")
-		return c.addAndStartScraperWithLock(ctx, check)
+	} else {
+		old.Stop()
+
+		c.metrics.runningScrapers.WithLabelValues(old.CheckType().String()).Dec()
 	}
 
-	// this is the lazy way to update the scraper: tear everything
-	// down, start it again.
-
-	scraper.Stop()
-	checkType := scraper.CheckType().String()
-
-	delete(c.scrapers, cid)
-
-	c.metrics.runningScrapers.WithLabelValues(checkType).Dec()
-
-	return c.addAndStartScraperWithLock(ctx, check)
+	return c.addAndStartScraper(ctx, check)
 }
 
 func (c *Updater) handleCheckDelete(ctx context.Context, check model.Check) error {
 	c.metrics.changesCounter.WithLabelValues("delete").Inc()
 
-	cid := check.GlobalID()
-
-	c.scrapersMutex.Lock()
-	defer c.scrapersMutex.Unlock()
-
-	scraper, found := c.scrapers[cid]
+	scraper, found := c.scrapers.remove(check.GlobalID())
 	if !found {
 		c.logger.Warn().Int64("check_id", check.Id).Int("region_id", check.RegionId).Msg("delete request for an unknown check")
 		return errors.New("check not found")
 	}
 
 	scraper.Stop()
-	checkType := scraper.CheckType().String()
 
-	delete(c.scrapers, cid)
-
-	c.metrics.runningScrapers.WithLabelValues(checkType).Dec()
+	c.metrics.runningScrapers.WithLabelValues(scraper.CheckType().String()).Dec()
 
 	return nil
 }
@@ -771,9 +742,6 @@ func (c *Updater) handleCheckDelete(ctx context.Context, check model.Check) erro
 func (c *Updater) handleFirstBatch(ctx context.Context, changes *sm.Changes) {
 	newChecks := make(map[model.GlobalID]struct{})
 
-	c.scrapersMutex.Lock()
-	defer c.scrapersMutex.Unlock()
-
 	// add checks from the provided list
 	for _, checkChange := range changes.Checks {
 		c.logger.Debug().Interface("check change", checkChange).Msg("got check change")
@@ -786,7 +754,7 @@ func (c *Updater) handleFirstBatch(ctx context.Context, changes *sm.Changes) {
 				continue
 			}
 
-			if err := c.handleInitialChangeAddWithLock(ctx, check); err != nil {
+			if err := c.handleInitialChangeAdd(ctx, check); err != nil {
 				c.metrics.changeErrorsCounter.WithLabelValues("add").Inc()
 				c.logger.Error().Err(err).Int64("check_id", check.Id).Int("region_id", check.RegionId).
 					Msg("adding check failed, dropping check")
@@ -811,34 +779,26 @@ func (c *Updater) handleFirstBatch(ctx context.Context, changes *sm.Changes) {
 	}
 
 	// remove all the running scrapers that weren't sent with the first batch
-	for id, scraper := range c.scrapers {
-		if _, found := newChecks[id]; found {
-			continue
-		}
+	for _, scraper := range c.scrapers.removeAbsent(newChecks) {
+		check := scraper.Check()
 
-		cid, rid := model.GetLocalAndRegionIDs(id)
 		c.logger.Debug().
-			Int64("check_id", cid).
-			Int("region_id", rid).
+			Int64("check_id", check.Id).
+			Int("region_id", check.RegionId).
 			Msg("stopping scraper during first batch handling")
 
-		checkType := scraper.CheckType().String()
 		scraper.Stop()
 
-		delete(c.scrapers, id)
-
-		c.metrics.runningScrapers.WithLabelValues(checkType).Dec()
+		c.metrics.runningScrapers.WithLabelValues(scraper.CheckType().String()).Dec()
 	}
 }
 
-// handleCheckUpdateWithLock the specified check to the running checks.
+// handleInitialChangeAdd adds the specified check to the running checks.
 //
 // It deals with the case where this check is the product of a reconnection
 // and changes the operation to an update if necessary.
-//
-// This function MUST be called with the scrapers mutex held.
-func (c *Updater) handleInitialChangeAddWithLock(ctx context.Context, check model.Check) error {
-	if running, found := c.scrapers[check.GlobalID()]; found {
+func (c *Updater) handleInitialChangeAdd(ctx context.Context, check model.Check) error {
+	if running, found := c.scrapers.get(check.GlobalID()); found {
 		oldVersion := running.ConfigVersion()
 		newVersion := check.ConfigVersion()
 
@@ -852,7 +812,7 @@ func (c *Updater) handleInitialChangeAddWithLock(ctx context.Context, check mode
 		// transform this request into an update
 		c.logger.Debug().Str("old_check_version", oldVersion).Str("new_check_version", newVersion).Msg("transforming add into update")
 
-		return c.handleCheckUpdateWithLock(ctx, check)
+		return c.restartCheck(ctx, check)
 	}
 
 	c.metrics.changesCounter.WithLabelValues("add").Inc()
@@ -861,7 +821,7 @@ func (c *Updater) handleInitialChangeAddWithLock(ctx context.Context, check mode
 		return err
 	}
 
-	if err := c.addAndStartScraperWithLock(ctx, check); err != nil {
+	if err := c.addAndStartScraper(ctx, check); err != nil {
 		c.metrics.changeErrorsCounter.WithLabelValues("add").Inc()
 		return err
 	}
@@ -910,11 +870,9 @@ func (c *Updater) handleChangeBatch(ctx context.Context, changes *sm.Changes, fi
 	}
 }
 
-// addAndStartScraperWithLock creates a new scraper, adds it to the list of
+// addAndStartScraper creates a new scraper, adds it to the list of
 // scrapers managed by this updater and starts running it.
-//
-// This MUST be called with the scrapersMutex held.
-func (c *Updater) addAndStartScraperWithLock(ctx context.Context, check model.Check) error {
+func (c *Updater) addAndStartScraper(ctx context.Context, check model.Check) error {
 	// This is a good place to filter out checks by feature flags.
 	//
 	// If we need to accept checks based on whether a feature flag
@@ -977,7 +935,7 @@ func (c *Updater) addAndStartScraperWithLock(ctx context.Context, check model.Ch
 		return fmt.Errorf("cannot create new scraper: %w", err)
 	}
 
-	c.scrapers[check.GlobalID()] = scraper
+	c.scrapers.add(check, scraper)
 
 	go scraper.Run(ctx)
 

--- a/internal/checks/checks.go
+++ b/internal/checks/checks.go
@@ -745,6 +745,36 @@ func (c *Updater) handleCheckDelete(ctx context.Context, check model.Check) erro
 	return nil
 }
 
+// handleTenantUpdate restarts every scraper belonging to tenant, but only
+// if tenant's label mode differs from the last one this agent observed for
+// it (or if this is the first time this agent has seen this tenant at
+// all). A scraper already re-fetches its tenant's label mode on every
+// scrape (collectDataWith's call to labellingMode.ForTenant); what the
+// restart buys is the replacement scraper's fresh startup offset, which
+// bounds mode-pickup latency to at most min(frequency,
+// maxPublishInterval), i.e. ~2 minutes, instead of the remainder of the
+// old scraper's current cycle — a material difference only for checks
+// whose frequency exceeds that bound.
+func (c *Updater) handleTenantUpdate(ctx context.Context, tenant sm.Tenant) {
+	tenantKey := model.GlobalID(tenant.Id)
+
+	if !c.scrapers.setLabelMode(tenantKey, tenant.LabelMode) {
+		return
+	}
+
+	for _, check := range c.scrapers.checksForTenant(tenantKey) {
+		if err := c.restartCheck(ctx, check); err != nil {
+			c.metrics.changeErrorsCounter.WithLabelValues("update").Inc()
+			c.logger.Error().
+				Err(err).
+				Int64("check_id", check.Id).
+				Int("region_id", check.RegionId).
+				Int64("tenant_id", tenant.Id).
+				Msg("restarting scraper after tenant label mode change")
+		}
+	}
+}
+
 // handleFirstBatch takes a list of changes and adds them to the running set
 // and stops any scrapers that shouldn't be running.
 //
@@ -858,6 +888,8 @@ func (c *Updater) handleChangeBatch(ctx context.Context, changes *sm.Changes, fi
 
 	for _, tenant := range changes.Tenants {
 		c.tenantCh <- tenant
+
+		c.handleTenantUpdate(ctx, tenant)
 	}
 
 	for _, checkChange := range changes.Checks {

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"syscall"
@@ -305,6 +306,450 @@ func testHandleCheckOpImpl(t *testing.T) {
 	requireRegistryConsistent(t, u.scrapers)
 
 	// Wait for all scraper goroutines to fully exit before test completes.
+	synctest.Wait()
+}
+
+func TestHandleTenantUpdate(t *testing.T) {
+	synctest.Test(t, testHandleTenantUpdateImpl)
+}
+
+func testHandleTenantUpdateImpl(t *testing.T) {
+	u, err := NewUpdater(
+		UpdaterOptions{
+			Conn:           new(grpc.ClientConn),
+			PromRegisterer: prometheus.NewPedanticRegistry(),
+			Publisher:      channelPublisher(make(chan pusher.Payload, 100)),
+			TenantCh:       make(chan sm.Tenant, 10),
+			Logger:         testhelper.Logger(t),
+			ScraperFactory: testScraperFactory,
+		},
+	)
+	require.NoError(t, err)
+
+	u.probe = &sm.Probe{Id: 100, Name: "test-probe"}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	readLastLabelMode := func(id model.GlobalID) (sm.LabelMode, bool) {
+		u.scrapers.mu.Lock()
+		defer u.scrapers.mu.Unlock()
+
+		mode, ok := u.scrapers.labelModes[id]
+
+		return mode, ok
+	}
+
+	// A tenant with zero running scrapers (the registry is still empty at
+	// this point in the test) must not panic and must not add anything to
+	// the registry, but it must still record the tenant's mode so a later
+	// update for the same tenant can tell a no-op change from a real one.
+	require.NotPanics(t, func() {
+		u.handleTenantUpdate(ctx, sm.Tenant{Id: 7, LabelMode: sm.LabelMode_LABEL_MODE_UNPREFIXED})
+	})
+	requireRegistryConsistent(t, u.scrapers)
+
+	require.Zero(t, registryLen(u.scrapers), "handleTenantUpdate must not add scrapers for a tenant with none running")
+
+	recordedMode, seen := readLastLabelMode(model.GlobalID(7))
+	require.True(t, seen, "labelModes should record the tenant even though it had zero running scrapers")
+	require.Equal(t, sm.LabelMode_LABEL_MODE_UNPREFIXED, recordedMode)
+
+	// record-always means a follow-up identical update is a no-op
+	require.NotPanics(t, func() {
+		u.handleTenantUpdate(ctx, sm.Tenant{Id: 7, LabelMode: sm.LabelMode_LABEL_MODE_UNPREFIXED})
+	})
+	require.Zero(t, registryLen(u.scrapers))
+	requireRegistryConsistent(t, u.scrapers)
+
+	newCheck := func(id int64) model.Check {
+		var check model.Check
+
+		err := check.FromSM(sm.Check{
+			Id:        id,
+			TenantId:  42,
+			Frequency: 1000,
+			Timeout:   1000,
+			Target:    "127.0.0.1",
+			Job:       "test-job",
+			Probes:    []int64{1},
+			Settings:  sm.CheckSettings{Ping: &sm.PingSettings{}},
+		})
+		require.NoError(t, err)
+
+		return check
+	}
+
+	checkA := newCheck(5001)
+	checkB := newCheck(5002)
+
+	require.NoError(t, u.handleCheckAdd(ctx, checkA))
+	require.NoError(t, u.handleCheckAdd(ctx, checkB))
+	requireRegistryConsistent(t, u.scrapers)
+
+	scraperPointer := func(id model.GlobalID) *scraper.Scraper {
+		s, _ := u.scrapers.get(id)
+		return s
+	}
+
+	beforeA := scraperPointer(checkA.GlobalID())
+	beforeB := scraperPointer(checkB.GlobalID())
+
+	require.NotNil(t, beforeA)
+	require.NotNil(t, beforeB)
+
+	// First sighting of tenant 42: restart happens even though the mode
+	// (PREFIXED, the zero value) matches what an unseen tenant would
+	// default to if the zero value were mistaken for "no change".
+	u.handleTenantUpdate(ctx, sm.Tenant{Id: 42, LabelMode: sm.LabelMode_LABEL_MODE_PREFIXED})
+	requireRegistryConsistent(t, u.scrapers)
+
+	afterFirstA := scraperPointer(checkA.GlobalID())
+	afterFirstB := scraperPointer(checkB.GlobalID())
+
+	require.NotSame(t, beforeA, afterFirstA, "checkA's scraper should have been replaced on first sighting of its tenant")
+	require.NotSame(t, beforeB, afterFirstB, "checkB's scraper should have been replaced on first sighting of its tenant")
+
+	// Same mode again: no restart.
+	u.handleTenantUpdate(ctx, sm.Tenant{Id: 42, LabelMode: sm.LabelMode_LABEL_MODE_PREFIXED})
+	requireRegistryConsistent(t, u.scrapers)
+
+	afterRepeatA := scraperPointer(checkA.GlobalID())
+	afterRepeatB := scraperPointer(checkB.GlobalID())
+
+	require.Same(t, afterFirstA, afterRepeatA, "no label mode change should not restart checkA's scraper")
+	require.Same(t, afterFirstB, afterRepeatB, "no label mode change should not restart checkB's scraper")
+
+	// Different mode: restart again, but only for this tenant. Add an
+	// unrelated check for a different tenant first and confirm it is left
+	// alone by the restart.
+	otherCheck := newCheck(5003)
+	otherCheck.TenantId = 99
+	require.NoError(t, u.handleCheckAdd(ctx, otherCheck))
+	requireRegistryConsistent(t, u.scrapers)
+
+	beforeOther := scraperPointer(otherCheck.GlobalID())
+	require.NotNil(t, beforeOther)
+
+	u.handleTenantUpdate(ctx, sm.Tenant{Id: 42, LabelMode: sm.LabelMode_LABEL_MODE_DUAL_WRITE})
+	requireRegistryConsistent(t, u.scrapers)
+
+	afterChangedA := scraperPointer(checkA.GlobalID())
+	afterChangedB := scraperPointer(checkB.GlobalID())
+	afterOther := scraperPointer(otherCheck.GlobalID())
+
+	require.NotSame(t, afterRepeatA, afterChangedA, "checkA's scraper should have been replaced when its tenant's label mode changed")
+	require.NotSame(t, afterRepeatB, afterChangedB, "checkB's scraper should have been replaced when its tenant's label mode changed")
+	require.Same(t, beforeOther, afterOther, "a different tenant's scraper must not be restarted")
+
+	// Clean up: stop every scraper this test started before it exits.
+	require.NoError(t, u.handleCheckDelete(ctx, checkA))
+	require.NoError(t, u.handleCheckDelete(ctx, checkB))
+	require.NoError(t, u.handleCheckDelete(ctx, otherCheck))
+	requireRegistryConsistent(t, u.scrapers)
+	synctest.Wait()
+}
+
+// TestHandleTenantUpdateRestartFailure exercises handleTenantUpdate's error
+// branch: one check's scraper fails to restart (its factory returns an
+// error) while another check in the same tenant restarts successfully. It
+// asserts the failing check keeps its old scraper (restartCheck builds the
+// replacement before stopping anything), that the failure doesn't abort
+// the loop over the rest of the tenant's checks, and that the failure is
+// surfaced on changeErrorsCounter (not just logged) per the "update" label
+// already used by every other restart-style failure path in this file.
+func TestHandleTenantUpdateRestartFailure(t *testing.T) {
+	synctest.Test(t, testHandleTenantUpdateRestartFailureImpl)
+}
+
+func testHandleTenantUpdateRestartFailureImpl(t *testing.T) {
+	const failingCheckID = int64(6001)
+
+	var failNextRestart atomic.Bool
+
+	factory := func(ctx context.Context, check model.Check, publisher pusher.Publisher, probe sm.Probe,
+		features feature.Collection,
+		logger zerolog.Logger,
+		metrics scraper.Metrics,
+		k6Runner k6runner.Runner,
+		labelsLimiter scraper.LabelsLimiter,
+		telemeter *telemetry.Telemeter,
+		secretStore secrets.SecretProvider,
+		cals scraper.TenantCals,
+		labellingMode scraper.TenantLabelMode,
+	) (*scraper.Scraper, error) {
+		if check.Id == failingCheckID && failNextRestart.Load() {
+			return nil, errors.New("synthetic factory failure for test")
+		}
+
+		return testScraperFactory(ctx, check, publisher, probe, features, logger, metrics, k6Runner, labelsLimiter, telemeter, secretStore, cals, labellingMode)
+	}
+
+	u, err := NewUpdater(
+		UpdaterOptions{
+			Conn:           new(grpc.ClientConn),
+			PromRegisterer: prometheus.NewPedanticRegistry(),
+			Publisher:      channelPublisher(make(chan pusher.Payload, 100)),
+			TenantCh:       make(chan sm.Tenant, 10),
+			Logger:         testhelper.Logger(t),
+			ScraperFactory: factory,
+		},
+	)
+	require.NoError(t, err)
+
+	u.probe = &sm.Probe{Id: 100, Name: "test-probe"}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	newCheck := func(id int64) model.Check {
+		var check model.Check
+
+		err := check.FromSM(sm.Check{
+			Id:        id,
+			TenantId:  55,
+			Frequency: 1000,
+			Timeout:   1000,
+			Target:    "127.0.0.1",
+			Job:       "test-job",
+			Probes:    []int64{1},
+			Settings:  sm.CheckSettings{Ping: &sm.PingSettings{}},
+		})
+		require.NoError(t, err)
+
+		return check
+	}
+
+	failingCheck := newCheck(failingCheckID)
+	okCheck := newCheck(6002)
+
+	require.NoError(t, u.handleCheckAdd(ctx, failingCheck))
+	require.NoError(t, u.handleCheckAdd(ctx, okCheck))
+	requireRegistryConsistent(t, u.scrapers)
+
+	scraperPointer := func(id model.GlobalID) *scraper.Scraper {
+		s, _ := u.scrapers.get(id)
+		return s
+	}
+
+	beforeOK := scraperPointer(okCheck.GlobalID())
+	beforeFailing := scraperPointer(failingCheck.GlobalID())
+
+	require.NotNil(t, beforeOK)
+	require.NotNil(t, beforeFailing)
+	require.Equal(t, 0.0, testutil.ToFloat64(u.metrics.changeErrorsCounter.WithLabelValues("update")))
+
+	// Arm the failure only now, so both checks started cleanly above and
+	// the only failure this test exercises is the one inside
+	// handleTenantUpdate's restart loop.
+	failNextRestart.Store(true)
+
+	u.handleTenantUpdate(ctx, sm.Tenant{Id: 55, LabelMode: sm.LabelMode_LABEL_MODE_DUAL_WRITE})
+	requireRegistryConsistent(t, u.scrapers)
+
+	// restartCheck builds the replacement before touching the old scraper,
+	// so a construction failure must leave the old scraper registered and
+	// running: better a scraper on the stale label mode than a check with
+	// no scraper and no retry path.
+	afterFailing := scraperPointer(failingCheck.GlobalID())
+	require.NotNil(t, afterFailing)
+	require.Same(t, beforeFailing, afterFailing, "a failed restart must leave the old scraper in place")
+
+	// The other check in the same tenant must still have been restarted:
+	// one check's restart failure must not abort the loop over the rest.
+	afterOK := scraperPointer(okCheck.GlobalID())
+	require.NotNil(t, afterOK)
+	require.NotSame(t, beforeOK, afterOK, "okCheck's scraper should still be restarted despite failingCheck's error")
+
+	require.Equal(t, 1.0, testutil.ToFloat64(u.metrics.changeErrorsCounter.WithLabelValues("update")),
+		"a restart failure must increment changeErrorsCounter the same way other failure paths in this file do")
+
+	// The surviving old scraper still counts as running.
+	require.Equal(t, 2.0, testutil.ToFloat64(u.metrics.runningScrapers))
+
+	// Clean up: the failing check still has its (old) scraper to delete.
+	require.NoError(t, u.handleCheckDelete(ctx, okCheck))
+	require.NoError(t, u.handleCheckDelete(ctx, failingCheck))
+	requireRegistryConsistent(t, u.scrapers)
+	synctest.Wait()
+}
+
+// TestHandleTenantUpdateRegionEncodedIDs pins the ID-space agreement that
+// tenant isolation rests on: for a check delivered with region-encoded
+// (global, negative) wire IDs, the registry's tenant index key
+// (check.GlobalTenantID()) must be the same value as the sm.Tenant.Id the
+// API sends for that tenant. A regression indexing by the decoded local
+// tenant ID (GlobalID(check.TenantId)) must fail this test.
+func TestHandleTenantUpdateRegionEncodedIDs(t *testing.T) {
+	synctest.Test(t, testHandleTenantUpdateRegionEncodedIDsImpl)
+}
+
+func testHandleTenantUpdateRegionEncodedIDsImpl(t *testing.T) {
+	u, err := NewUpdater(
+		UpdaterOptions{
+			Conn:           new(grpc.ClientConn),
+			PromRegisterer: prometheus.NewPedanticRegistry(),
+			Publisher:      channelPublisher(make(chan pusher.Payload, 100)),
+			TenantCh:       make(chan sm.Tenant, 10),
+			Logger:         testhelper.Logger(t),
+			ScraperFactory: testScraperFactory,
+		},
+	)
+	require.NoError(t, err)
+
+	u.probe = &sm.Probe{Id: 100, Name: "test-probe"}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	// Global wire IDs per pkg/pb/synthetic_monitoring/ids.go:
+	// -(localID*1000 + regionID). Check 5001 and tenant 42, both region 2.
+	const (
+		globalCheckID  = int64(-5001002)
+		globalTenantID = int64(-42002)
+	)
+
+	var check model.Check
+
+	require.NoError(t, check.FromSM(sm.Check{
+		Id:        globalCheckID,
+		TenantId:  globalTenantID,
+		Frequency: 1000,
+		Timeout:   1000,
+		Target:    "127.0.0.1",
+		Job:       "test-job",
+		Probes:    []int64{1},
+		Settings:  sm.CheckSettings{Ping: &sm.PingSettings{}},
+	}))
+
+	// FromSM decodes the wire IDs to local ones; the global forms are
+	// recovered through the region. Pin all of it so a change to either
+	// side of the agreement shows up here, not as a silent non-restart.
+	require.Equal(t, int64(5001), check.Id)
+	require.Equal(t, 2, check.RegionId)
+	require.Equal(t, int64(42), check.TenantId)
+	require.Equal(t, model.GlobalID(globalCheckID), check.GlobalID())
+	require.Equal(t, model.GlobalID(globalTenantID), check.GlobalTenantID())
+
+	require.NoError(t, u.handleCheckAdd(ctx, check))
+	requireRegistryConsistent(t, u.scrapers)
+
+	before, found := u.scrapers.get(check.GlobalID())
+	require.True(t, found)
+
+	// The API addresses the tenant by its global wire ID.
+	u.handleTenantUpdate(ctx, sm.Tenant{Id: globalTenantID, LabelMode: sm.LabelMode_LABEL_MODE_DUAL_WRITE})
+	requireRegistryConsistent(t, u.scrapers)
+
+	after, found := u.scrapers.get(check.GlobalID())
+	require.True(t, found)
+	require.NotSame(t, before, after, "a region-encoded tenant ID must reach the scrapers indexed under it")
+
+	require.NoError(t, u.handleCheckDelete(ctx, check))
+	requireRegistryConsistent(t, u.scrapers)
+	synctest.Wait()
+}
+
+// TestHandleChangeBatchTenantWiring drives handleChangeBatch directly: a
+// delta batch carrying a tenant restarts that tenant's scrapers via
+// handleTenantUpdate, while a classic first batch (IsDeltaFirstBatch
+// false) never looks at changes.Tenants at all — handleFirstBatch ignores
+// them (pre-existing behavior, pinned here).
+func TestHandleChangeBatchTenantWiring(t *testing.T) {
+	synctest.Test(t, testHandleChangeBatchTenantWiringImpl)
+}
+
+func testHandleChangeBatchTenantWiringImpl(t *testing.T) {
+	tenantCh := make(chan sm.Tenant, 10)
+
+	u, err := NewUpdater(
+		UpdaterOptions{
+			Conn:           new(grpc.ClientConn),
+			PromRegisterer: prometheus.NewPedanticRegistry(),
+			Publisher:      channelPublisher(make(chan pusher.Payload, 100)),
+			TenantCh:       tenantCh,
+			Logger:         testhelper.Logger(t),
+			ScraperFactory: testScraperFactory,
+		},
+	)
+	require.NoError(t, err)
+
+	u.probe = &sm.Probe{Id: 100, Name: "test-probe"}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	smCheck := sm.Check{
+		Id:        7001,
+		TenantId:  42,
+		Frequency: 1000,
+		Timeout:   1000,
+		Target:    "127.0.0.1",
+		Job:       "test-job",
+		Probes:    []int64{1},
+		Settings:  sm.CheckSettings{Ping: &sm.PingSettings{}},
+	}
+
+	var check model.Check
+	require.NoError(t, check.FromSM(smCheck))
+
+	// deliver the check through a delta batch, the way production would
+	u.handleChangeBatch(ctx, &sm.Changes{
+		Checks: []sm.CheckChange{{Operation: sm.CheckOperation_CHECK_ADD, Check: smCheck}},
+	}, false)
+	requireRegistryConsistent(t, u.scrapers)
+
+	p0, found := u.scrapers.get(check.GlobalID())
+	require.True(t, found)
+
+	// a delta batch carrying a tenant must reach handleTenantUpdate
+	u.handleChangeBatch(ctx, &sm.Changes{
+		Tenants: []sm.Tenant{{Id: 42, LabelMode: sm.LabelMode_LABEL_MODE_DUAL_WRITE}},
+	}, false)
+	requireRegistryConsistent(t, u.scrapers)
+
+	p1, found := u.scrapers.get(check.GlobalID())
+	require.True(t, found)
+	require.NotSame(t, p0, p1, "a delta batch with a tenant mode change must restart that tenant's scrapers")
+
+	// repeating the same mode in another delta batch restarts nothing
+	u.handleChangeBatch(ctx, &sm.Changes{
+		Tenants: []sm.Tenant{{Id: 42, LabelMode: sm.LabelMode_LABEL_MODE_DUAL_WRITE}},
+	}, false)
+	requireRegistryConsistent(t, u.scrapers)
+
+	p2, found := u.scrapers.get(check.GlobalID())
+	require.True(t, found)
+	require.Same(t, p1, p2)
+
+	// a classic first batch ignores changes.Tenants: no restart and no
+	// mode recording, even though the mode differs from the recorded one
+	u.handleChangeBatch(ctx, &sm.Changes{
+		Checks:  []sm.CheckChange{{Operation: sm.CheckOperation_CHECK_ADD, Check: smCheck}},
+		Tenants: []sm.Tenant{{Id: 42, LabelMode: sm.LabelMode_LABEL_MODE_UNPREFIXED}},
+	}, true)
+	requireRegistryConsistent(t, u.scrapers)
+
+	p3, found := u.scrapers.get(check.GlobalID())
+	require.True(t, found)
+	require.Same(t, p1, p3, "handleFirstBatch must not act on tenants")
+
+	// ...and because the first batch recorded nothing, the same mode in a
+	// later delta batch still counts as a change
+	u.handleChangeBatch(ctx, &sm.Changes{
+		Tenants: []sm.Tenant{{Id: 42, LabelMode: sm.LabelMode_LABEL_MODE_UNPREFIXED}},
+	}, false)
+	requireRegistryConsistent(t, u.scrapers)
+
+	p4, found := u.scrapers.get(check.GlobalID())
+	require.True(t, found)
+	require.NotSame(t, p3, p4)
+
+	// only the three delta batches forwarded their tenant to tenantCh
+	require.Len(t, tenantCh, 3)
+
+	require.NoError(t, u.handleCheckDelete(ctx, check))
+	requireRegistryConsistent(t, u.scrapers)
 	synctest.Wait()
 }
 

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -235,10 +235,7 @@ func testHandleCheckOpImpl(t *testing.T) {
 	require.NoError(t, err)
 
 	scraperExists := func() bool {
-		u.scrapersMutex.Lock()
-		defer u.scrapersMutex.Unlock()
-
-		_, found := u.scrapers[check.GlobalID()]
+		_, found := u.scrapers.get(check.GlobalID())
 
 		return found
 	}
@@ -250,6 +247,7 @@ func testHandleCheckOpImpl(t *testing.T) {
 	// (because of the error):
 	// require.Equal(t, 0.0, testutil.ToFloat64(u.metrics.runningScrapers))
 	require.False(t, scraperExists())
+	requireRegistryConsistent(t, u.scrapers)
 
 	// fix check
 	check.Job = "test-job"
@@ -259,6 +257,7 @@ func testHandleCheckOpImpl(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1.0, testutil.ToFloat64(u.metrics.runningScrapers))
 	require.True(t, scraperExists())
+	requireRegistryConsistent(t, u.scrapers)
 
 	check.Modified++
 
@@ -267,6 +266,7 @@ func testHandleCheckOpImpl(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, 1.0, testutil.ToFloat64(u.metrics.runningScrapers))
 	require.True(t, scraperExists())
+	requireRegistryConsistent(t, u.scrapers)
 
 	check.Modified++
 
@@ -275,31 +275,111 @@ func testHandleCheckOpImpl(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1.0, testutil.ToFloat64(u.metrics.runningScrapers))
 	require.True(t, scraperExists())
+	requireRegistryConsistent(t, u.scrapers)
 
 	err = u.handleCheckDelete(ctx, check)
 	require.NoError(t, err)
 	require.Equal(t, 0.0, testutil.ToFloat64(u.metrics.runningScrapers))
 	require.False(t, scraperExists())
+	requireRegistryConsistent(t, u.scrapers)
 
 	// try to delete again
 	err = u.handleCheckDelete(ctx, check)
 	require.Error(t, err)
 	require.Equal(t, 0.0, testutil.ToFloat64(u.metrics.runningScrapers))
 	require.False(t, scraperExists())
+	requireRegistryConsistent(t, u.scrapers)
 
 	// updating a non-existing check becomes an add
 	err = u.handleCheckUpdate(ctx, check)
 	require.NoError(t, err)
 	require.Equal(t, 1.0, testutil.ToFloat64(u.metrics.runningScrapers))
 	require.True(t, scraperExists())
+	requireRegistryConsistent(t, u.scrapers)
 
 	// clean up
 	err = u.handleCheckDelete(ctx, check)
 	require.NoError(t, err)
 	require.Equal(t, 0.0, testutil.ToFloat64(u.metrics.runningScrapers))
 	require.False(t, scraperExists())
+	requireRegistryConsistent(t, u.scrapers)
 
 	// Wait for all scraper goroutines to fully exit before test completes.
+	synctest.Wait()
+}
+
+// TestHandleFirstBatchSweep covers the reconnect sweep at the Updater
+// level: scrapers absent from the first batch are stopped and dropped
+// (registry index included), survivors with an unchanged config version
+// keep their scraper.
+func TestHandleFirstBatchSweep(t *testing.T) {
+	synctest.Test(t, testHandleFirstBatchSweepImpl)
+}
+
+func testHandleFirstBatchSweepImpl(t *testing.T) {
+	u, err := NewUpdater(
+		UpdaterOptions{
+			Conn:           new(grpc.ClientConn),
+			PromRegisterer: prometheus.NewPedanticRegistry(),
+			Publisher:      channelPublisher(make(chan pusher.Payload, 100)),
+			TenantCh:       make(chan sm.Tenant, 10),
+			Logger:         testhelper.Logger(t),
+			ScraperFactory: testScraperFactory,
+		},
+	)
+	require.NoError(t, err)
+
+	u.probe = &sm.Probe{Id: 100, Name: "test-probe"}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	newSMCheck := func(id, tenantID int64) sm.Check {
+		return sm.Check{
+			Id:        id,
+			TenantId:  tenantID,
+			Frequency: 1000,
+			Timeout:   1000,
+			Target:    "127.0.0.1",
+			Job:       "test-job",
+			Probes:    []int64{1},
+			Settings:  sm.CheckSettings{Ping: &sm.PingSettings{}},
+		}
+	}
+
+	smKept := newSMCheck(8001, 42)
+	smSwept := newSMCheck(8002, 43)
+
+	var kept, swept model.Check
+
+	require.NoError(t, kept.FromSM(smKept))
+	require.NoError(t, swept.FromSM(smSwept))
+
+	require.NoError(t, u.handleCheckAdd(ctx, kept))
+	require.NoError(t, u.handleCheckAdd(ctx, swept))
+	requireRegistryConsistent(t, u.scrapers)
+	require.Equal(t, 2.0, testutil.ToFloat64(u.metrics.runningScrapers))
+
+	keptBefore, found := u.scrapers.get(kept.GlobalID())
+	require.True(t, found)
+
+	// reconnect: the server only knows about one of the two checks
+	u.handleFirstBatch(ctx, &sm.Changes{
+		Checks: []sm.CheckChange{{Operation: sm.CheckOperation_CHECK_ADD, Check: smKept}},
+	})
+	requireRegistryConsistent(t, u.scrapers)
+
+	_, found = u.scrapers.get(swept.GlobalID())
+	require.False(t, found, "a scraper absent from the first batch must be swept")
+
+	keptAfter, found := u.scrapers.get(kept.GlobalID())
+	require.True(t, found)
+	require.Same(t, keptBefore, keptAfter, "a survivor with an unchanged config version must not be restarted")
+
+	require.Equal(t, 1.0, testutil.ToFloat64(u.metrics.runningScrapers))
+
+	require.NoError(t, u.handleCheckDelete(ctx, kept))
+	requireRegistryConsistent(t, u.scrapers)
 	synctest.Wait()
 }
 

--- a/internal/checks/registry.go
+++ b/internal/checks/registry.go
@@ -1,0 +1,142 @@
+package checks
+
+import (
+	"sync"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
+	"github.com/grafana/synthetic-monitoring-agent/internal/scraper"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+// scraperRegistry owns the set of currently-running scrapers and a
+// derived view of it: a per-tenant index of the checks each tenant has
+// running. Both are guarded by mu and are only ever mutated together, so
+// the index can never drift from the scraper set. The registry is pure
+// state: it never stops scrapers, logs, or records metrics — callers do
+// that with the values it returns.
+type scraperRegistry struct {
+	mu       sync.Mutex
+	scrapers map[model.GlobalID]*scraper.Scraper
+	// byTenant has a key for a tenant if and only if at least one scraper
+	// for that tenant is present in scrapers; the inner set holds those
+	// checks' global IDs.
+	byTenant map[model.GlobalID]map[model.GlobalID]struct{}
+}
+
+func newScraperRegistry() *scraperRegistry {
+	return &scraperRegistry{
+		scrapers: make(map[model.GlobalID]*scraper.Scraper),
+		byTenant: make(map[model.GlobalID]map[model.GlobalID]struct{}),
+	}
+}
+
+func (r *scraperRegistry) get(id model.GlobalID) (*scraper.Scraper, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	s, found := r.scrapers[id]
+
+	return s, found
+}
+
+func (r *scraperRegistry) add(check model.Check, s *scraper.Scraper) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	cid := check.GlobalID()
+	tid := check.GlobalTenantID()
+
+	r.scrapers[cid] = s
+
+	checks, found := r.byTenant[tid]
+	if !found {
+		checks = make(map[model.GlobalID]struct{})
+		r.byTenant[tid] = checks
+	}
+
+	checks[cid] = struct{}{}
+}
+
+func (r *scraperRegistry) remove(id model.GlobalID) (*scraper.Scraper, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.removeLocked(id)
+}
+
+// removeLocked requires r.mu to be held by the caller.
+func (r *scraperRegistry) removeLocked(id model.GlobalID) (*scraper.Scraper, bool) {
+	s, found := r.scrapers[id]
+	if !found {
+		return nil, false
+	}
+
+	delete(r.scrapers, id)
+
+	// The tenant is derived from the removed scraper's own check rather
+	// than trusted from the caller, so the index entry removed here is
+	// always the one add created.
+	check := s.Check()
+	tid := check.GlobalTenantID()
+
+	checks := r.byTenant[tid]
+	delete(checks, id)
+
+	if len(checks) == 0 {
+		delete(r.byTenant, tid)
+	}
+
+	return s, true
+}
+
+// removeAbsent removes every scraper whose check ID is not in keep and
+// returns the removed scrapers so the caller can stop them.
+func (r *scraperRegistry) removeAbsent(keep map[model.GlobalID]struct{}) []*scraper.Scraper {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var removed []*scraper.Scraper
+
+	for id := range r.scrapers {
+		if _, found := keep[id]; found {
+			continue
+		}
+
+		if s, ok := r.removeLocked(id); ok {
+			removed = append(removed, s)
+		}
+	}
+
+	return removed
+}
+
+// checksForTenant returns a fresh snapshot of the checks tenant has running
+// scrapers for; callers may mutate the registry while iterating it.
+func (r *scraperRegistry) checksForTenant(tenant model.GlobalID) []model.Check {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	ids := r.byTenant[tenant]
+
+	checks := make([]model.Check, 0, len(ids))
+	for id := range ids {
+		checks = append(checks, r.scrapers[id].Check())
+	}
+
+	return checks
+}
+
+func (r *scraperRegistry) entityRefs() []sm.EntityRef {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	refs := make([]sm.EntityRef, 0, len(r.scrapers))
+	for id, s := range r.scrapers {
+		refs = append(refs, sm.EntityRef{
+			Id:           int64(id),
+			LastModified: s.LastModified(),
+		})
+	}
+
+	return refs
+}

--- a/internal/checks/registry.go
+++ b/internal/checks/registry.go
@@ -8,12 +8,13 @@ import (
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 )
 
-// scraperRegistry owns the set of currently-running scrapers and a
-// derived view of it: a per-tenant index of the checks each tenant has
-// running. Both are guarded by mu and are only ever mutated together, so
-// the index can never drift from the scraper set. The registry is pure
-// state: it never stops scrapers, logs, or records metrics — callers do
-// that with the values it returns.
+// scraperRegistry owns the set of currently-running scrapers and two
+// derived views of it: a per-tenant index of the checks each tenant has
+// running, and the most recently observed label mode per tenant. All three
+// are guarded by mu and are only ever mutated together, so the index can
+// never drift from the scraper set. The registry is pure state: it never
+// stops scrapers, logs, or records metrics — callers do that with the
+// values it returns.
 type scraperRegistry struct {
 	mu       sync.Mutex
 	scrapers map[model.GlobalID]*scraper.Scraper
@@ -21,12 +22,17 @@ type scraperRegistry struct {
 	// for that tenant is present in scrapers; the inner set holds those
 	// checks' global IDs.
 	byTenant map[model.GlobalID]map[model.GlobalID]struct{}
+	// labelModes records the most recently observed label mode per tenant.
+	// Entries are recorded for any tenant seen in a change batch, running
+	// scrapers or not, and are never removed.
+	labelModes map[model.GlobalID]sm.LabelMode
 }
 
 func newScraperRegistry() *scraperRegistry {
 	return &scraperRegistry{
-		scrapers: make(map[model.GlobalID]*scraper.Scraper),
-		byTenant: make(map[model.GlobalID]map[model.GlobalID]struct{}),
+		scrapers:   make(map[model.GlobalID]*scraper.Scraper),
+		byTenant:   make(map[model.GlobalID]map[model.GlobalID]struct{}),
+		labelModes: make(map[model.GlobalID]sm.LabelMode),
 	}
 }
 
@@ -139,4 +145,20 @@ func (r *scraperRegistry) entityRefs() []sm.EntityRef {
 	}
 
 	return refs
+}
+
+// setLabelMode records mode as tenant's current label mode and reports
+// whether that differs from the previous record. A tenant never seen
+// before counts as changed: LabelMode's zero value is PREFIXED, so an
+// absent entry cannot be told apart from "seen at PREFIXED" without the
+// two-value read, and treating unseen as unchanged would reopen the
+// staleness bug the restart-on-mode-change feature exists to fix.
+func (r *scraperRegistry) setLabelMode(tenant model.GlobalID, mode sm.LabelMode) (changed bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	previous, seen := r.labelModes[tenant]
+	r.labelModes[tenant] = mode
+
+	return !seen || previous != mode
 }

--- a/internal/checks/registry.go
+++ b/internal/checks/registry.go
@@ -15,6 +15,13 @@ import (
 // never drift from the scraper set. The registry is pure state: it never
 // stops scrapers, logs, or records metrics — callers do that with the
 // values it returns.
+//
+// Concurrency contract: each method is individually atomic under mu, but
+// compound sequences in checks.go (duplicate-check-then-add,
+// build-then-replace) are consistent only because Updater has exactly one
+// mutating goroutine, processChanges; the other caller, loop's entityRefs
+// read, is sequenced before processChanges starts. Adding a concurrent
+// accessor requires revisiting those sequences.
 type scraperRegistry struct {
 	mu       sync.Mutex
 	scrapers map[model.GlobalID]*scraper.Scraper
@@ -49,6 +56,11 @@ func (r *scraperRegistry) add(check model.Check, s *scraper.Scraper) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	r.addLocked(check, s)
+}
+
+// addLocked requires r.mu to be held by the caller.
+func (r *scraperRegistry) addLocked(check model.Check, s *scraper.Scraper) {
 	cid := check.GlobalID()
 	tid := check.GlobalTenantID()
 
@@ -93,6 +105,22 @@ func (r *scraperRegistry) removeLocked(id model.GlobalID) (*scraper.Scraper, boo
 	}
 
 	return s, true
+}
+
+// replace atomically swaps in s as the scraper registered for check,
+// removing any scraper previously held under the same check ID — tenant
+// index entry included — within a single lock hold, so no reader can
+// observe the check absent mid-swap. It returns the displaced scraper, if
+// any, for the caller to stop.
+func (r *scraperRegistry) replace(check model.Check, s *scraper.Scraper) (old *scraper.Scraper, found bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	old, found = r.removeLocked(check.GlobalID())
+
+	r.addLocked(check, s)
+
+	return old, found
 }
 
 // removeAbsent removes every scraper whose check ID is not in keep and

--- a/internal/checks/registry_test.go
+++ b/internal/checks/registry_test.go
@@ -44,9 +44,9 @@ func requireRegistryConsistent(t *testing.T, r *scraperRegistry) {
 	}
 }
 
-// registryLen reaches into the registry under its lock; the registry
-// deliberately exposes no size accessor because production code has no
-// use for one.
+// registryLen reaches into the registry under its lock, the same way tests
+// read labelModes; the registry deliberately exposes no size accessor
+// because production code has no use for one.
 func registryLen(r *scraperRegistry) int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -177,4 +177,20 @@ func TestScraperRegistry(t *testing.T) {
 	require.Equal(t, 1, registryLen(r))
 	require.Empty(t, r.checksForTenant(tenant42))
 	require.ElementsMatch(t, []model.Check{checkC}, r.checksForTenant(tenant99))
+
+	// setLabelMode truth table. The first sighting uses PREFIXED, the
+	// enum's zero value, to pin that "never seen" is distinguished from
+	// "seen at PREFIXED".
+	require.True(t, r.setLabelMode(tenant42, sm.LabelMode_LABEL_MODE_PREFIXED),
+		"first sighting of a tenant must count as changed even at the zero-value mode")
+	require.False(t, r.setLabelMode(tenant42, sm.LabelMode_LABEL_MODE_PREFIXED),
+		"repeating the recorded mode must not count as changed")
+	require.True(t, r.setLabelMode(tenant42, sm.LabelMode_LABEL_MODE_DUAL_WRITE),
+		"a different mode must count as changed")
+
+	// record-always: a tenant with zero running scrapers still records
+	noScrapersTenant := model.GlobalID(7)
+	require.True(t, r.setLabelMode(noScrapersTenant, sm.LabelMode_LABEL_MODE_UNPREFIXED))
+	require.False(t, r.setLabelMode(noScrapersTenant, sm.LabelMode_LABEL_MODE_UNPREFIXED))
+	requireRegistryConsistent(t, r)
 }

--- a/internal/checks/registry_test.go
+++ b/internal/checks/registry_test.go
@@ -1,0 +1,180 @@
+package checks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/synthetic-monitoring-agent/internal/model"
+	"github.com/grafana/synthetic-monitoring-agent/internal/pusher"
+	"github.com/grafana/synthetic-monitoring-agent/internal/scraper"
+	"github.com/grafana/synthetic-monitoring-agent/internal/testhelper"
+	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
+)
+
+// requireRegistryConsistent rebuilds the tenant index from the scraper map
+// from scratch and requires it to match byTenant exactly, catching any
+// drift a code path could introduce between the two. It also requires that
+// no empty inner set survives, pinning the "byTenant key present iff the
+// tenant has at least one running scraper" invariant.
+func requireRegistryConsistent(t *testing.T, r *scraperRegistry) {
+	t.Helper()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	want := make(map[model.GlobalID]map[model.GlobalID]struct{})
+
+	for id, s := range r.scrapers {
+		check := s.Check()
+		tid := check.GlobalTenantID()
+
+		if want[tid] == nil {
+			want[tid] = make(map[model.GlobalID]struct{})
+		}
+
+		want[tid][id] = struct{}{}
+	}
+
+	require.Equal(t, want, r.byTenant, "tenant index has drifted from the scraper map")
+
+	for tid, checks := range r.byTenant {
+		require.NotEmpty(t, checks, "tenant %d has an empty index entry", tid)
+	}
+}
+
+// registryLen reaches into the registry under its lock; the registry
+// deliberately exposes no size accessor because production code has no
+// use for one.
+func registryLen(r *scraperRegistry) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.scrapers)
+}
+
+func newRegistryTestCheck(t *testing.T, id, tenantID int64) model.Check {
+	t.Helper()
+
+	var check model.Check
+
+	err := check.FromSM(sm.Check{
+		Id:        id,
+		TenantId:  tenantID,
+		Frequency: 1000,
+		Timeout:   1000,
+		Target:    "127.0.0.1",
+		Job:       "test-job",
+		Probes:    []int64{1},
+		Settings:  sm.CheckSettings{Ping: &sm.PingSettings{}},
+	})
+	require.NoError(t, err)
+
+	return check
+}
+
+// newRegistryTestScraper builds a real *scraper.Scraper for check without
+// ever running it, so the zero-value collaborators are never exercised and
+// no goroutine needs stopping.
+func newRegistryTestScraper(t *testing.T, check model.Check) *scraper.Scraper {
+	t.Helper()
+
+	s, err := testScraperFactory(
+		context.Background(),
+		check,
+		channelPublisher(make(chan pusher.Payload, 1)),
+		sm.Probe{Id: 100, Name: "test-probe"},
+		nil,
+		testhelper.Logger(t),
+		nil,
+		nil, nil, nil, nil, nil, nil,
+	)
+	require.NoError(t, err)
+
+	return s
+}
+
+func TestScraperRegistry(t *testing.T) {
+	r := newScraperRegistry()
+	requireRegistryConsistent(t, r)
+	require.Zero(t, registryLen(r))
+
+	checkA := newRegistryTestCheck(t, 1, 42)
+	checkB := newRegistryTestCheck(t, 2, 42)
+	checkC := newRegistryTestCheck(t, 3, 99)
+
+	tenant42 := checkA.GlobalTenantID()
+	tenant99 := checkC.GlobalTenantID()
+
+	scraperA := newRegistryTestScraper(t, checkA)
+	scraperB := newRegistryTestScraper(t, checkB)
+	scraperC := newRegistryTestScraper(t, checkC)
+
+	r.add(checkA, scraperA)
+	r.add(checkB, scraperB)
+	r.add(checkC, scraperC)
+	requireRegistryConsistent(t, r)
+	require.Equal(t, 3, registryLen(r))
+
+	got, found := r.get(checkA.GlobalID())
+	require.True(t, found)
+	require.Same(t, scraperA, got)
+
+	_, found = r.get(model.GlobalID(12345))
+	require.False(t, found)
+
+	require.ElementsMatch(t, []model.Check{checkA, checkB}, r.checksForTenant(tenant42))
+	require.ElementsMatch(t, []model.Check{checkC}, r.checksForTenant(tenant99))
+
+	refs := r.entityRefs()
+	require.ElementsMatch(t,
+		[]int64{int64(checkA.GlobalID()), int64(checkB.GlobalID()), int64(checkC.GlobalID())},
+		[]int64{refs[0].Id, refs[1].Id, refs[2].Id})
+
+	// removing one of tenant 42's checks leaves the other indexed
+	removed, found := r.remove(checkA.GlobalID())
+	require.True(t, found)
+	require.Same(t, scraperA, removed)
+	requireRegistryConsistent(t, r)
+	require.Equal(t, 2, registryLen(r))
+	require.ElementsMatch(t, []model.Check{checkB}, r.checksForTenant(tenant42))
+
+	// removing tenant 42's last check deletes its index key entirely
+	removed, found = r.remove(checkB.GlobalID())
+	require.True(t, found)
+	require.Same(t, scraperB, removed)
+	requireRegistryConsistent(t, r)
+	require.Empty(t, r.checksForTenant(tenant42))
+
+	func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+
+		_, exists := r.byTenant[tenant42]
+		require.False(t, exists, "a tenant with no running scrapers must not keep an index key")
+	}()
+
+	// removing an absent ID reports absence and mutates nothing
+	removed, found = r.remove(checkA.GlobalID())
+	require.False(t, found)
+	require.Nil(t, removed)
+	require.Equal(t, 1, registryLen(r))
+	requireRegistryConsistent(t, r)
+
+	// re-populate tenant 42 so the sweep below has something to remove
+	scraperA2 := newRegistryTestScraper(t, checkA)
+	scraperB2 := newRegistryTestScraper(t, checkB)
+
+	r.add(checkA, scraperA2)
+	r.add(checkB, scraperB2)
+	requireRegistryConsistent(t, r)
+	require.Equal(t, 3, registryLen(r))
+
+	swept := r.removeAbsent(map[model.GlobalID]struct{}{checkC.GlobalID(): {}})
+	require.ElementsMatch(t, []*scraper.Scraper{scraperA2, scraperB2}, swept)
+	requireRegistryConsistent(t, r)
+	require.Equal(t, 1, registryLen(r))
+	require.Empty(t, r.checksForTenant(tenant42))
+	require.ElementsMatch(t, []model.Check{checkC}, r.checksForTenant(tenant99))
+}

--- a/internal/checks/registry_test.go
+++ b/internal/checks/registry_test.go
@@ -147,13 +147,11 @@ func TestScraperRegistry(t *testing.T) {
 	requireRegistryConsistent(t, r)
 	require.Empty(t, r.checksForTenant(tenant42))
 
-	func() {
-		r.mu.Lock()
-		defer r.mu.Unlock()
+	r.mu.Lock()
+	_, exists := r.byTenant[tenant42]
+	r.mu.Unlock()
 
-		_, exists := r.byTenant[tenant42]
-		require.False(t, exists, "a tenant with no running scrapers must not keep an index key")
-	}()
+	require.False(t, exists, "a tenant with no running scrapers must not keep an index key")
 
 	// removing an absent ID reports absence and mutates nothing
 	removed, found = r.remove(checkA.GlobalID())
@@ -177,6 +175,36 @@ func TestScraperRegistry(t *testing.T) {
 	require.Equal(t, 1, registryLen(r))
 	require.Empty(t, r.checksForTenant(tenant42))
 	require.ElementsMatch(t, []model.Check{checkC}, r.checksForTenant(tenant99))
+
+	// replace under an existing key hands back the displaced scraper and
+	// registers the new one; the index does not change shape
+	scraperC2 := newRegistryTestScraper(t, checkC)
+
+	displaced, found := r.replace(checkC, scraperC2)
+	require.True(t, found)
+	require.Same(t, scraperC, displaced)
+	requireRegistryConsistent(t, r)
+	require.Equal(t, 1, registryLen(r))
+
+	got, found = r.get(checkC.GlobalID())
+	require.True(t, found)
+	require.Same(t, scraperC2, got)
+	require.ElementsMatch(t, []model.Check{checkC}, r.checksForTenant(tenant99))
+
+	// replace of an absent key displaces nothing and registers the new
+	// scraper under a fresh index entry
+	scraperA3 := newRegistryTestScraper(t, checkA)
+
+	displaced, found = r.replace(checkA, scraperA3)
+	require.False(t, found)
+	require.Nil(t, displaced)
+	requireRegistryConsistent(t, r)
+	require.Equal(t, 2, registryLen(r))
+
+	got, found = r.get(checkA.GlobalID())
+	require.True(t, found)
+	require.Same(t, scraperA3, got)
+	require.ElementsMatch(t, []model.Check{checkA}, r.checksForTenant(tenant42))
 
 	// setLabelMode truth table. The first sighting uses PREFIXED, the
 	// enum's zero value, to pin that "never seen" is distinguished from

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -420,6 +420,10 @@ func (s Scraper) ConfigVersion() string {
 	return s.check.ConfigVersion()
 }
 
+func (s Scraper) Check() model.Check {
+	return s.check
+}
+
 func (s Scraper) LastModified() float64 {
 	return s.check.Modified
 }


### PR DESCRIPTION
## Context

When a tenant flips its label migration mode (PREFIXED/DUAL_WRITE/UNPREFIXED), a running scraper only re-reads the new mode on its own next scheduled tick. Up to a full check-frequency interval after the API confirmed the change, checks keep rendering metrics under the old mode.

## This PR

`checks.Updater` tracks the last label mode it saw per tenant. On a mode change, every scraper belonging to that tenant is restarted; a restarted scraper re-fetches the tenant's mode on its first tick, bounding pickup latency to its fresh startup offset (~2 min) instead of the rest of the old execution cycle.

Scraper tracking also moved into a `scraperRegistry` type (map + tenant→checks index + mutex in one place, replacing comment-enforced locking), so per-tenant restarts are O(that tenant's checks) instead of a full scan, and a factory failure during a restart now leaves the old scraper running instead of the check going dead.

## Known limitation

The tenant cache write (`tenantCh` → `tenants.Manager`) stays async, so a restarted scraper's very first tick could rarely still race a stale cached tenant — self-heals on the next tick. Fixing it would need a synchronous update path into `tenants.Manager`.
