### PR TITLE
chore: Bump shared-workflows/create-github-app-token to v0.3.1

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -188,7 +188,7 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get-release-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: sm-release-app
 


### PR DESCRIPTION
Follow-up to #1963