### PR TITLE
fix: Redact check credentials in logs

### DIFF
--- a/cmd/test-api/internal/grpc/checks.go
+++ b/cmd/test-api/internal/grpc/checks.go
@@ -472,7 +472,7 @@ func (s *ChecksServer) sendInitialChanges(currentState *sm.ProbeState, stream sm
 		}
 	}
 
-	s.logger.Info().Int64("probeId", probeID).Interface("changes", changes).Msg("initial changes")
+	s.logger.Info().Int64("probeId", probeID).Interface("changes", sm.Changes{Checks: changes}).Msg("initial changes")
 
 	// If existing checks were provided, notify the probe that we're sending a diff
 	// against the existing checks instead of the full batch.

--- a/internal/adhoc/adhoc_test.go
+++ b/internal/adhoc/adhoc_test.go
@@ -159,6 +159,79 @@ func TestHandlerRun(t *testing.T) {
 	require.NoError(t, err, "execution_id should be a valid UUID")
 }
 
+func TestHandleAdHocCheckDoesNotLogCredentials(t *testing.T) {
+	const (
+		checkPassword  = "randompasswordinplaintext"
+		remotePassword = "theremotepassword"
+	)
+
+	features := feature.NewCollection()
+	require.NoError(t, features.Set("adhoc"))
+
+	logs := &testhelper.LogBuffer{}
+
+	globalLevel := zerolog.GlobalLevel()
+
+	zerolog.SetGlobalLevel(zerolog.DebugLevel)
+
+	t.Cleanup(func() { zerolog.SetGlobalLevel(globalLevel) })
+
+	logger := zerolog.New(logs).Level(zerolog.DebugLevel)
+
+	h, err := NewHandler(HandlerOpts{
+		Logger:         logger,
+		Publisher:      channelPublisher(make(chan pusher.Payload, 1)),
+		TenantCh:       make(chan sm.Tenant, 1),
+		PromRegisterer: prometheus.NewPedanticRegistry(),
+		Features:       features,
+		runnerFactory: func(ctx context.Context, req *sm.AdHocRequest) (*runner, error) {
+			return &runner{
+				logger: logger,
+				prober: &testProber{logger},
+				id:     req.AdHocCheck.Id,
+				target: req.AdHocCheck.Target,
+				probe:  "testProbe",
+			}, nil
+		},
+	})
+	require.NoError(t, err)
+
+	request := sm.AdHocRequest{
+		AdHocCheck: sm.AdHocCheck{
+			Id:       "8f8b7b4e-1f5d-4b0f-9b3a-000000000000",
+			TenantId: 1,
+			Timeout:  10000,
+			Target:   "https://intranet.example.org/alerts",
+			Settings: sm.CheckSettings{
+				Http: &sm.HttpSettings{
+					BasicAuth: &sm.BasicAuth{
+						Username: "grafana",
+						Password: checkPassword,
+					},
+				},
+			},
+		},
+		Tenant: &sm.Tenant{
+			Id: 1,
+			MetricsRemote: &sm.RemoteInfo{
+				Name:     "metrics",
+				Url:      "https://example.org/push",
+				Username: "1",
+				Password: remotePassword,
+			},
+		},
+	}
+
+	require.NoError(t, h.handleAdHocCheck(t.Context(), &request))
+
+	actual := logs.String()
+
+	require.Contains(t, actual, "got ad-hoc check request", "the log line under test did not make it to the logger")
+	require.NotContains(t, actual, checkPassword, "the debug log must not leak the HTTP basic auth password")
+	require.NotContains(t, actual, remotePassword, "the debug log must not leak the tenant remote write password")
+	require.Contains(t, actual, request.AdHocCheck.Id)
+}
+
 type channelPublisher chan pusher.Payload
 
 func (c channelPublisher) Publish(payload pusher.Payload) {

--- a/internal/checks/checks_test.go
+++ b/internal/checks/checks_test.go
@@ -303,6 +303,94 @@ func testHandleCheckOpImpl(t *testing.T) {
 	synctest.Wait()
 }
 
+func TestHandleFirstBatchDoesNotLogCredentials(t *testing.T) {
+	synctest.Test(t, testHandleFirstBatchDoesNotLogCredentialsImpl)
+}
+
+func testHandleFirstBatchDoesNotLogCredentialsImpl(t *testing.T) {
+	const (
+		password    = "randompasswordinplaintext"
+		bearerToken = "supersecretbearertoken"
+	)
+
+	publishCh := make(chan pusher.Payload, 100)
+
+	logs := &testhelper.LogBuffer{}
+
+	u, err := NewUpdater(
+		UpdaterOptions{
+			Conn:           new(grpc.ClientConn),
+			PromRegisterer: prometheus.NewPedanticRegistry(),
+			Publisher:      channelPublisher(publishCh),
+			TenantCh:       make(chan<- sm.Tenant),
+			Logger:         zerolog.New(logs).Level(zerolog.DebugLevel),
+			ScraperFactory: testScraperFactory,
+		},
+	)
+
+	require.NotNil(t, u)
+	require.NoError(t, err)
+
+	u.probe = &sm.Probe{
+		Id:   100,
+		Name: "test-probe",
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	smCheck := sm.Check{
+		Id:        1565289,
+		TenantId:  1,
+		Frequency: 120000,
+		Timeout:   10000,
+		Enabled:   true,
+		Probes:    []int64{7193},
+		Target:    "https://intranet.example.org/alerts",
+		Job:       "Intranet - Alerts",
+		Settings: sm.CheckSettings{
+			Http: &sm.HttpSettings{
+				TlsConfig: &sm.TLSConfig{InsecureSkipVerify: true},
+				BasicAuth: &sm.BasicAuth{
+					Username: "grafana",
+					Password: password,
+				},
+				BearerToken:      bearerToken,
+				ValidStatusCodes: []int32{200},
+			},
+		},
+	}
+
+	u.handleFirstBatch(ctx, &sm.Changes{
+		Checks: []sm.CheckChange{
+			{Operation: sm.CheckOperation_CHECK_ADD, Check: smCheck},
+		},
+	})
+
+	actual := logs.String()
+
+	require.Contains(t, actual, "got check change", "the log line under test did not make it to the logger")
+	require.NotContains(t, actual, password, "the debug log must not leak the HTTP basic auth password")
+	require.NotContains(t, actual, bearerToken, "the debug log must not leak the HTTP bearer token")
+
+	require.Contains(t, actual, `"id":1565289`)
+	require.Contains(t, actual, `"username":"grafana"`)
+
+	var check model.Check
+
+	require.NoError(t, check.FromSM(smCheck))
+
+	u.scrapersMutex.Lock()
+	_, found := u.scrapers[check.GlobalID()]
+	u.scrapersMutex.Unlock()
+
+	if found {
+		require.NoError(t, u.handleCheckDelete(ctx, check))
+	}
+
+	synctest.Wait()
+}
+
 func TestCheckHandlerProbeValidation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/testhelper/testhelper.go
+++ b/internal/testhelper/testhelper.go
@@ -1,6 +1,7 @@
 package testhelper
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,6 +41,26 @@ func Logger(t *testing.T) zerolog.Logger {
 // where you don't need to see the log output.
 func NewTestLogger() zerolog.Logger {
 	return zerolog.New(io.Discard)
+}
+
+// LogBuffer captures log output so that a test can assert on it. Safe for async call.
+type LogBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *LogBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.Write(p)
+}
+
+func (b *LogBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.String()
 }
 
 func MustReadFile(t *testing.T, filename string) []byte {

--- a/pkg/pb/synthetic_monitoring/checks_extra.go
+++ b/pkg/pb/synthetic_monitoring/checks_extra.go
@@ -324,36 +324,48 @@ func CheckTypeFromString(in string) (CheckType, bool) {
 }
 
 func (c Check) Type() CheckType {
+	checkType, found := c.Settings.checkType()
+	if !found {
+		panic("unhandled check type")
+	}
+
+	return checkType
+}
+
+// checkType reports the type of check the settings describe. Unlike
+// Check.Type it does not panic on settings that have nothing set, which is
+// what a check attached to a delete operation looks like.
+func (s CheckSettings) checkType() (CheckType, bool) {
 	switch {
-	case c.Settings.Dns != nil:
-		return CheckTypeDns
+	case s.Dns != nil:
+		return CheckTypeDns, true
 
-	case c.Settings.Http != nil:
-		return CheckTypeHttp
+	case s.Http != nil:
+		return CheckTypeHttp, true
 
-	case c.Settings.Ping != nil:
-		return CheckTypePing
+	case s.Ping != nil:
+		return CheckTypePing, true
 
-	case c.Settings.Tcp != nil:
-		return CheckTypeTcp
+	case s.Tcp != nil:
+		return CheckTypeTcp, true
 
-	case c.Settings.Traceroute != nil:
-		return CheckTypeTraceroute
+	case s.Traceroute != nil:
+		return CheckTypeTraceroute, true
 
-	case c.Settings.Scripted != nil:
-		return CheckTypeScripted
+	case s.Scripted != nil:
+		return CheckTypeScripted, true
 
-	case c.Settings.Multihttp != nil:
-		return CheckTypeMultiHttp
+	case s.Multihttp != nil:
+		return CheckTypeMultiHttp, true
 
-	case c.Settings.Grpc != nil:
-		return CheckTypeGrpc
+	case s.Grpc != nil:
+		return CheckTypeGrpc, true
 
-	case c.Settings.Browser != nil:
-		return CheckTypeBrowser
+	case s.Browser != nil:
+		return CheckTypeBrowser, true
 
 	default:
-		panic("unhandled check type")
+		return 0, false
 	}
 }
 
@@ -517,37 +529,12 @@ func (c Check) ConfigVersion() string {
 }
 
 func (c AdHocCheck) Type() CheckType {
-	switch {
-	case c.Settings.Dns != nil:
-		return CheckTypeDns
-
-	case c.Settings.Http != nil:
-		return CheckTypeHttp
-
-	case c.Settings.Ping != nil:
-		return CheckTypePing
-
-	case c.Settings.Tcp != nil:
-		return CheckTypeTcp
-
-	case c.Settings.Traceroute != nil:
-		return CheckTypeTraceroute
-
-	case c.Settings.Scripted != nil:
-		return CheckTypeScripted
-
-	case c.Settings.Multihttp != nil:
-		return CheckTypeMultiHttp
-
-	case c.Settings.Grpc != nil:
-		return CheckTypeGrpc
-
-	case c.Settings.Browser != nil:
-		return CheckTypeBrowser
-
-	default:
+	checkType, found := c.Settings.checkType()
+	if !found {
 		panic("unhandled check type")
 	}
+
+	return checkType
 }
 
 func (c AdHocCheck) Validate() error {

--- a/pkg/pb/synthetic_monitoring/logging.go
+++ b/pkg/pb/synthetic_monitoring/logging.go
@@ -1,0 +1,260 @@
+// Copyright 2020 Grafana Labs
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetic_monitoring
+
+import (
+	"strings"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/rs/zerolog"
+)
+
+const redactedSecret = "<redacted>"
+
+func (t Tenant) MarshalZerologObject(e *zerolog.Event) {
+	e.Int64("id", t.Id).
+		Int64("orgId", t.OrgId).
+		Int64("stackId", t.StackId).
+		Str("status", t.Status.String()).
+		Str("reason", t.Reason).
+		Strs("costAttributionLabels", t.CostAttributionLabels).
+		Str("labelMode", t.LabelMode.String()).
+		Float64("created", t.Created).
+		Float64("modified", t.Modified)
+
+	if t.MetricsRemote != nil {
+		e.Object("metricsRemote", t.MetricsRemote)
+	}
+
+	if t.EventsRemote != nil {
+		e.Object("eventsRemote", t.EventsRemote)
+	}
+
+	if t.Limits != nil {
+		e.Interface("limits", t.Limits)
+	}
+
+	if t.SecretStore != nil {
+		e.Dict("secretStore", e.CreateDict().
+			Str("url", t.SecretStore.Url).
+			Str("token", redactedSecret).
+			Float64("expiry", t.SecretStore.Expiry))
+	}
+}
+
+func (c Check) MarshalZerologObject(e *zerolog.Event) {
+	e.Int64("id", c.Id).
+		Int64("tenantId", c.TenantId)
+
+	if checkType, found := c.Settings.checkType(); found {
+		e.Str("type", checkType.String())
+	}
+
+	e.Int64("frequency", c.Frequency).
+		Int64("offset", c.Offset).
+		Int64("timeout", c.Timeout).
+		Bool("enabled", c.Enabled).
+		Interface("labels", c.Labels).
+		Ints64("probes", c.Probes).
+		Str("target", c.Target).
+		Str("job", c.Job).
+		Bool("basicMetricsOnly", c.BasicMetricsOnly).
+		Str("alertSensitivity", c.AlertSensitivity).
+		Interface("channels", c.Channels).
+		Float64("created", c.Created).
+		Float64("modified", c.Modified).
+		Interface("settings", c.Settings.Redacted())
+}
+
+func (cc CheckChange) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("operation", cc.Operation.String()).
+		Object("check", cc.Check)
+}
+
+func (c Changes) MarshalZerologObject(e *zerolog.Event) {
+	checks := e.CreateArray()
+	for _, checkChange := range c.Checks {
+		checks.Object(checkChange)
+	}
+
+	tenants := e.CreateArray()
+	for _, tenant := range c.Tenants {
+		tenants.Object(tenant)
+	}
+
+	e.Array("checks", checks).
+		Array("tenants", tenants).
+		Bool("isDeltaFirstBatch", c.IsDeltaFirstBatch)
+}
+
+func (c AdHocCheck) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("id", c.Id).
+		Int64("tenantId", c.TenantId)
+
+	if checkType, found := c.Settings.checkType(); found {
+		e.Str("type", checkType.String())
+	}
+
+	e.Int64("timeout", c.Timeout).
+		Ints64("probes", c.Probes).
+		Str("target", c.Target).
+		Interface("channels", c.Channels).
+		Interface("settings", c.Settings.Redacted())
+}
+
+func (r AdHocRequest) MarshalZerologObject(e *zerolog.Event) {
+	e.Object("adHocCheck", r.AdHocCheck)
+
+	if r.Tenant != nil {
+		e.Object("tenant", r.Tenant)
+	}
+}
+
+// Redacted returns a copy of the settings with every value that might have a credential replaced by a placeholder.
+func (s CheckSettings) Redacted() CheckSettings {
+	redacted := *(proto.Clone(&s).(*CheckSettings))
+
+	if redacted.Http != nil {
+		redactHttpSettings(redacted.Http)
+	}
+
+	if redacted.Tcp != nil {
+		redactTcpSettings(redacted.Tcp)
+	}
+
+	if redacted.Grpc != nil {
+		redactTlsConfig(redacted.Grpc.TlsConfig)
+	}
+
+	if redacted.Multihttp != nil {
+		redactMultiHttpSettings(redacted.Multihttp)
+	}
+
+	if redacted.Scripted != nil {
+		redacted.Scripted.Script = redactBytes(redacted.Scripted.Script)
+	}
+
+	if redacted.Browser != nil {
+		redacted.Browser.Script = redactBytes(redacted.Browser.Script)
+	}
+
+	return redacted
+}
+
+func redactHttpSettings(s *HttpSettings) {
+	if s.BasicAuth != nil {
+		s.BasicAuth.Password = redactString(s.BasicAuth.Password)
+	}
+
+	s.BearerToken = redactString(s.BearerToken)
+	s.Body = redactString(s.Body)
+	s.Headers = redactHeaders(s.Headers)
+	s.ProxyConnectHeaders = redactHeaders(s.ProxyConnectHeaders)
+
+	redactTlsConfig(s.TlsConfig)
+
+	if s.Oauth2Config != nil {
+		s.Oauth2Config.ClientSecret = redactString(s.Oauth2Config.ClientSecret)
+
+		for i := range s.Oauth2Config.EndpointParams {
+			s.Oauth2Config.EndpointParams[i].Value = redactedSecret
+		}
+
+		redactTlsConfig(s.Oauth2Config.TlsConfig)
+	}
+}
+
+func redactTcpSettings(s *TcpSettings) {
+	redactTlsConfig(s.TlsConfig)
+
+	// TCP usually carries credentials as-is.
+	for i := range s.QueryResponse {
+		s.QueryResponse[i].Send = redactBytes(s.QueryResponse[i].Send)
+		s.QueryResponse[i].Expect = redactBytes(s.QueryResponse[i].Expect)
+	}
+}
+
+func redactMultiHttpSettings(s *MultiHttpSettings) {
+	for _, entry := range s.Entries {
+		if entry == nil {
+			continue
+		}
+
+		if entry.Request != nil {
+			for _, header := range entry.Request.Headers {
+				if header != nil {
+					header.Value = redactedSecret
+				}
+			}
+
+			for _, field := range entry.Request.QueryFields {
+				if field != nil {
+					field.Value = redactedSecret
+				}
+			}
+
+			if entry.Request.Body != nil {
+				entry.Request.Body.Payload = redactBytes(entry.Request.Body.Payload)
+			}
+		}
+
+		for _, assertion := range entry.Assertions {
+			if assertion != nil {
+				assertion.Value = redactString(assertion.Value)
+			}
+		}
+	}
+}
+
+func redactTlsConfig(c *TLSConfig) {
+	if c == nil {
+		return
+	}
+
+	c.CACert = redactBytes(c.CACert)
+	c.ClientCert = redactBytes(c.ClientCert)
+	c.ClientKey = redactBytes(c.ClientKey)
+}
+
+func redactHeaders(headers []string) []string {
+	redacted := make([]string, 0, len(headers))
+
+	for _, header := range headers {
+		name, _, found := strings.Cut(header, ":")
+		if !found {
+			redacted = append(redacted, redactedSecret)
+			continue
+		}
+
+		redacted = append(redacted, name+": "+redactedSecret)
+	}
+
+	return redacted
+}
+
+func redactString(s string) string {
+	if s == "" {
+		return s
+	}
+
+	return redactedSecret
+}
+
+func redactBytes(b []byte) []byte {
+	if len(b) == 0 {
+		return b
+	}
+
+	return []byte(redactedSecret)
+}

--- a/pkg/pb/synthetic_monitoring/logging_test.go
+++ b/pkg/pb/synthetic_monitoring/logging_test.go
@@ -1,0 +1,293 @@
+package synthetic_monitoring
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckSettingsRedacted(t *testing.T) {
+	const secret = "averysecretvalue"
+
+	// Every case carries the secret in each field that could hold one, plus a value that has to stay untouched.
+	testcases := map[string]struct {
+		settings CheckSettings
+		kept     []string
+	}{
+		"http": {
+			settings: CheckSettings{
+				Http: &HttpSettings{
+					Method:              HttpMethod_POST,
+					Headers:             []string{"Authorization: Bearer " + secret, secret},
+					ProxyConnectHeaders: []string{"Proxy-Authorization: " + secret},
+					Body:                secret,
+					BearerToken:         secret,
+					BasicAuth:           &BasicAuth{Username: "grafana", Password: secret},
+					TlsConfig: &TLSConfig{
+						ServerName: "example.org",
+						CACert:     []byte(secret),
+						ClientCert: []byte(secret),
+						ClientKey:  []byte(secret),
+					},
+					Oauth2Config: &OAuth2Config{
+						ClientId:       "the client id",
+						ClientSecret:   secret,
+						TokenURL:       "https://example.org/token",
+						EndpointParams: []Label{{Name: "audience", Value: secret}},
+						TlsConfig:      &TLSConfig{ClientKey: []byte(secret)},
+					},
+					ValidStatusCodes: []int32{200},
+				},
+			},
+			kept: []string{"POST", "grafana", "example.org", "the client id", "https://example.org/token", "audience", "Authorization", "Proxy-Authorization"},
+		},
+		"tcp": {
+			settings: CheckSettings{
+				Tcp: &TcpSettings{
+					SourceIpAddress: "10.0.0.1",
+					TlsConfig:       &TLSConfig{ClientKey: []byte(secret)},
+					QueryResponse: []TCPQueryResponse{
+						{Send: []byte(secret), Expect: []byte(secret), StartTLS: true},
+					},
+				},
+			},
+			kept: []string{"10.0.0.1"},
+		},
+		"grpc": {
+			settings: CheckSettings{
+				Grpc: &GrpcSettings{
+					Service:   "the service",
+					TlsConfig: &TLSConfig{ClientKey: []byte(secret)},
+				},
+			},
+			kept: []string{"the service"},
+		},
+		"multihttp": {
+			settings: CheckSettings{
+				Multihttp: &MultiHttpSettings{
+					Entries: []*MultiHttpEntry{
+						{
+							Request: &MultiHttpEntryRequest{
+								Url:         "https://example.org/login",
+								Headers:     []*HttpHeader{{Name: "Authorization", Value: secret}},
+								QueryFields: []*QueryField{{Name: "token", Value: secret}},
+								Body:        &HttpRequestBody{ContentType: "application/json", Payload: []byte(secret)},
+							},
+							Assertions: []*MultiHttpEntryAssertion{
+								{Type: MultiHttpEntryAssertionType_TEXT, Value: secret},
+							},
+							Variables: []*MultiHttpEntryVariable{
+								{Name: "sessionId", Expression: "$.session"},
+							},
+						},
+					},
+				},
+			},
+			kept: []string{"https://example.org/login", "Authorization", "token", "application/json", "sessionId", "$.session"},
+		},
+		"scripted": {
+			settings: CheckSettings{Scripted: &ScriptedSettings{Script: []byte(secret)}},
+		},
+		"browser": {
+			settings: CheckSettings{Browser: &BrowserSettings{Script: []byte(secret)}},
+		},
+		"ping": {
+			settings: CheckSettings{Ping: &PingSettings{SourceIpAddress: "10.0.0.1", PacketCount: 3}},
+			kept:     []string{"10.0.0.1"},
+		},
+		"dns": {
+			settings: CheckSettings{Dns: &DnsSettings{Server: "8.8.8.8", RecordType: DnsRecordType_A}},
+			kept:     []string{"8.8.8.8"},
+		},
+		"traceroute": {
+			settings: CheckSettings{Traceroute: &TracerouteSettings{MaxHops: 64}},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			original, err := json.Marshal(tc.settings)
+			require.NoError(t, err)
+
+			redacted, err := json.Marshal(tc.settings.Redacted())
+			require.NoError(t, err)
+
+			require.NotContains(t, string(redacted), secret,
+				"redacted settings must not contain any value that could be a credential")
+
+			for _, kept := range tc.kept {
+				require.Contains(t, string(redacted), kept,
+					"redacting must not throw away the values that make the log useful")
+			}
+
+			afterwards, err := json.Marshal(tc.settings)
+			require.NoError(t, err)
+			require.Equal(t, string(original), string(afterwards), "Redacted must not modify the receiver")
+		})
+	}
+}
+
+func TestCheckMarshalZerologObject(t *testing.T) {
+	check := Check{
+		Id:               1565289,
+		TenantId:         1,
+		Frequency:        120000,
+		Timeout:          10000,
+		Enabled:          true,
+		Probes:           []int64{7193},
+		Target:           "https://intranet.example.org/alerts",
+		Job:              "Intranet - Alerts",
+		BasicMetricsOnly: true,
+		AlertSensitivity: "none",
+		Settings: CheckSettings{
+			Http: &HttpSettings{
+				BasicAuth:   &BasicAuth{Username: "grafana", Password: "randompasswordinplaintext"},
+				BearerToken: "supersecretbearertoken",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+
+	logger := zerolog.New(&buf)
+	logger.Info().Interface("check", check).Send()
+
+	expected := `{"level":"info","check":{"id":1565289,"tenantId":1,"type":"http","frequency":120000,"offset":0,"timeout":10000,"enabled":true,"labels":null,"probes":[7193],"target":"https://intranet.example.org/alerts","job":"Intranet - Alerts","basicMetricsOnly":true,"alertSensitivity":"none","channels":null,"created":0,"modified":0,"settings":{"http":{"ipVersion":"Any","method":"GET","noFollowRedirects":false,"basicAuth":{"username":"grafana","password":"<redacted>"},"bearerToken":"<redacted>","failIfSSL":false,"failIfNotSSL":false}}}}` + "\n"
+
+	require.Equal(t, expected, buf.String())
+}
+
+func TestCheckChangeMarshalZerologObject(t *testing.T) {
+	// A delete operation has a check that holds nothing but an ID. Check.Type panics on settings call.
+	checkChange := CheckChange{
+		Operation: CheckOperation_CHECK_DELETE,
+		Check:     Check{Id: 1565289},
+	}
+
+	var buf bytes.Buffer
+
+	logger := zerolog.New(&buf)
+
+	require.NotPanics(t, func() {
+		logger.Info().Interface("check change", checkChange).Send()
+	})
+
+	require.Contains(t, buf.String(), `"operation":"CHECK_DELETE"`)
+	require.Contains(t, buf.String(), `"id":1565289`)
+	require.NotContains(t, buf.String(), `"type"`)
+}
+
+func TestAdHocRequestMarshalZerologObject(t *testing.T) {
+	const (
+		checkPassword  = "randompasswordinplaintext"
+		remotePassword = "theremotepassword"
+	)
+
+	request := AdHocRequest{
+		AdHocCheck: AdHocCheck{
+			Id:       "the ad-hoc check id",
+			TenantId: 1,
+			Target:   "https://example.org",
+			Settings: CheckSettings{
+				Http: &HttpSettings{
+					BasicAuth: &BasicAuth{Username: "grafana", Password: checkPassword},
+				},
+			},
+		},
+		Tenant: &Tenant{
+			Id:            1,
+			MetricsRemote: &RemoteInfo{Name: "metrics", Url: "https://example.org/push", Username: "1", Password: remotePassword},
+			SecretStore:   &SecretStore{Url: "https://example.org/secrets", Token: "thesecretstoretoken"},
+		},
+	}
+
+	var buf bytes.Buffer
+
+	logger := zerolog.New(&buf)
+	logger.Info().Interface("request", &request).Send()
+
+	actual := buf.String()
+
+	require.NotContains(t, actual, checkPassword)
+	require.NotContains(t, actual, remotePassword)
+	require.NotContains(t, actual, "thesecretstoretoken")
+	require.Contains(t, actual, "the ad-hoc check id")
+	require.Contains(t, actual, "https://example.org/push")
+}
+
+func TestChangesMarshalZerologObject(t *testing.T) {
+	const (
+		checkPassword  = "randompasswordinplaintext"
+		remotePassword = "theremotepassword"
+	)
+
+	changes := Changes{
+		Checks: []CheckChange{
+			{
+				Operation: CheckOperation_CHECK_ADD,
+				Check: Check{
+					Id: 1565289,
+					Settings: CheckSettings{
+						Http: &HttpSettings{
+							BasicAuth: &BasicAuth{Username: "grafana", Password: checkPassword},
+						},
+					},
+				},
+			},
+		},
+		Tenants: []Tenant{
+			{
+				Id:            1,
+				MetricsRemote: &RemoteInfo{Url: "https://example.org/push", Username: "1", Password: remotePassword},
+			},
+		},
+		IsDeltaFirstBatch: true,
+	}
+
+	var buf bytes.Buffer
+
+	logger := zerolog.New(&buf)
+	logger.Info().Interface("changes", changes).Send()
+
+	actual := buf.String()
+
+	require.NotContains(t, actual, checkPassword)
+	require.NotContains(t, actual, remotePassword)
+	require.Contains(t, actual, `"id":1565289`)
+	require.Contains(t, actual, "https://example.org/push")
+	require.Contains(t, actual, `"isDeltaFirstBatch":true`)
+}
+
+// TestCheckJSONRoundTrip protects the wire format.
+func TestCheckJSONRoundTrip(t *testing.T) {
+	const (
+		password    = "randompasswordinplaintext"
+		bearerToken = "supersecretbearertoken"
+	)
+
+	check := Check{
+		Id:       1565289,
+		TenantId: 1,
+		Target:   "https://intranet.example.org/alerts",
+		Job:      "Intranet - Alerts",
+		Settings: CheckSettings{
+			Http: &HttpSettings{
+				BasicAuth:   &BasicAuth{Username: "grafana", Password: password},
+				BearerToken: bearerToken,
+			},
+		},
+	}
+
+	encoded, err := json.Marshal(&check)
+	require.NoError(t, err)
+
+	var decoded Check
+
+	require.NoError(t, json.Unmarshal(encoded, &decoded))
+	require.Equal(t, check, decoded)
+	require.Equal(t, password, decoded.Settings.Http.BasicAuth.Password)
+	require.Equal(t, bearerToken, decoded.Settings.Http.BearerToken)
+}


### PR DESCRIPTION
Implement MarshalZerologObject interface for check and tenant types, so that they do not leak the secret information into logs.

Small change: wrap one debug line in the API server so it also gets the structure with implemented interface.

Fixes #508
