### PR TITLE
fix: Use the configured port for DNS checks

### DIFF
--- a/internal/prober/dns/dns.go
+++ b/internal/prober/dns/dns.go
@@ -3,6 +3,8 @@ package dns
 import (
 	"context"
 	"errors"
+	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -31,7 +33,7 @@ func NewProber(check model.Check) (Prober, error) {
 	cfg.Timeout = time.Duration(check.Timeout) * time.Millisecond
 
 	return Prober{
-		target: check.Settings.Dns.Server,
+		target: serverAddr(check.Settings.Dns),
 		config: cfg,
 	}, nil
 }
@@ -100,6 +102,10 @@ func settingsToModule(settings *sm.DnsSettings, target string) config.Module {
 	// "udp".
 	m.DNS.TransportProtocol = strings.ToLower(settings.Protocol.String())
 
+	// TODO(digitalcrab): DnsSettings carries no TLS field, so DNSOverTLS
+	// is never set and the DoT path in the BBE prober is unreachable.
+	// Needs to be wired up.
+
 	m.DNS.Recursion = true
 
 	m.DNS.ValidRcodes = settings.ValidRCodes
@@ -120,4 +126,14 @@ func settingsToModule(settings *sm.DnsSettings, target string) config.Module {
 	}
 
 	return m
+}
+
+// serverAddr joins the DNS server and port. Port zero means unset,
+// and in that case the BBE prober applies its own default of 53.
+func serverAddr(settings *sm.DnsSettings) string {
+	if settings.Port == 0 {
+		return settings.Server
+	}
+
+	return net.JoinHostPort(settings.Server, strconv.Itoa(int(settings.Port)))
 }

--- a/internal/prober/dns/dns_test.go
+++ b/internal/prober/dns/dns_test.go
@@ -55,6 +55,86 @@ func TestNewProber(t *testing.T) {
 			},
 			ExpectError: false,
 		},
+		"custom-port": {
+			input: model.Check{Check: sm.Check{
+				Target: "www.grafana.com",
+				Settings: sm.CheckSettings{
+					Dns: &sm.DnsSettings{
+						Server: "127.0.0.1",
+						Port:   5353,
+					},
+				},
+			}},
+			expected: Prober{
+				target: "127.0.0.1:5353",
+				config: config.Module{
+					Prober:  "dns",
+					Timeout: 0,
+					DNS: config.DNSProbe{
+						IPProtocol:         "ip6",
+						IPProtocolFallback: true,
+						TransportProtocol:  "tcp",
+						QueryName:          "www.grafana.com",
+						QueryType:          "ANY",
+						Recursion:          true,
+					},
+				},
+			},
+			ExpectError: false,
+		},
+		"custom-port-ipv6": {
+			input: model.Check{Check: sm.Check{
+				Target: "www.grafana.com",
+				Settings: sm.CheckSettings{
+					Dns: &sm.DnsSettings{
+						Server: "::1",
+						Port:   5353,
+					},
+				},
+			}},
+			expected: Prober{
+				target: "[::1]:5353",
+				config: config.Module{
+					Prober:  "dns",
+					Timeout: 0,
+					DNS: config.DNSProbe{
+						IPProtocol:         "ip6",
+						IPProtocolFallback: true,
+						TransportProtocol:  "tcp",
+						QueryName:          "www.grafana.com",
+						QueryType:          "ANY",
+						Recursion:          true,
+					},
+				},
+			},
+			ExpectError: false,
+		},
+		"no-port": {
+			input: model.Check{Check: sm.Check{
+				Target: "www.grafana.com",
+				Settings: sm.CheckSettings{
+					Dns: &sm.DnsSettings{
+						Server: "127.0.0.1",
+					},
+				},
+			}},
+			expected: Prober{
+				target: "127.0.0.1",
+				config: config.Module{
+					Prober:  "dns",
+					Timeout: 0,
+					DNS: config.DNSProbe{
+						IPProtocol:         "ip6",
+						IPProtocolFallback: true,
+						TransportProtocol:  "tcp",
+						QueryName:          "www.grafana.com",
+						QueryType:          "ANY",
+						Recursion:          true,
+					},
+				},
+			},
+			ExpectError: false,
+		},
 		"no-settings": {
 			input: model.Check{
 				Check: sm.Check{


### PR DESCRIPTION
## What I was doing

Building a local fake DNS server to test DNS checks against, running it on a non-standard port.

## How I found it

The check failed straight away and the log of the fake server stayed empty, so nothing ever reached it. Network path and check configuration were both fine, which left the agent: the port from the check settings was never used, so the query always went to the default port.

## The fix

The prober now builds the server address from the server and the port together. An unset port keeps its current meaning, so existing checks are not affected, and tests cover an explicit port, an IPv6 server and no port at all. I also left a TODO where DNS over TLS would be wired up, as it is not reachable from the check settings today.

Worth keeping in mind on rollout: a check configured with a non-default port has been quietly querying the default one and may look healthy today. After this it queries what it asked for, so it can start failing - the correct result, just no longer a silent one.
