### PR TITLE
fix: Correct TCP query/response conversion

### DIFF
--- a/internal/prober/tcp/tcp.go
+++ b/internal/prober/tcp/tcp.go
@@ -58,18 +58,26 @@ func settingsToModule(ctx context.Context, settings *sm.TcpSettings, logger zero
 
 	m.TCP.TLS = settings.Tls
 
-	m.TCP.QueryResponse = make([]config.QueryResponse, len(settings.QueryResponse))
+	m.TCP.QueryResponse = make([]config.QueryResponse, 0, len(settings.QueryResponse))
 
 	for _, qr := range settings.QueryResponse {
-		re, err := config.NewRegexp(string(qr.Expect))
-		if err != nil {
-			return m, err
+		entry := config.QueryResponse{
+			Send:     string(qr.Send),
+			StartTLS: qr.StartTLS,
 		}
 
-		m.TCP.QueryResponse = append(m.TCP.QueryResponse, config.QueryResponse{
-			Expect: re,
-			Send:   string(qr.Send),
-		})
+		// An empty expect has to stay a nil regexp: BBE reads a line for
+		// every step that carries one, and an empty pattern matches anything.
+		if len(qr.Expect) > 0 {
+			re, err := config.NewRegexp(string(qr.Expect))
+			if err != nil {
+				return m, err
+			}
+
+			entry.Expect = re
+		}
+
+		m.TCP.QueryResponse = append(m.TCP.QueryResponse, entry)
 	}
 
 	if settings.TlsConfig != nil {

--- a/internal/prober/tcp/tcp_test.go
+++ b/internal/prober/tcp/tcp_test.go
@@ -1,14 +1,20 @@
 package tcp
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"io"
+	"log/slog"
+	"net"
 	"testing"
 	"time"
 
 	"github.com/grafana/synthetic-monitoring-agent/internal/model"
 	sm "github.com/grafana/synthetic-monitoring-agent/pkg/pb/synthetic_monitoring"
 	"github.com/prometheus/blackbox_exporter/config"
+	bbeprober "github.com/prometheus/blackbox_exporter/prober"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
@@ -95,6 +101,30 @@ func TestSettingsToModule(t *testing.T) {
 				},
 			},
 		},
+		"query-response": {
+			input: sm.TcpSettings{
+				QueryResponse: []sm.TCPQueryResponse{
+					{Send: []byte("EHLO sm"), Expect: []byte("^250")},
+					{Send: []byte("STARTTLS"), Expect: []byte("^220"), StartTLS: true},
+					{Send: []byte("PING")},
+					{Expect: []byte("PONG")},
+				},
+			},
+			expected: config.Module{
+				Prober:  "tcp",
+				Timeout: 0,
+				TCP: config.TCPProbe{
+					IPProtocol:         "ip6",
+					IPProtocolFallback: true,
+					QueryResponse: []config.QueryResponse{
+						{Send: "EHLO sm", Expect: config.MustNewRegexp("^250")},
+						{Send: "STARTTLS", Expect: config.MustNewRegexp("^220"), StartTLS: true},
+						{Send: "PING"},
+						{Expect: config.MustNewRegexp("PONG")},
+					},
+				},
+			},
+		},
 		"partial-settings": {
 			input: sm.TcpSettings{
 				SourceIpAddress: "0.0.0.0",
@@ -140,4 +170,114 @@ func testCtx(ctx context.Context, t *testing.T) context.Context {
 	t.Cleanup(cancel)
 
 	return ctx
+}
+
+func TestProbeQueryResponse(t *testing.T) {
+	testcases := map[string]struct {
+		banner    string
+		settings  sm.TcpSettings
+		expectGot []string
+	}{
+		"client-speaks-first": {
+			settings: sm.TcpSettings{
+				QueryResponse: []sm.TCPQueryResponse{
+					{Send: []byte("PING")},
+					{Expect: []byte("^PONG")},
+				},
+			},
+			expectGot: []string{"PING"},
+		},
+		"banner-then-send": {
+			banner: "220 ready",
+			settings: sm.TcpSettings{
+				QueryResponse: []sm.TCPQueryResponse{
+					{Expect: []byte("^220")},
+					{Send: []byte("PING")},
+					{Expect: []byte("^PONG")},
+				},
+			},
+			expectGot: []string{"PING"},
+		},
+		"consecutive-sends": {
+			settings: sm.TcpSettings{
+				QueryResponse: []sm.TCPQueryResponse{
+					{Send: []byte("HELO")},
+					{Send: []byte("PING")},
+					{Expect: []byte("^PONG")},
+				},
+			},
+			expectGot: []string{"HELO", "PING"},
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			// Bounded so that a step waiting for input it should not wait for
+			// fails here instead of hanging until the package timeout.
+			ctx, cancel := context.WithTimeout(testCtx(context.Background(), t), 10*time.Second)
+			defer cancel()
+
+			module, err := settingsToModule(ctx, &testcase.settings, zerolog.New(io.Discard))
+			require.NoError(t, err)
+
+			addr, got := runEchoServer(t, testcase.banner)
+
+			registry := prometheus.NewRegistry()
+			success := bbeprober.ProbeTCP(ctx, addr, module, registry, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			require.True(t, success)
+			require.Equal(t, testcase.expectGot, got())
+		})
+	}
+}
+
+// runEchoServer accepts a single connection, optionally greets the client with
+// banner, and answers every line it reads with "PONG". It returns the address to
+// dial and a function that waits for the connection to close before reporting
+// what the client sent.
+func runEchoServer(t *testing.T, banner string) (string, func() []string) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	var (
+		sent []string
+		done = make(chan struct{})
+	)
+
+	go func() {
+		defer close(done)
+
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		if banner != "" {
+			_, _ = fmt.Fprintf(conn, "%s\n", banner)
+		}
+
+		scanner := bufio.NewScanner(conn)
+		for scanner.Scan() {
+			sent = append(sent, scanner.Text())
+
+			if _, err := fmt.Fprintf(conn, "PONG\n"); err != nil {
+				return
+			}
+		}
+	}()
+
+	return listener.Addr().String(), func() []string {
+		t.Helper()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for the server to finish")
+		}
+
+		return sent
+	}
 }


### PR DESCRIPTION
## The problem

The TCP prober padded the query/response step list with empty entries, dropped `startTLS`, and compiled an empty `expect` into a regexp matching anything, so a send-only step waited for a line before sending.

## The fix

Steps are converted one to one, `startTLS` is carried over, and `expect` is only compiled when it is set.

Worth keeping in mind on rollout: a check using `startTLS` has been passing without ever upgrading the connection, and will now do the handshake for real, so it can start failing - the correct result, just no longer a silent one.

## Screenshots - Before the fix

### STARTTLS full conversation

Expect | Send | startTLS
-- | -- | --
^220 | EHLO probe | off
^250 | STARTTLS | off
^220 | leave empty | ON
^250 | QUIT | off

<img width="1992" height="1274" alt="image" src="https://github.com/user-attachments/assets/a26b26bf-5ff0-4404-9701-c229bc7ff4be" />

### The probe speaks first

Expect | Send | startTLS
-- | -- | --
leave empty | HELLO probe | off
^250 | QUIT | off

<img width="1986" height="1316" alt="image" src="https://github.com/user-attachments/assets/7e48d51f-ea69-44dc-880c-5fbf55ab8bbb" />

## Screenshots - After the fix

### STARTTLS full conversation

<img width="1978" height="1280" alt="image" src="https://github.com/user-attachments/assets/935fa2cb-8974-423e-8ca7-deb724a13ab6" />

### The probe speaks first

<img width="1968" height="954" alt="image" src="https://github.com/user-attachments/assets/44614043-d1e0-4942-8537-3a7cb0494fc4" />
